### PR TITLE
外观优化：令牌列表默认padding调整为16，滑动按钮边距对齐用户配置

### DIFF
--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -279,6 +279,6 @@ export struct TokenListPage {
         })
       })
     }
-    .margin({ left: 10, right: 10 })
+    .margin({ left: 10, right: this.token_preference.app_appearance_token_list_item_suffix_padding })
   }
 }

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -164,6 +164,7 @@ export struct TokenListPage {
         .scrollBar(BarState.Off)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
         .clip(false)
+        .cachedCount(3, true)
       }
       .alignItems(HorizontalAlign.Center)
     }
@@ -278,6 +279,6 @@ export struct TokenListPage {
         })
       })
     }
-    .margin({ left: 10 })
+    .margin({ left: 10, right: 10 })
   }
 }

--- a/entry/src/main/ets/pages/TokenSearchPage.ets
+++ b/entry/src/main/ets/pages/TokenSearchPage.ets
@@ -344,6 +344,6 @@ export struct TokenSearchPage {
         })
       })
     }
-    .margin({ left: 10 })
+    .margin({ left: 10, right: 10 })
   }
 }

--- a/entry/src/main/ets/pages/TokenSearchPage.ets
+++ b/entry/src/main/ets/pages/TokenSearchPage.ets
@@ -344,6 +344,6 @@ export struct TokenSearchPage {
         })
       })
     }
-    .margin({ left: 10, right: 10 })
+    .margin({ left: 10, right: this.token_preference.app_appearance_token_list_item_suffix_padding })
   }
 }

--- a/entry/src/main/ets/utils/AppPreference.ets
+++ b/entry/src/main/ets/utils/AppPreference.ets
@@ -298,8 +298,8 @@ export class TokenPreference {
   @Trace app_appearance_user_name_font_size = 10;
   @Trace app_appearance_user_name_font_weight = 400;
   @Trace app_appearance_item_max_width = 800;
-  @Trace app_appearance_token_list_item_prefix_padding = 10;
-  @Trace app_appearance_token_list_item_suffix_padding = 10;
+  @Trace app_appearance_token_list_item_prefix_padding = 16;
+  @Trace app_appearance_token_list_item_suffix_padding = 16;
   @Trace app_appearance_chain_animation_enable = true;
   @Trace app_appearance_long_press_duration = 300;
 }
@@ -419,8 +419,8 @@ export class AppPreference {
     [PREF_KEYS.APPEARANCE_USER_NAME_FONT_SIZE, 10],
     [PREF_KEYS.APPEARANCE_USER_NAME_FONT_WEIGHT, 400],
     [PREF_KEYS.APPEARANCE_ITEM_MAX_WIDTH, 800],
-    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING, 10],
-    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING, 10],
+    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_PREFIX_PADDING, 16],
+    [PREF_KEYS.APPEARANCE_TOKEN_LIST_ITEM_SUFFIX_PADDING, 16],
     [PREF_KEYS.APPEARANCE_CHAIN_ANIMATION_ENABLE, true],
     [PREF_KEYS.APPEARANCE_LONG_PRESS_DURATION, 300],
     // 外观-顶部模糊类型


### PR DESCRIPTION
## 改动内容

1. **令牌列表默认左右内边距从 10 提升到 16**（`AppPreference.ets`）
   - prefix_padding 和 suffix_padding 两处默认值同步修改

2. **列表滑动操作按钮右侧边距改用用户可配置值**（`TokenListPage.ets` / `TokenSearchPage.ets`）
   - 滑动按钮 Row 右侧 margin 从硬编码 10 改为读取 `token_preference.suffix_padding`
   - 用户在「外观设置」调整右内边距后，滑动按钮区也会同步生效

3. **列表添加 cachedCount 预加载优化**（`TokenListPage.ets`）
   - List 组件添加 `.cachedCount(3, true)`，减少滚动白屏