### PR TITLE
feat: 系统卡片视觉与配置页沉浸式优化

### DIFF
--- a/common/src/main/ets/utils/TokenCardStore.ets
+++ b/common/src/main/ets/utils/TokenCardStore.ets
@@ -2,6 +2,7 @@ import { PreferenceManager } from "./PreferenceManager";
 import { TokenConfig, otpType } from "./TokenConfig";
 import { TokenStore } from "./TokenStore";
 import { generateOTP } from "./TokenUtils";
+import { AppPreference, PREF_KEYS } from "./AppPreference";
 import { systemDateTime } from "@kit.BasicServicesKit";
 
 export interface CardConfig {
@@ -117,6 +118,9 @@ export class TokenCardStore {
         formData[`token${i}_period`] = String(token.TokenPeriod);
         formData[`token${i}_type`] = String(token.TokenType ?? otpType.TOTP);
         formData[`token${i}_counter`] = String(token.TokenCounter ?? 0);
+        // 即将过期阈值(用户设置): 卡片进度条剩余时间低于该值变红
+        const nextMargin = AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_COUNTER_NEXT_MARGIN);
+        formData[`token${i}_next_margin`] = String(typeof nextMargin === 'number' ? nextMargin : 5);
       }
     }
 

--- a/common/src/main/resources/base/element/color.json
+++ b/common/src/main/resources/base/element/color.json
@@ -99,6 +99,30 @@
     {
       "name": "card_selected_icon",
       "value": "#FF007DFF"
+    },
+    {
+      "name": "card_bg",
+      "value": "#FFFFFFFF"
+    },
+    {
+      "name": "card_content_bg",
+      "value": "#0F000000"
+    },
+    {
+      "name": "card_text_primary",
+      "value": "#E6000000"
+    },
+    {
+      "name": "card_text_secondary",
+      "value": "#99000000"
+    },
+    {
+      "name": "card_code",
+      "value": "#0A59F7"
+    },
+    {
+      "name": "card_code_warning",
+      "value": "#FFD71616"
     }
   ]
 }

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -1471,6 +1471,46 @@
     {
       "name": "cloud_sync_icon_pack_state_checking",
       "value": "Checking..."
+    },
+    {
+      "name": "card_config_title",
+      "value": "Configure Card Token"
+    },
+    {
+      "name": "card_config_preview",
+      "value": "Preview"
+    },
+    {
+      "name": "card_config_select_hint",
+      "value": "Select tokens (max %d)"
+    },
+    {
+      "name": "card_config_selected",
+      "value": "Selected %d/%d"
+    },
+    {
+      "name": "card_config_confirm",
+      "value": "Confirm"
+    },
+    {
+      "name": "card_config_cancel",
+      "value": "Cancel"
+    },
+    {
+      "name": "card_config_success",
+      "value": "Card updated"
+    },
+    {
+      "name": "card_config_fail",
+      "value": "Card update failed: %s"
+    },
+    {
+      "name": "card_config_empty_slot",
+      "value": "Add token"
+    },
+    {
+      "name": "card_config_no_token",
+      "value": "No tokens available"
     }
   ]
 }

