### PR TITLE
feat: 删除令牌弹窗添加标题与副标题，优化按钮文案

### DIFF
--- a/entry/src/main/ets/components/ArcTokenItem.ets
+++ b/entry/src/main/ets/components/ArcTokenItem.ets
@@ -343,7 +343,8 @@ export struct ArcTokenItem {
       MenuItem({ symbolStartIcon: this.menu_icon_trash, content: $r('app.string.token_right_menu_delete') })
         .onClick(() => {
           this.getUIContext().showAlertDialog({
-            message: $r('app.string.alert_remove_confirm_msg', this.Config.TokenName),
+            title: $r('app.string.alert_remove_title', this.Config.TokenIssuer),
+            message: $r('app.string.alert_remove_confirm_msg'),
             autoCancel: true,
             alignment: DialogAlignment.Center,
             primaryButton: {
@@ -354,7 +355,7 @@ export struct ArcTokenItem {
               }
             },
             secondaryButton: {
-              value: $r('app.string.dialog_btn_confirm'),
+              value: $r('app.string.dialog_btn_delete'),
               fontColor: Color.Red,
               action: async () => {
                 tkStore.deleteToken(this.Config.TokenUUID);

--- a/entry/src/main/ets/components/ArcTokenItem.ets
+++ b/entry/src/main/ets/components/ArcTokenItem.ets
@@ -344,6 +344,7 @@ export struct ArcTokenItem {
         .onClick(() => {
           this.getUIContext().showAlertDialog({
             title: $r('app.string.alert_remove_title', this.Config.TokenIssuer),
+            subtitle: this.Config.TokenName,
             message: $r('app.string.alert_remove_confirm_msg'),
             autoCancel: true,
             alignment: DialogAlignment.Center,

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -414,6 +414,7 @@ export struct TokenItem {
         .onClick(() => {
           this.getUIContext().showAlertDialog({
             title: $r('app.string.alert_remove_title', this.Config.TokenIssuer),
+            subtitle: this.Config.TokenName,
             message: $r('app.string.alert_remove_confirm_msg'),
             autoCancel: true,
             alignment: DialogAlignment.Center,

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -413,7 +413,8 @@ export struct TokenItem {
       MenuItem({ symbolStartIcon: this.menu_icon_trash, content: $r('app.string.token_right_menu_delete') })
         .onClick(() => {
           this.getUIContext().showAlertDialog({
-            message: $r('app.string.alert_remove_confirm_msg', this.Config.TokenName),
+            title: $r('app.string.alert_remove_title', this.Config.TokenIssuer),
+            message: $r('app.string.alert_remove_confirm_msg'),
             autoCancel: true,
             alignment: DialogAlignment.Center,
             primaryButton: {
@@ -424,7 +425,7 @@ export struct TokenItem {
               }
             },
             secondaryButton: {
-              value: $r('app.string.dialog_btn_confirm'),
+              value: $r('app.string.dialog_btn_delete'),
               fontColor: Color.Red,
               action: async () => {
                 tkStore.deleteToken(this.Config.TokenUUID);

--- a/entry/src/main/ets/pages/ArcTokenListPage.ets
+++ b/entry/src/main/ets/pages/ArcTokenListPage.ets
@@ -153,6 +153,7 @@ export struct ArcTokenListPage {
       .onClick(async () => {
         this.getUIContext().showAlertDialog({
           title: $r('app.string.alert_remove_title', conf.TokenIssuer),
+          subtitle: conf.TokenName,
           message: $r('app.string.alert_remove_confirm_msg'),
           autoCancel: true,
           alignment: DialogAlignment.Center,

--- a/entry/src/main/ets/pages/ArcTokenListPage.ets
+++ b/entry/src/main/ets/pages/ArcTokenListPage.ets
@@ -152,7 +152,8 @@ export struct ArcTokenListPage {
       .padding(10)
       .onClick(async () => {
         this.getUIContext().showAlertDialog({
-          message: $r('app.string.alert_remove_confirm_msg', conf.TokenName),
+          title: $r('app.string.alert_remove_title', conf.TokenIssuer),
+          message: $r('app.string.alert_remove_confirm_msg'),
           autoCancel: true,
           alignment: DialogAlignment.Center,
           primaryButton: {
@@ -163,7 +164,7 @@ export struct ArcTokenListPage {
             }
           },
           secondaryButton: {
-            value: $r('app.string.dialog_btn_confirm'),
+            value: $r('app.string.dialog_btn_delete'),
             fontColor: Color.Red,
             action: async () => {
               tkStore.deleteToken(conf.TokenUUID);

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -260,6 +260,7 @@ export struct TokenListPage {
       .onClick(async () => {
         AlertDialog.show({
           title: $r('app.string.alert_remove_title', vm.config.TokenIssuer),
+          subtitle: vm.config.TokenName,
           message: $r('app.string.alert_remove_confirm_msg'),
           autoCancel: true,
           alignment: DialogAlignment.Center,

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -259,7 +259,8 @@ export struct TokenListPage {
       .padding(10)
       .onClick(async () => {
         AlertDialog.show({
-          message: $r('app.string.alert_remove_confirm_msg', vm.config.TokenName),
+          title: $r('app.string.alert_remove_title', vm.config.TokenIssuer),
+          message: $r('app.string.alert_remove_confirm_msg'),
           autoCancel: true,
           alignment: DialogAlignment.Center,
           primaryButton: {
@@ -270,7 +271,7 @@ export struct TokenListPage {
             }
           },
           secondaryButton: {
-            value: $r('app.string.dialog_btn_confirm'),
+            value: $r('app.string.dialog_btn_delete'),
             fontColor: Color.Red,
             action: async () => {
               tkStore.deleteToken(vm.config.TokenUUID);

--- a/entry/src/main/ets/pages/TokenSearchPage.ets
+++ b/entry/src/main/ets/pages/TokenSearchPage.ets
@@ -324,7 +324,8 @@ export struct TokenSearchPage {
       .padding(10)
       .onClick(async () => {
         AlertDialog.show({
-          message: $r('app.string.alert_remove_confirm_msg', vm.config.TokenName),
+          title: $r('app.string.alert_remove_title', vm.config.TokenIssuer),
+          message: $r('app.string.alert_remove_confirm_msg'),
           autoCancel: true,
           alignment: DialogAlignment.Center,
           primaryButton: {
@@ -335,7 +336,7 @@ export struct TokenSearchPage {
             }
           },
           secondaryButton: {
-            value: $r('app.string.dialog_btn_confirm'),
+            value: $r('app.string.dialog_btn_delete'),
             fontColor: Color.Red,
             action: async () => {
               tkStore.deleteToken(vm.config.TokenUUID);

--- a/entry/src/main/ets/pages/TokenSearchPage.ets
+++ b/entry/src/main/ets/pages/TokenSearchPage.ets
@@ -325,6 +325,7 @@ export struct TokenSearchPage {
       .onClick(async () => {
         AlertDialog.show({
           title: $r('app.string.alert_remove_title', vm.config.TokenIssuer),
+          subtitle: vm.config.TokenName,
           message: $r('app.string.alert_remove_confirm_msg'),
           autoCancel: true,
           alignment: DialogAlignment.Center,

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -49,8 +49,12 @@
       "value": "Settings"
     },
     {
+      "name": "alert_remove_title",
+      "value": "Delete token %s"
+    },
+    {
       "name": "alert_remove_confirm_msg",
-      "value": "Confirm to remove token for %s?"
+      "value": "This action cannot be undone."
     },
     {
       "name": "dialog_btn_confirm",
@@ -59,6 +63,10 @@
     {
       "name": "dialog_btn_cancel",
       "value": "Cancel"
+    },
+    {
+      "name": "dialog_btn_delete",
+      "value": "Delete"
     },
     {
       "name": "dialog_cfg_tk_secret",

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -49,8 +49,12 @@
       "value": "Settings"
     },
     {
+      "name": "alert_remove_title",
+      "value": "Delete token %s"
+    },
+    {
       "name": "alert_remove_confirm_msg",
-      "value": "Are you sure you want to delete the token for %s?"
+      "value": "This action cannot be undone."
     },
     {
       "name": "dialog_btn_confirm",
@@ -59,6 +63,10 @@
     {
       "name": "dialog_btn_cancel",
       "value": "Cancel"
+    },
+    {
+      "name": "dialog_btn_delete",
+      "value": "Delete"
     },
     {
       "name": "dialog_cfg_tk_secret",

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -49,8 +49,12 @@
       "value": "设置"
     },
     {
+      "name": "alert_remove_title",
+      "value": "删除令牌 %s"
+    },
+    {
       "name": "alert_remove_confirm_msg",
-      "value": "确认删除%s的令牌吗?"
+      "value": "此操作无法撤销。"
     },
     {
       "name": "dialog_btn_confirm",
@@ -59,6 +63,10 @@
     {
       "name": "dialog_btn_cancel",
       "value": "取消"
+    },
+    {
+      "name": "dialog_btn_delete",
+      "value": "删除"
     },
     {
       "name": "dialog_cfg_tk_secret",

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -1222,7 +1222,7 @@
     },
     {
       "name": "setting_dlp_anti_peep_des",
-      "value": "检测到他人窥视时自动遮盖令牌内容"
+      "value": "检测到他人窥视时自动遮盖令牌内容。"
     },
     {
       "name": "setting_dlp_anti_peep_unsupported",

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -1222,7 +1222,7 @@
     },
     {
       "name": "setting_dlp_anti_peep_des",
-      "value": "检测到他人窥视时自动遮盖令牌内容"
+      "value": "檢測到他人窺視時自動遮蓋令牌內容。"
     },
     {
       "name": "setting_dlp_anti_peep_unsupported",

--- a/entry/src/main/resources/zh_TW/element/string.json
+++ b/entry/src/main/resources/zh_TW/element/string.json
@@ -49,8 +49,12 @@
       "value": "設置"
     },
     {
+      "name": "alert_remove_title",
+      "value": "刪除令牌 %s"
+    },
+    {
       "name": "alert_remove_confirm_msg",
-      "value": "確認刪除%s的令牌嗎?"
+      "value": "此操作無法撤銷。"
     },
     {
       "name": "dialog_btn_confirm",
@@ -59,6 +63,10 @@
     {
       "name": "dialog_btn_cancel",
       "value": "取消"
+    },
+    {
+      "name": "dialog_btn_delete",
+      "value": "刪除"
     },
     {
       "name": "dialog_cfg_tk_secret",


### PR DESCRIPTION
## 改动内容

- AlertDialog 新增 title 显示「删除令牌 + TokenIssuer」
- 新增 subtitle 显示账户名 TokenName
- message 改为不可撤销提示
- 确认按钮从「确认/Confirm」改为「删除/Delete」
- 覆盖 5 处删除入口