### PR TITLE
docs: 修复中文README Badge图标仓库指向为OHOTP

### DIFF
--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -3,7 +3,7 @@
 <img src="images/app_icon.png" width="40"> OTP令牌
 </h1>
 
-![GitHub License](https://img.shields.io/github/license/SolidFaker/ohtotptoken) ![GitHub Release](https://img.shields.io/github/v/release/SolidFaker/ohtotptoken) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/SolidFaker/ohtotptoken/build.yaml) ![QQ Group](https://img.shields.io/badge/QQ-1060812974-red)
+![GitHub License](https://img.shields.io/github/license/OHOTP/ohtotptoken) ![GitHub Release](https://img.shields.io/github/v/release/OHOTP/ohtotptoken) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/OHOTP/ohtotptoken/build.yaml) ![QQ Group](https://img.shields.io/badge/QQ-1060812974-red)
 
 
 </div>


### PR DESCRIPTION
将 `docs/README_CN.md` 中 Badge 图标的仓库名从 `SolidFaker` 修正为 `OHOTP`，与英文主 README 保持一致。