--- a/common/src/main/resources/dark/element/color.json
+++ b/common/src/main/resources/dark/element/color.json
@@ -99,6 +99,30 @@
     {
       "name": "card_selected_icon",
       "value": "#FF5291FF"
+    },
+    {
+      "name": "card_bg",
+      "value": "#FF1A1A1C"
+    },
+    {
+      "name": "card_content_bg",
+      "value": "#1AFFFFFF"
+    },
+    {
+      "name": "card_text_primary",
+      "value": "#E6FFFFFF"
+    },
+    {
+      "name": "card_text_secondary",
+      "value": "#99FFFFFF"
+    },
+    {
+      "name": "card_code",
+      "value": "#5291FF"
+    },
+    {
+      "name": "card_code_warning",
+      "value": "#FFD71616"
     }
   ]
 }

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -1471,6 +1471,46 @@
     {
       "name": "cloud_sync_icon_pack_state_checking",
       "value": "Checking..."
+    },
+    {
+      "name": "card_config_title",
+      "value": "Configure Card Token"
+    },
+    {
+      "name": "card_config_preview",
+      "value": "Preview"
+    },
+    {
+      "name": "card_config_select_hint",
+      "value": "Select tokens (max %d)"
+    },
+    {
+      "name": "card_config_selected",
+      "value": "Selected %d/%d"
+    },
+    {
+      "name": "card_config_confirm",
+      "value": "Confirm"
+    },
+    {
+      "name": "card_config_cancel",
+      "value": "Cancel"
+    },
+    {
+      "name": "card_config_success",
+      "value": "Card updated"
+    },
+    {
+      "name": "card_config_fail",
+      "value": "Card update failed: %s"
+    },
+    {
+      "name": "card_config_empty_slot",
+      "value": "Add token"
+    },
+    {
+      "name": "card_config_no_token",
+      "value": "No tokens available"
     }
   ]
 }

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -1471,6 +1471,46 @@
     {
       "name": "cloud_sync_icon_pack_state_checking",
       "value": "正在检查..."
+    },
+    {
+      "name": "card_config_title",
+      "value": "配置卡片令牌"
+    },
+    {
+      "name": "card_config_preview",
+      "value": "预览"
+    },
+    {
+      "name": "card_config_select_hint",
+      "value": "选择令牌（最多%d个）"
+    },
+    {
+      "name": "card_config_selected",
+      "value": "已选 %d/%d"
+    },
+    {
+      "name": "card_config_confirm",
+      "value": "确认"
+    },
+    {
+      "name": "card_config_cancel",
+      "value": "取消"
+    },
+    {
+      "name": "card_config_success",
+      "value": "卡片更新成功"
+    },
+    {
+      "name": "card_config_fail",
+      "value": "卡片更新失败：%s"
+    },
+    {
+      "name": "card_config_empty_slot",
+      "value": "添加令牌"
+    },
+    {
+      "name": "card_config_no_token",
+      "value": "暂无可用令牌"
     }
   ]
 }

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -1471,6 +1471,46 @@
     {
       "name": "cloud_sync_icon_pack_state_checking",
       "value": "正在檢查..."
+    },
+    {
+      "name": "card_config_title",
+      "value": "配置卡片令牌"
+    },
+    {
+      "name": "card_config_preview",
+      "value": "預覽"
+    },
+    {
+      "name": "card_config_select_hint",
+      "value": "選擇令牌（最多%d個）"
+    },
+    {
+      "name": "card_config_selected",
+      "value": "已選 %d/%d"
+    },
+    {
+      "name": "card_config_confirm",
+      "value": "確認"
+    },
+    {
+      "name": "card_config_cancel",
+      "value": "取消"
+    },
+    {
+      "name": "card_config_success",
+      "value": "卡片更新成功"
+    },
+    {
+      "name": "card_config_fail",
+      "value": "卡片更新失敗：%s"
+    },
+    {
+      "name": "card_config_empty_slot",
+      "value": "添加令牌"
+    },
+    {
+      "name": "card_config_no_token",
+      "value": "暫無可用令牌"
     }
   ]
 }

--- a/entry/src/main/ets/pages/TokenCardConfigPage.ets
+++ b/entry/src/main/ets/pages/TokenCardConfigPage.ets
@@ -2,11 +2,17 @@ import { TokenConfig, otpType } from 'common';
 import { TokenStore } from 'common';
 import { TokenCardStore, CardConfig } from 'common';
 import { formProvider, formBindingData } from '@kit.FormKit';
+import { ConfigurationConstant } from '@kit.AbilityKit';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { AppStorageV2 } from '@kit.ArkUI';
-import { AppWindowInfo } from 'common';
+import { AppWindowInfo, CommonConstants } from 'common';
 import { PageScaffold } from '../components/PageScaffold';
+import { MaterialSurface } from '../components/MaterialSurface';
+import { MaterialTheme, MaterialThickness } from '../components/MaterialTheme';
+import { hdsMaterial, HdsNavDestination, HdsNavDestinationTitleMode } from '@kit.UIDesignKit';
+import { MaterialPolicy } from '../utils/MaterialPolicy';
+import { TokenIcon } from 'uikit';
 
 @Entry
 @ComponentV2
@@ -18,6 +24,12 @@ export struct TokenCardConfigPage {
   @Local formId: string = '';
   @Local formName: string = 'tokenCard_1x2';
   @Local maxSelect: number = 1;
+
+  /** 亮暗模式判定: 浅灰按钮背景在亮色下用深色文字, 暗色下用白色文字 */
+  @Computed
+  get is_dark_mode() {
+    return this.window.ColorMode == ConfigurationConstant.ColorMode.COLOR_MODE_DARK;
+  }
 
   aboutToAppear(): void {
     this.formName = AppStorage.get<string>('card_config_formName') ?? 'tokenCard_1x2';
@@ -41,55 +53,161 @@ export struct TokenCardConfigPage {
   }
 
   build() {
-    NavDestination() {
-      PageScaffold() {
-      Column() {
-        Text(`选择令牌 (最多${this.maxSelect}个)`)
-          .fontSize(16)
-          .fontColor($r('app.color.str_main'))
-          .fontWeight(FontWeight.Medium)
-          .margin({ left: 16, top: 12, bottom: 8 })
-
-        List({ space: 4 }) {
-          ForEach(this.tokens, (token: TokenConfig) => {
-            ListItem() {
-              this.TokenItemBuilder(token)
+    HdsNavDestination() {
+      // 页面背景与主 app 一致(实体 window_background, 亮 #eeeeee / 暗 #222)
+      PageScaffold({ bgColor: $r('app.color.window_background') }) {
+        // 顶对齐: 浮层 wrap 高度贴顶, 不撑满避免拦截列表触摸
+        Stack({ alignContent: Alignment.Top }) {
+          // 令牌列表: 撑满整个页面(顶部/底部经偏移让滚动内容从安全区穿过)
+          if (this.tokens.length === 0) {
+            Column() {
+              Text($r('app.string.card_config_no_token'))
+                .fontSize(14)
+                .fontColor($r('app.color.str_gray'))
             }
-          }, (token: TokenConfig) => token.TokenUUID)
+            .width('100%')
+            .height('100%')
+            .justifyContent(FlexAlign.Center)
+          } else {
+            List({ space: 4 }) {
+              ForEach(this.tokens, (token: TokenConfig) => {
+                ListItem() {
+                  this.TokenItemBuilder(token)
+                }
+              }, (token: TokenConfig) => token.TokenUUID)
+            }
+            .width('100%')
+            .height('100%')
+            // 顶部偏移 = 浮层总高度(状态栏 + 导航栏 52 + 提示行), 首项不被浮层遮挡
+            .contentStartOffset(this.window.AvoidTopHeight + 96)
+            // 上下撑满: 滚动内容从安全区(状态栏/导航条)穿过, 沉浸滚动
+            .contentEndOffset(this.window.AvoidBottomHeight)
+            .scrollBar(BarState.Off)
+          }
+
+          // 顶部浮层: 自绘导航栏(返回+标题+确认按钮) + 选择提示
+          // 沉浸光感渐变模糊: ImmersiveMaterial 材质(系统材质自带模糊/光感/边缘渐变)
+          Column() {
+            MaterialSurface({
+              thickness: MaterialThickness.THIN,
+              lightEffect: true,
+              radius: 0,
+              solidColor: MaterialTheme.surfaceBackground($r('app.color.window_background')),
+              fillWidth: true
+            }) {
+              Column() {
+                // 顶部安全区避让: 自绘导航栏需自行避开状态栏
+                Column()
+                  .height(this.window.AvoidTopHeight)
+
+                // 导航栏: 返回按钮 + 页面标题 + 右侧确认按钮
+                Row() {
+                  Button({ type: ButtonType.Circle }) {
+                    SymbolGlyph($r('sys.symbol.chevron_left'))
+                      .fontSize(20)
+                      .fontWeight(FontWeight.Medium)
+                      .fontColor([$r('sys.color.icon_primary')])
+                  }
+                  .width(36)
+                  .height(36)
+                  .backgroundColor(Color.Transparent)
+                  .stateEffect(false)
+                  .onClick(() => {
+                    this.pathStack.pop();
+                  })
+
+                  Text($r('app.string.card_config_title'))
+                    .fontSize(18)
+                    .fontWeight(FontWeight.Medium)
+                    .fontColor($r('sys.color.font_primary'))
+                    .margin({ left: 8 })
+                    .layoutWeight(1)
+                    .textAlign(TextAlign.Start)
+
+                  // 确认按钮(圆圈对勾): 选中令牌后才可用
+                  MaterialSurface({
+                    thickness: MaterialThickness.THIN,
+                    lightEffect: true,
+                    interactive: true,
+                    materialColor: $r('app.color.button_blue'),
+                    radius: 18,
+                    solidColor: Color.Transparent,
+                    fillWidth: false
+                  }) {
+                    Button({ type: ButtonType.Circle }) {
+                      SymbolGlyph($r('sys.symbol.checkmark_circle'))
+                        .fontSize(20)
+                        .fontWeight(FontWeight.Medium)
+                        .fontColor([Color.White])
+                    }
+                    .width(36)
+                    .height(36)
+                    .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_blue')))
+                    .stateEffect(false)
+                    .enabled(this.selectedUUIDs.length > 0)
+                    .onClick(() => {
+                      this.saveAndRefresh();
+                    })
+                  }
+                }
+                .width('100%')
+                .height(52)
+                .padding({ left: 12, right: 16 })
+                .alignItems(VerticalAlign.Center)
+
+                // 选择提示行
+                Row() {
+                  Text($r('app.string.card_config_select_hint', this.maxSelect))
+                    .fontSize(16)
+                    .fontColor($r('app.color.str_main'))
+                    .fontWeight(FontWeight.Medium)
+                  Blank()
+                  Text($r('app.string.card_config_selected', this.selectedUUIDs.length, this.maxSelect))
+                    .fontSize(12)
+                    .fontColor($r('app.color.str_gray'))
+                }
+                .width('100%')
+                .padding({ left: 16, right: 16, top: 4, bottom: 8 })
+              }
+            }
+          }
+          // 浮层: 内容自适应高度(仅覆盖顶部区域, 下方列表可正常触摸)
+          .width('100%')
+
         }
         .width('100%')
-        .layoutWeight(1)
-        .padding({ left: 12, right: 12 })
-
-        Row() {
-          Button('取消')
-            .fontSize(16)
-            .fontColor($r('app.color.str_gray'))
-            .backgroundColor(Color.Transparent)
-            .onClick(() => {
-              this.pathStack.pop();
-            })
-
-          Button('确认')
-            .fontSize(16)
-            .fontColor($r('app.color.white'))
-            .backgroundColor($r('app.color.button_blue'))
-            .enabled(this.selectedUUIDs.length > 0)
-            .onClick(() => {
-              this.saveAndRefresh();
-            })
-        }
-        .width('100%')
-        .justifyContent(FlexAlign.SpaceEvenly)
-        .padding({ left: 24, right: 24, top: 12, bottom: 12 })
-      }
-      .width('100%')
-      .height('100%')
+        .height('100%')
       }
     }
-    .title('配置卡片令牌')
-    .hideTitleBar(false)
-    .margin({ top: this.window.AvoidTopHeight, bottom: this.window.AvoidBottomHeight})
+    .titleMode(HdsNavDestinationTitleMode.MODAL)
+    .titleBar({
+      // 标题栏避让系统安全区(状态栏): 对齐 TokenSortPage 等正常页面配置
+      avoidLayoutSafeArea: true,
+      style: {
+        originalStyle: {
+          contentStyle: {
+            titleStyle: {
+              mainTitleColor: $r('sys.color.font_primary'),
+              subTitleColor: $r('sys.color.font_secondary')
+            },
+            backIconStyle: {
+              iconColor: $r('sys.color.icon_primary')
+            }
+          },
+        },
+        systemMaterialEffect: {
+          materialType: hdsMaterial.MaterialType.ADAPTIVE,
+          materialLevel: MaterialPolicy.getInstance().getHdsAdaptiveMaterialLevel()
+        }
+      },
+      content: {
+        title: {
+          mainTitle: $r('app.string.card_config_title'),
+        },
+      }
+    })
+    // 隐藏系统标题栏: 导航栏由页面自绘(返回+标题+确认按钮)
+    .hideTitleBar(true)
     .onReady((context: NavDestinationContext) => {
       this.pathStack = context.pathStack;
     })
@@ -97,51 +215,58 @@ export struct TokenCardConfigPage {
 
   @Builder
   TokenItemBuilder(token: TokenConfig) {
-    Row() {
-      SymbolGlyph($r('sys.symbol.key_fill'))
-        .fontSize(20)
-        .fontColor([$r('app.color.item_fg')])
+    // 令牌行: 实体背景(滚动列表逐项 systemMaterial 会材质层偏移,
+    // 与手机端 TokenItem 默认行为一致), 选中态高亮
+    Column() {
+      Row() {
+        TokenIcon({ issuer: token.TokenIssuer, icon_path: token.TokenIconPath })
+          .width(32)
+          .height(32)
 
-      Column() {
-        Text(token.TokenIssuer || token.TokenName)
-          .fontSize(14)
-          .fontColor($r('app.color.str_main'))
-          .maxLines(1)
-          .textOverflow({ overflow: TextOverflow.Ellipsis })
-        if (token.TokenIssuer && token.TokenName) {
-          Text(token.TokenName)
-            .fontSize(12)
-            .fontColor($r('app.color.str_gray'))
+        Column() {
+          Text(token.TokenIssuer || token.TokenName)
+            .fontSize(14)
+            .fontColor($r('app.color.str_main'))
             .maxLines(1)
             .textOverflow({ overflow: TextOverflow.Ellipsis })
+          if (token.TokenIssuer && token.TokenName) {
+            Text(token.TokenName)
+              .fontSize(12)
+              .fontColor($r('app.color.str_gray'))
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+          }
+        }
+        .margin({ left: 12 })
+        .layoutWeight(1)
+        .alignItems(HorizontalAlign.Start)
+
+        if (this.selectedUUIDs.includes(token.TokenUUID)) {
+          SymbolGlyph($r('sys.symbol.checkmark_circle_fill'))
+            .fontSize(22)
+            .fontColor([$r('app.color.card_selected_icon')])
+        } else {
+          SymbolGlyph($r('sys.symbol.circle'))
+            .fontSize(22)
+            .fontColor([$r('app.color.card_unselected_icon')])
         }
       }
-      .margin({ left: 12 })
-      .layoutWeight(1)
-      .alignItems(HorizontalAlign.Start)
-
-      if (this.selectedUUIDs.includes(token.TokenUUID)) {
-        SymbolGlyph($r('sys.symbol.checkmark_circle_fill'))
-          .fontSize(22)
-          .fontColor([$r('app.color.card_selected_icon')])
-      } else {
-        SymbolGlyph($r('sys.symbol.circle'))
-          .fontSize(22)
-          .fontColor([$r('app.color.card_unselected_icon')])
-      }
+      .width('100%')
+      .padding(12)
+      .borderRadius(12)
+      .backgroundColor(this.selectedUUIDs.includes(token.TokenUUID)
+        ? $r('app.color.card_item_bg') : $r('app.color.item_bg'))
+      .onClick(() => {
+        const idx = this.selectedUUIDs.indexOf(token.TokenUUID);
+        if (idx >= 0) {
+          this.selectedUUIDs.splice(idx, 1);
+        } else if (this.selectedUUIDs.length < this.maxSelect) {
+          this.selectedUUIDs.push(token.TokenUUID);
+        }
+      })
     }
     .width('100%')
-    .padding(12)
-    .borderRadius(12)
-    .backgroundColor($r('app.color.card_item_bg'))
-    .onClick(() => {
-      const idx = this.selectedUUIDs.indexOf(token.TokenUUID);
-      if (idx >= 0) {
-        this.selectedUUIDs.splice(idx, 1);
-      } else if (this.selectedUUIDs.length < this.maxSelect) {
-        this.selectedUUIDs.push(token.TokenUUID);
-      }
-    })
+    .padding({ left: 15, right: 15 })
   }
 
   private async saveAndRefresh(): Promise<void> {

--- a/entry/src/main/ets/pages/TokenCardConfigPage.ets
+++ b/entry/src/main/ets/pages/TokenCardConfigPage.ets
@@ -48,8 +48,28 @@ export struct TokenCardConfigPage {
     cardStore.getCardConfig(this.formId).then((config: CardConfig | null) => {
       if (config) {
         this.selectedUUIDs = [...config.tokenUUIDs];
+        // 进入配置页即刷新卡片: 系统重启后卡片可能仍显示初始空态
+        // (系统缓存 onAddForm 快照), 立即用最新配置纠正, 无需等待定时更新
+        this.refreshCardNow(config);
       }
     });
+  }
+
+  /** 用现有配置立即刷新桌面卡片(进入配置页时兜底纠正空态) */
+  private async refreshCardNow(config: CardConfig): Promise<void> {
+    if (!this.formId) {
+      return;
+    }
+    try {
+      const cardStore = TokenCardStore.getInstance();
+      const formData = await cardStore.generateCardData(this.formId, config);
+      const bindingData = formBindingData.createFormBindingData(formData);
+      await formProvider.updateForm(this.formId, bindingData);
+      hilog.info(0, 'TokenCardConfig', `refreshCardNow success, formId: ${this.formId}`);
+    } catch (err) {
+      const errMsg = (err as BusinessError).message;
+      hilog.error(0, 'TokenCardConfig', `refreshCardNow error: ${errMsg}`);
+    }
   }
 
   build() {

--- a/entry/src/main/ets/widget/pages/TokenCard_1x2.ets
+++ b/entry/src/main/ets/widget/pages/TokenCard_1x2.ets
@@ -17,12 +17,19 @@ struct TokenCard_1x2 {
   @LocalStorageProp('token0_type') token0Type: string = '0';
   @LocalStorageProp('token0_counter') token0Counter: string = '0';
   @LocalStorageProp('token0_uuid') token0UUID: string = '';
+  @LocalStorageProp('token0_next_margin') token0NextMargin: string = '5';
   @State isFlipped: boolean = false;
   @State currentCode: string = '';
   @State localCounterOffset: number = 0;
 
   private isHOTP(): boolean {
     return this.token0Type === '2';
+  }
+
+  /** 当前 TOTP 周期剩余秒数(渲染/翻转/刷新时计算; 卡片无定时器能力, 随刷新时机校正) */
+  private remainingSeconds(): number {
+    const period = parseInt(this.token0Period) || 30;
+    return period - (Math.floor(Date.now() / 1000) % period);
   }
 
   private computeOTP(): string {
@@ -44,10 +51,10 @@ struct TokenCard_1x2 {
         Row() {
           SymbolGlyph($r('sys.symbol.key_fill'))
             .fontSize(16)
-            .fontColor(['#E6000000'])
+            .fontColor([$r('app.color.card_text_primary')])
           Text('OTP令牌')
             .fontSize(12)
-            .fontColor('#E6000000')
+            .fontColor($r('app.color.card_text_primary'))
             .fontWeight(FontWeight.Bold)
             .margin({ left: 6 })
         }
@@ -78,7 +85,7 @@ struct TokenCard_1x2 {
         .width('100%')
         .height('100%')
         .borderRadius(8)
-        .backgroundColor('#0F000000')
+        .backgroundColor($r('app.color.card_content_bg'))
         .padding({ left: 8, right: 8, top: 4, bottom: 4 })
         .onClick(() => {
           if (!this.isFlipped) {
@@ -104,26 +111,28 @@ struct TokenCard_1x2 {
     .width('100%')
     .height('100%')
     .borderRadius(12)
-    .backgroundColor('#FFFFFFFF')
+    .backgroundColor($r('app.color.card_bg'))
     .padding(8)
   }
 
   @Builder
   TokenFrontView() {
     Row() {
+      // 注: 卡片环境对动态 $rawfile 路径支持受限, 运行时拼接可能致整卡渲染空白,
+      // 图标暂用系统符号, 静态 rawfile 图标待卡片侧验证后接入
       SymbolGlyph($r('sys.symbol.key_fill'))
         .fontSize(14)
-        .fontColor(['#E6000000'])
+        .fontColor([$r('app.color.card_text_primary')])
       Column() {
         Text(this.token0Issuer)
           .fontSize(11)
-          .fontColor('#E6000000')
+          .fontColor($r('app.color.card_text_primary'))
           .fontWeight(FontWeight.Medium)
           .maxLines(1)
           .textOverflow({ overflow: TextOverflow.Ellipsis })
         Text(this.token0Name)
           .fontSize(9)
-          .fontColor('#99000000')
+          .fontColor($r('app.color.card_text_secondary'))
           .maxLines(1)
           .textOverflow({ overflow: TextOverflow.Ellipsis })
       }
@@ -138,25 +147,38 @@ struct TokenCard_1x2 {
 
   @Builder
   TokenBackView() {
-    Row() {
-      Column() {
-        Text(this.currentCode)
-          .fontSize(18)
-          .fontColor('#E6000000')
-          .fontWeight(FontWeight.Bold)
-          .letterSpacing(1)
-          .fontFamily('monospace')
-        Text(this.token0Issuer)
-          .fontSize(8)
-          .fontColor('#99000000')
-          .maxLines(1)
-          .textOverflow({ overflow: TextOverflow.Ellipsis })
+    Column() {
+      Row() {
+        Column() {
+          Text(this.currentCode)
+            .fontSize(18)
+            .fontColor($r('app.color.card_code'))
+            .fontWeight(FontWeight.Bold)
+            .letterSpacing(1)
+            .fontFamily('monospace')
+          Text(this.token0Issuer)
+            .fontSize(8)
+            .fontColor($r('app.color.card_text_secondary'))
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+        }
+        .alignItems(HorizontalAlign.Start)
+        .layoutWeight(1)
       }
-      .alignItems(HorizontalAlign.Start)
+      .width('100%')
       .layoutWeight(1)
+      .alignItems(VerticalAlign.Center)
+
+      // TOTP 剩余时间进度条(底部): 剩余时间低于用户设置的即将过期阈值时变红
+      Progress({ value: this.remainingSeconds(), total: parseInt(this.token0Period) || 30 })
+        .width('100%')
+        .height(3)
+        .color(this.remainingSeconds() <= (parseInt(this.token0NextMargin) || 5)
+          ? $r('app.color.card_code_warning') : $r('app.color.card_code'))
+        .backgroundColor($r('app.color.card_text_secondary'))
+        .margin({ top: 2 })
     }
     .width('100%')
     .height('100%')
-    .alignItems(VerticalAlign.Center)
   }
 }

--- a/entry/src/main/ets/widget/pages/TokenCard_2x2.ets
+++ b/entry/src/main/ets/widget/pages/TokenCard_2x2.ets
@@ -26,6 +26,8 @@ struct TokenCard_2x2 {
   @LocalStorageProp('token1_type') token1Type: string = '0';
   @LocalStorageProp('token1_counter') token1Counter: string = '0';
   @LocalStorageProp('token1_uuid') token1UUID: string = '';
+  @LocalStorageProp('token0_next_margin') token0NextMargin: string = '5';
+  @LocalStorageProp('token1_next_margin') token1NextMargin: string = '5';
   @State flippedIndex: number = -1;
   @State currentCode0: string = '';
   @State currentCode1: string = '';
@@ -34,6 +36,12 @@ struct TokenCard_2x2 {
 
   private isHOTP(index: number): boolean {
     return index === 0 ? this.token0Type === '2' : this.token1Type === '2';
+  }
+
+  /** 当前 TOTP 周期剩余秒数(渲染/翻转/刷新时计算; 卡片无定时器能力, 随刷新时机校正) */
+  private remainingSeconds(index: number): number {
+    const period = parseInt(index === 0 ? this.token0Period : this.token1Period) || 30;
+    return period - (Math.floor(Date.now() / 1000) % period);
   }
 
   private computeOTP(index: number): string {
@@ -55,15 +63,15 @@ struct TokenCard_2x2 {
         Column() {
           SymbolGlyph($r('sys.symbol.key_fill'))
             .fontSize(32)
-            .fontColor(['#E6000000'])
+            .fontColor([$r('app.color.card_text_primary')])
           Text('OTP令牌')
             .fontSize(16)
-            .fontColor('#E6000000')
+            .fontColor($r('app.color.card_text_primary'))
             .fontWeight(FontWeight.Bold)
             .margin({ top: 8 })
           Text('点击配置令牌')
             .fontSize(12)
-            .fontColor('#99000000')
+            .fontColor($r('app.color.card_text_secondary'))
             .margin({ top: 4 })
         }
         .width('100%')
@@ -87,15 +95,15 @@ struct TokenCard_2x2 {
           if (this.token0Issuer !== '') {
             Column() {
               if (this.flippedIndex !== 0) {
-                this.TokenFrontView(this.token0Issuer, this.token0Name)
+                this.TokenFrontView(this.token0Issuer, this.token0Name, 0)
               } else {
-                this.TokenBackView(this.currentCode0, this.token0Issuer)
+                this.TokenBackView(this.currentCode0, this.token0Issuer, parseInt(this.token0Period) || 30, this.remainingSeconds(0), parseInt(this.token0NextMargin) || 5)
               }
             }
             .width('100%')
             .layoutWeight(1)
             .borderRadius(12)
-            .backgroundColor('#0F000000')
+            .backgroundColor($r('app.color.card_content_bg'))
             .padding({ left: 12, right: 12, top: 8, bottom: 8 })
             .onClick(() => {
               if (this.flippedIndex !== 0) {
@@ -123,15 +131,15 @@ struct TokenCard_2x2 {
           if (this.token1Issuer !== '') {
             Column() {
               if (this.flippedIndex !== 1) {
-                this.TokenFrontView(this.token1Issuer, this.token1Name)
+                this.TokenFrontView(this.token1Issuer, this.token1Name, 1)
               } else {
-                this.TokenBackView(this.currentCode1, this.token1Issuer)
+                this.TokenBackView(this.currentCode1, this.token1Issuer, parseInt(this.token1Period) || 30, this.remainingSeconds(1), parseInt(this.token1NextMargin) || 5)
               }
             }
             .width('100%')
             .layoutWeight(1)
             .borderRadius(12)
-            .backgroundColor('#0F000000')
+            .backgroundColor($r('app.color.card_content_bg'))
             .padding({ left: 12, right: 12, top: 8, bottom: 8 })
             .onClick(() => {
               if (this.flippedIndex !== 1) {
@@ -158,12 +166,12 @@ struct TokenCard_2x2 {
             Column() {
               Text('+')
                 .fontSize(20)
-                .fontColor('#99000000')
+                .fontColor($r('app.color.card_text_secondary'))
             }
             .width('100%')
             .layoutWeight(1)
             .borderRadius(12)
-            .backgroundColor('#0F000000')
+            .backgroundColor($r('app.color.card_content_bg'))
             .justifyContent(FlexAlign.Center)
             .alignItems(HorizontalAlign.Center)
             .onClick(() => {
@@ -187,26 +195,28 @@ struct TokenCard_2x2 {
     .width('100%')
     .height('100%')
     .borderRadius(16)
-    .backgroundColor('#FFFFFFFF')
+    .backgroundColor($r('app.color.card_bg'))
     .padding(12)
   }
 
   @Builder
-  TokenFrontView(issuer: string, name: string) {
+  TokenFrontView(issuer: string, name: string, index: number) {
     Row() {
+      // 注: 卡片环境对动态 $rawfile 路径支持受限, 运行时拼接可能致整卡渲染空白,
+      // 图标暂用系统符号, 静态 rawfile 图标待卡片侧验证后接入
       SymbolGlyph($r('sys.symbol.key_fill'))
         .fontSize(18)
-        .fontColor(['#E6000000'])
+        .fontColor([$r('app.color.card_text_primary')])
       Column() {
         Text(issuer)
           .fontSize(13)
-          .fontColor('#E6000000')
+          .fontColor($r('app.color.card_text_primary'))
           .fontWeight(FontWeight.Medium)
           .maxLines(1)
           .textOverflow({ overflow: TextOverflow.Ellipsis })
         Text(name)
           .fontSize(11)
-          .fontColor('#99000000')
+          .fontColor($r('app.color.card_text_secondary'))
           .maxLines(1)
           .textOverflow({ overflow: TextOverflow.Ellipsis })
       }
@@ -220,26 +230,39 @@ struct TokenCard_2x2 {
   }
 
   @Builder
-  TokenBackView(code: string, issuer: string) {
-    Row() {
-      Column() {
-        Text(code)
-          .fontSize(24)
-          .fontColor('#E6000000')
-          .fontWeight(FontWeight.Bold)
-          .letterSpacing(2)
-          .fontFamily('monospace')
-        Text(issuer)
-          .fontSize(10)
-          .fontColor('#99000000')
-          .maxLines(1)
-          .textOverflow({ overflow: TextOverflow.Ellipsis })
+  TokenBackView(code: string, issuer: string, period: number, remaining: number, nextMargin: number) {
+    Column() {
+      Row() {
+        Column() {
+          Text(code)
+            .fontSize(24)
+            .fontColor($r('app.color.card_code'))
+            .fontWeight(FontWeight.Bold)
+            .letterSpacing(2)
+            .fontFamily('monospace')
+          Text(issuer)
+            .fontSize(10)
+            .fontColor($r('app.color.card_text_secondary'))
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+        }
+        .alignItems(HorizontalAlign.Start)
+        .layoutWeight(1)
       }
-      .alignItems(HorizontalAlign.Start)
+      .width('100%')
       .layoutWeight(1)
+      .alignItems(VerticalAlign.Center)
+
+      // TOTP 剩余时间进度条(底部): 剩余时间低于用户设置的即将过期阈值时变红
+      Progress({ value: remaining, total: period })
+        .width('100%')
+        .height(3)
+        .color(remaining <= nextMargin
+          ? $r('app.color.card_code_warning') : $r('app.color.card_code'))
+        .backgroundColor($r('app.color.card_text_secondary'))
+        .margin({ top: 2 })
     }
     .width('100%')
     .height('100%')
-    .alignItems(VerticalAlign.Center)
   }
 }


### PR DESCRIPTION
## 背景

优化系统卡片（桌面服务卡片）的视觉设计与卡片配置页交互，方向（经讨论确认）：**视觉设计优化 + 配置页优化**。

## 改动内容

### 卡片视觉（TokenCard_1x2 / TokenCard_2x2）

- **深色模式适配**：写死黑灰白替换为双模式资源（`card_bg`/`card_content_bg`/`card_text_primary`/`card_text_secondary`/`card_code`）
- **验证码品牌色**：翻转显示验证码用品牌蓝（亮 `#0A59F7` / 暗 `#5291FF`）
- **TOTP 剩余时间进度条**（背面底部）：`Progress` 显示周期剩余；**剩余时间低于用户设置的"即将过期"阈值时变红**（`card_code_warning`，与手机端 expiring 色一致）——阈值经 `TokenCardStore.generateCardData` 随卡片数据下发（`token{i}_next_margin`）

### 卡片配置页（TokenCardConfigPage）

- **自绘导航栏**：隐藏系统标题栏（HDS `TitleBarContentOptions` 经验证不支持 trailing/customBuilder），页面自绘导航栏（返回按钮 + 标题 + 右侧**圆圈对勾确认按钮**，选中令牌后才可用）；移除底部取消/确认按钮
- **令牌列表撑满全页**：列表贯穿上下安全区（`contentStartOffset`/`contentEndOffset` 沉浸滚动）
- **顶部渐变模糊浮层**：导航栏 + 选择提示行承载于 `MaterialSurface` 沉浸材质（系统材质自带模糊/光感/边缘渐变）
- **令牌行**：TokenIcon 图标、选中高亮、实体背景（滚动列表逐项 `systemMaterial` 会材质层偏移——官方不建议滚动列表逐项设材质，与手机端 TokenItem 默认行为一致）
- **标题栏安全区**：`avoidLayoutSafeArea: true` 避让状态栏；内容区 `AvoidTopHeight + 96` 偏移避免首项被浮层遮挡
- 页面背景与主 app 一致（`window_background`）；字符串资源化（10 条 ×4 语言）

## 测试用例

- [x] 卡片深色/亮色模式下配色正确
- [x] 卡片翻转显示验证码 + 品牌色 + 进度条
- [x] 进度条剩余时间低于阈值变红（手机端设置生效）
- [x] 配置页：导航栏返回/标题/确认按钮布局与安全区避让
- [x] 令牌选择/取消/计数、确认后桌面卡片更新
- [x] 列表滚动无光效偏移（实体行）
- [x] 亮色/暗色模式下背景与主 app 一致

## 已知限制

- 卡片内动态 `$rawfile` 图标不可用（卡片环境限制，运行时拼接路径会导致整卡渲染空白），令牌图标暂用系统符号 `key_fill`，静态 rawfile 映射待验证后接入
