### PR TITLE
feat: 令牌列表预加载与折叠区域、图标选择页、关于页等多项 UI 优化与修复

### DIFF
--- a/common/src/main/ets/utils/AppPreference.ets
+++ b/common/src/main/ets/utils/AppPreference.ets
@@ -466,6 +466,22 @@ export enum EXTERNAL_URLS {
   FEEDBACK_SURVEY = 'https://wj.qq.com/s2/24518107/2b26/',
   /** GitHub反馈 */
   FEEDBACK_GITHUB = 'https://github.com/OHOTP/ohtotptoken/issues',
+  /** 代码仓主页 */
+  REPO_HOME = 'https://github.com/OHOTP/ohtotptoken',
+  /** 贡献者列表 */
+  REPO_CONTRIBUTORS = 'https://github.com/OHOTP/ohtotptoken/graphs/contributors',
+  /** MIT 许可证全文 */
+  REPO_LICENSE = 'https://github.com/OHOTP/ohtotptoken/blob/main/LICENSE',
+  /** 开源软件: libcotp */
+  OSS_LIBCOTP = 'https://github.com/paolostivanin/libcotp',
+  /** 开源软件: TOTP-MCU */
+  OSS_TOTP_MCU = 'https://github.com/Netthaw/TOTP-MCU',
+  /** 开源软件: fortitoken-mobile-registration */
+  OSS_FORTI_REGISTRATION = 'https://github.com/ss23/fortitoken-mobile-registration',
+  /** 开源软件: Aigis */
+  OSS_AIGIS = 'https://github.com/iamhyc/Aigis',
+  /** 开源软件: andOTP 图标 */
+  OSS_ANDOTP_ICONS = 'https://github.com/andOTP/andOTP',
 }
 
 /**

--- a/common/src/main/ets/utils/AppPreference.ets
+++ b/common/src/main/ets/utils/AppPreference.ets
@@ -9,6 +9,8 @@ export const BUILTIN_DEFAULT_PACK_ID = '__builtin_default_pack__';
 export enum EVENT_NAMES {
   /** 顶部模糊效果类型变更事件 */
   TOP_EFFECT_TYPE_CHANGED = 'onTopEffectTypeChanged',
+  /** 底部页签类型变更事件 */
+  BOTTOM_TABS_TYPE_CHANGED = 'onBottomTabsTypeChanged',
   /** Token变更事件 */
   TOKEN_CHANGED = 'onTokenChanged',
   /** NFC外部令牌变更事件 */
@@ -64,6 +66,8 @@ export enum PREF_KEYS {
   SAFETY_AUTO_UNLOCK_ENABLE = 'app_safety_auto_unlock_enable',
   /** 顶部模糊效果类型 */
   APPEARANCE_TOP_EFFECT_TYPE = 'app_appearance_top_effect_type',
+  /** 底部页签类型 */
+  APPEARANCE_BOTTOM_TABS_TYPE = 'app_appearance_bottom_tabs_type',
   /** 背景模糊开关 */
   SAFETY_BACKGROUND_BLUR_ENABLE = 'app_safety_background_blur_enable',
   /** 快速扫描开关 */
@@ -558,6 +562,8 @@ export class AppPreference {
     [PREF_KEYS.APPEARANCE_LONG_PRESS_DURATION, 300],
     // 外观-顶部模糊类型
     [PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE, SettingTopEffectType.IMMERSIVE_GRADIENT_BLUR],
+    // 外观-底部页签类型（默认悬浮，平铺为鸿蒙 6.1+ 另一种呈现方式）
+    [PREF_KEYS.APPEARANCE_BOTTOM_TABS_TYPE, SettingBottomTabsType.SUSPENSION],
     [PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, false],
   ]);
   private static settings: Map<string, SettingValue> = new Map<string, SettingValue>([

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -170,7 +170,11 @@
     },
     {
       "name": "dialog_backup_password",
-      "value": "Password"
+      "value": "Enter backup password"
+    },
+    {
+      "name": "dialog_backup_password_set",
+      "value": "Set backup password"
     },
     {
       "name": "dialog_backup_password_placeholder",
@@ -266,23 +270,19 @@
     },
     {
       "name": "setting_backup_output",
-      "value": "Export password？"
-    },
-    {
-      "name": "setting_backup_output_des",
-      "value": "If you choose the normal export method, the password will be displayed in plain text to anyone who has access to the file. Do you really want to export the password？"
+      "value": "Export backup?"
     },
     {
       "name": "setting_backup_output_msg",
-      "value": "Please choose the export method"
+      "value": "Unencrypted backups can be read by anyone who gains access to the file."
     },
     {
       "name": "setting_backup_type_default",
-      "value": "default"
+      "value": "Unencrypted"
     },
     {
       "name": "setting_backup_type_enc",
-      "value": "Encryption"
+      "value": "Encrypted"
     },
     {
       "name": "setting_backup_cancel",

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -189,6 +189,50 @@
       "value": "About"
     },
     {
+      "name": "about_app_version",
+      "value": "Version %s"
+    },
+    {
+      "name": "about_software_info",
+      "value": "Software Information"
+    },
+    {
+      "name": "about_opensource_project",
+      "value": "Open Source Info"
+    },
+    {
+      "name": "about_bundle_name",
+      "value": "Bundle Name"
+    },
+    {
+      "name": "about_version_code",
+      "value": "Version Code"
+    },
+    {
+      "name": "about_contact_email",
+      "value": "Contact E-mail"
+    },
+    {
+      "name": "about_repo",
+      "value": "Repository"
+    },
+    {
+      "name": "about_repo_desc",
+      "value": "View the source code on GitHub."
+    },
+    {
+      "name": "about_contributors",
+      "value": "Contributors"
+    },
+    {
+      "name": "about_license",
+      "value": "License"
+    },
+    {
+      "name": "about_license_desc",
+      "value": "Read the full MIT License text."
+    },
+    {
       "name": "setting_backup",
       "value": "Backup & Migration"
     },

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -1130,11 +1130,11 @@
     },
     {
       "name": "setting_bottom_tabs_type",
-      "value": "Bottom Tabs Type"
+      "value": "Bottom Tab Type"
     },
     {
       "name": "setting_bottom_tabs_type_desc",
-      "value": "Control the display type of bottom tab bar"
+      "value": "Controls the display style of the bottom tab bar."
     },
     {
       "name": "setting_bottom_tabs_type_flatten",

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -170,7 +170,11 @@
     },
     {
       "name": "dialog_backup_password",
-      "value": "Password"
+      "value": "Enter backup password"
+    },
+    {
+      "name": "dialog_backup_password_set",
+      "value": "Set backup password"
     },
     {
       "name": "dialog_backup_password_placeholder",
@@ -266,19 +270,15 @@
     },
     {
       "name": "setting_backup_output",
-      "value": "Export passwords?"
-    },
-    {
-      "name": "setting_backup_output_des",
-      "value": "If you choose plain export, passwords will be shown in plain text to anyone with access to the file. Are you sure you want to export passwords?"
+      "value": "Export backup?"
     },
     {
       "name": "setting_backup_output_msg",
-      "value": "Please select export method"
+      "value": "Unencrypted backups can be read by anyone who gains access to the file."
     },
     {
       "name": "setting_backup_type_default",
-      "value": "Plain Text"
+      "value": "Unencrypted"
     },
     {
       "name": "setting_backup_type_enc",

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -189,6 +189,50 @@
       "value": "About"
     },
     {
+      "name": "about_app_version",
+      "value": "Version %s"
+    },
+    {
+      "name": "about_software_info",
+      "value": "Software Information"
+    },
+    {
+      "name": "about_opensource_project",
+      "value": "Open Source Info"
+    },
+    {
+      "name": "about_bundle_name",
+      "value": "Bundle Name"
+    },
+    {
+      "name": "about_version_code",
+      "value": "Version Code"
+    },
+    {
+      "name": "about_contact_email",
+      "value": "Contact E-mail"
+    },
+    {
+      "name": "about_repo",
+      "value": "Repository"
+    },
+    {
+      "name": "about_repo_desc",
+      "value": "View the source code on GitHub."
+    },
+    {
+      "name": "about_contributors",
+      "value": "Contributors"
+    },
+    {
+      "name": "about_license",
+      "value": "License"
+    },
+    {
+      "name": "about_license_desc",
+      "value": "Read the full MIT License text."
+    },
+    {
       "name": "setting_backup",
       "value": "Backup & Migration"
     },

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -1118,11 +1118,11 @@
     },
     {
       "name": "setting_bottom_tabs_type",
-      "value": "Bottom Tabs Type"
+      "value": "Bottom Tab Type"
     },
     {
       "name": "setting_bottom_tabs_type_desc",
-      "value": "Control the display type of bottom tab bar"
+      "value": "Controls the display style of the bottom tab bar."
     },
     {
       "name": "setting_bottom_tabs_type_flatten",

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -1118,11 +1118,11 @@
     },
     {
       "name": "setting_bottom_tabs_type",
-      "value": "底部Tabs类型"
+      "value": "底部页签类型"
     },
     {
       "name": "setting_bottom_tabs_type_desc",
-      "value": "控制底部标签栏的显示类型"
+      "value": "控制底部页签的显示样式。"
     },
     {
       "name": "setting_bottom_tabs_type_flatten",

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -170,7 +170,11 @@
     },
     {
       "name": "dialog_backup_password",
-      "value": "密码"
+      "value": "输入备份密码"
+    },
+    {
+      "name": "dialog_backup_password_set",
+      "value": "设置备份密码"
     },
     {
       "name": "dialog_backup_password_placeholder",
@@ -266,23 +270,19 @@
     },
     {
       "name": "setting_backup_output",
-      "value": "导出密码？"
-    },
-    {
-      "name": "setting_backup_output_des",
-      "value": "如果您选择普通导出方式，密码将以纯文本形式显示给有权访问该文件的任何人。是否确实要导出密码？"
+      "value": "导出备份？"
     },
     {
       "name": "setting_backup_output_msg",
-      "value": "请选择导出方式"
+      "value": "明文备份未经加密，获得该文件的任何人都能读取其中的令牌密钥。"
     },
     {
       "name": "setting_backup_type_default",
-      "value": "明文"
+      "value": "明文导出"
     },
     {
       "name": "setting_backup_type_enc",
-      "value": "加密"
+      "value": "加密导出"
     },
     {
       "name": "setting_backup_cancel",

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -189,6 +189,50 @@
       "value": "关于"
     },
     {
+      "name": "about_app_version",
+      "value": "版本 %s"
+    },
+    {
+      "name": "about_software_info",
+      "value": "软件信息"
+    },
+    {
+      "name": "about_opensource_project",
+      "value": "开源信息"
+    },
+    {
+      "name": "about_bundle_name",
+      "value": "包名"
+    },
+    {
+      "name": "about_version_code",
+      "value": "版本号"
+    },
+    {
+      "name": "about_contact_email",
+      "value": "联系邮箱"
+    },
+    {
+      "name": "about_repo",
+      "value": "代码仓"
+    },
+    {
+      "name": "about_repo_desc",
+      "value": "前往 GitHub 查看源代码。"
+    },
+    {
+      "name": "about_contributors",
+      "value": "贡献者"
+    },
+    {
+      "name": "about_license",
+      "value": "许可证"
+    },
+    {
+      "name": "about_license_desc",
+      "value": "查看 MIT 许可证全文。"
+    },
+    {
       "name": "setting_backup",
       "value": "备份与迁移"
     },

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -1118,11 +1118,11 @@
     },
     {
       "name": "setting_bottom_tabs_type",
-      "value": "底部Tabs類型"
+      "value": "底部頁籤類型"
     },
     {
       "name": "setting_bottom_tabs_type_desc",
-      "value": "控制底部標籤欄的顯示類型"
+      "value": "控制底部頁籤的顯示樣式。"
     },
     {
       "name": "setting_bottom_tabs_type_flatten",

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -189,6 +189,50 @@
       "value": "關於"
     },
     {
+      "name": "about_app_version",
+      "value": "版本 %s"
+    },
+    {
+      "name": "about_software_info",
+      "value": "軟體資訊"
+    },
+    {
+      "name": "about_opensource_project",
+      "value": "開源資訊"
+    },
+    {
+      "name": "about_bundle_name",
+      "value": "套件名稱"
+    },
+    {
+      "name": "about_version_code",
+      "value": "版本代碼"
+    },
+    {
+      "name": "about_contact_email",
+      "value": "聯絡信箱"
+    },
+    {
+      "name": "about_repo",
+      "value": "程式碼倉庫"
+    },
+    {
+      "name": "about_repo_desc",
+      "value": "前往 GitHub 檢視原始碼。"
+    },
+    {
+      "name": "about_contributors",
+      "value": "貢獻者"
+    },
+    {
+      "name": "about_license",
+      "value": "授權條款"
+    },
+    {
+      "name": "about_license_desc",
+      "value": "檢視 MIT 授權條款全文。"
+    },
+    {
       "name": "setting_backup",
       "value": "備份與遷移"
     },

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -170,7 +170,11 @@
     },
     {
       "name": "dialog_backup_password",
-      "value": "密碼"
+      "value": "輸入備份密碼"
+    },
+    {
+      "name": "dialog_backup_password_set",
+      "value": "設定備份密碼"
     },
     {
       "name": "dialog_backup_password_placeholder",
@@ -266,23 +270,19 @@
     },
     {
       "name": "setting_backup_output",
-      "value": "匯出密碼？"
-    },
-    {
-      "name": "setting_backup_output_des",
-      "value": "如果您選擇普通匯出方式，密碼將以純文字形式顯示給有權存取該檔案的任何人。是否確實要匯出密碼？"
+      "value": "匯出備份？"
     },
     {
       "name": "setting_backup_output_msg",
-      "value": "請選擇匯出方式"
+      "value": "明文備份未經加密，獲得該檔案的任何人都能讀取其中的權杖密鑰。"
     },
     {
       "name": "setting_backup_type_default",
-      "value": "明文"
+      "value": "明文匯出"
     },
     {
       "name": "setting_backup_type_enc",
-      "value": "加密"
+      "value": "加密匯出"
     },
     {
       "name": "setting_backup_cancel",

--- a/entry/src/main/ets/components/AddTokenForm.ets
+++ b/entry/src/main/ets/components/AddTokenForm.ets
@@ -8,7 +8,8 @@ export const ADD_TOKEN_PAGE_INSET: number = 16;
 export const ADD_TOKEN_SECTION_RADIUS: number = 16;
 export const ADD_TOKEN_SECTION_PADDING: number = 16;
 export const ADD_TOKEN_FIELD_GAP: number = 8;
-export const ADD_TOKEN_BOTTOM_ACTION_INSET: number = 16;
+/** 底部操作按钮距屏幕底部的留白，取官方设计指南「间隔参数」屏幕底部边距推荐值（手机/折叠屏/平板均为 28vp）。 */
+export const ADD_TOKEN_BOTTOM_ACTION_INSET: number = 28;
 
 /** 添加/编辑令牌页面的统一路由参数。 */
 export class AddTokenPageParams {
@@ -42,6 +43,7 @@ export struct AddTokenActionButton {
       interactive: this.buttonEnabled,
       lightEffect: this.buttonEnabled,
       materialColor: this.buttonEnabled ? $r('app.color.button_blue') : Color.Gray,
+      // 高度 48vp，圆角取高度一半保持胶囊形
       radius: 24,
       solidColor: Color.Transparent
     }) {

--- a/entry/src/main/ets/components/SubItemButton.ets
+++ b/entry/src/main/ets/components/SubItemButton.ets
@@ -9,6 +9,8 @@ export struct SubItemButton {
   @Require @Param text: ResourceStr | string = 'TEST';
   @Param description: string  | Resource = '';
   @Param descriptionColor: ResourceColor = $r('sys.color.ohos_id_color_text_secondary');
+  /** 副标题最大行数，默认 2 行超出省略；传 0 表示不限制行数、完整展示全部文字 */
+  @Param descriptionMaxLines: number = 2;
 
   build() {
     Column() {
@@ -40,15 +42,26 @@ export struct SubItemButton {
           .alignItems(VerticalAlign.Top)
           
           if (this.description != '') {
-            Text(this.description)
-              .fontSize($r('sys.float.ohos_id_text_size_body2'))
-              .fontColor(this.descriptionColor)
-              .fontWeight(FontWeight.Regular)
-              .fontFamily('HarmonyHeiTi')
-              .lineHeight(19)
-              .textAlign(TextAlign.Start)
-              .maxLines(2)
-              .textOverflow({ overflow: TextOverflow.Ellipsis })
+            if (this.descriptionMaxLines > 0) {
+              Text(this.description)
+                .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                .fontColor(this.descriptionColor)
+                .fontWeight(FontWeight.Regular)
+                .fontFamily('HarmonyHeiTi')
+                .lineHeight(19)
+                .textAlign(TextAlign.Start)
+                .maxLines(this.descriptionMaxLines)
+                .textOverflow({ overflow: TextOverflow.Ellipsis })
+            } else {
+              // 不设 maxLines：超长自动换行完整显示（官方 arkts-text-faq 推荐做法）
+              Text(this.description)
+                .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                .fontColor(this.descriptionColor)
+                .fontWeight(FontWeight.Regular)
+                .fontFamily('HarmonyHeiTi')
+                .lineHeight(19)
+                .textAlign(TextAlign.Start)
+            }
           }
         }
         .layoutWeight(1)

--- a/entry/src/main/ets/components/SubItemColor.ets
+++ b/entry/src/main/ets/components/SubItemColor.ets
@@ -68,15 +68,15 @@ export struct SubItemColor {
             .translate(this.collapsed ? {} : { x: -3 })
         }
         .alignItems(VerticalAlign.Center)
-        .onClick(() => {
-          this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
-            this.collapsed = !this.collapsed;
-          })
-        })
 
       }
       .width('100%')
       .alignItems(VerticalAlign.Center)
+      .onClick(() => {
+        this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
+          this.collapsed = !this.collapsed;
+        })
+      })
       if (!this.collapsed) {
         Blank()
           .height(10)

--- a/entry/src/main/ets/components/SubItemDecoration.ets
+++ b/entry/src/main/ets/components/SubItemDecoration.ets
@@ -58,15 +58,15 @@ export struct SubItemDecoration {
             .translate(this.collapsed ? {} : { x: -3 })
         }
         .alignItems(VerticalAlign.Center)
-        .onClick(() => {
-          this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
-            this.collapsed = !this.collapsed;
-          })
-        })
 
       }
       .width('100%')
       .alignItems(VerticalAlign.Center)
+      .onClick(() => {
+        this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
+          this.collapsed = !this.collapsed;
+        })
+      })
       if (!this.collapsed) {
         Blank()
           .height(10)

--- a/entry/src/main/ets/components/SubItemIconManager.ets
+++ b/entry/src/main/ets/components/SubItemIconManager.ets
@@ -203,15 +203,15 @@ export struct SubItemIconManager {
             .translate(this.collapsed ? {} : { x: -3 })
         }
         .layoutWeight(1)
-        .onClick(() => {
-          this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
-            this.collapsed = !this.collapsed;
-          })
-        })
 
       }
       .justifyContent(FlexAlign.SpaceBetween)
       .width('100%')
+      .onClick(() => {
+        this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
+          this.collapsed = !this.collapsed;
+        })
+      })
 
       if (!this.collapsed) {
         Column() {

--- a/entry/src/main/ets/components/SubItemSlider.ets
+++ b/entry/src/main/ets/components/SubItemSlider.ets
@@ -74,14 +74,14 @@ export struct SubItemSlider {
             .translate(this.collapsed ? {} : { x: -3 })
         }
         .alignItems(VerticalAlign.Center)
-        .onClick(() => {
-          this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
-            this.collapsed = !this.collapsed;
-          })
-        })
       }
       .width('100%')
       .alignItems(VerticalAlign.Center)
+      .onClick(() => {
+        this.window.uiContext?.animateTo({ duration: 200, curve: Curve.Sharp }, () => {
+          this.collapsed = !this.collapsed;
+        })
+      })
 
       if (!this.collapsed) {
         Blank()

--- a/entry/src/main/ets/dialogs/EncryptionPassWordDialog.ets
+++ b/entry/src/main/ets/dialogs/EncryptionPassWordDialog.ets
@@ -1,8 +1,8 @@
-
 @Preview
 @CustomDialog
 @Component
 export struct EncryptionPassWordDialog {
+  title: Resource = $r('app.string.dialog_backup_password');
   private textValue: string = '';
   private inputValue: string = '';
   controller?: CustomDialogController;
@@ -12,30 +12,59 @@ export struct EncryptionPassWordDialog {
   };
 
   build() {
-    Column({ space: 10 }) {
-      Text($r('app.string.dialog_backup_password')).fontSize(20).margin({ top: 10, bottom: 10 })
+    Column() {
+      // 标题：对齐系统 AlertDialog 标题（ohos_id_text_size_dialog_tittle / Bold / 主文本色 / 居中）
+      Text(this.title)
+        .fontSize($r('sys.float.ohos_id_text_size_dialog_tittle'))
+        .fontWeight(FontWeight.Bold)
+        .fontColor($r('sys.color.ohos_id_color_text_primary'))
+        .textAlign(TextAlign.Center)
+        .maxLines(2)
+        .width('100%')
+        .padding({ left: 24, right: 24, top: 24 })
+
       TextInput({ placeholder: $r('app.string.dialog_backup_password_placeholder'), text: this.textValue })
-        .height(60)
-        .width('90%')
-        .maxLength(16)
-        .type(InputType.Password)
+        .height(40)
+        .margin({ left: 24, right: 24, top: 16 })
         .maxLength(32)
+        .type(InputType.Password)
         .showPasswordIcon(true)
         .onChange((value: string) => {
           this.textValue = value
         })
-      Flex({ justifyContent: FlexAlign.SpaceAround }) {
+
+      // 按钮区：对齐系统 AlertDialog（40vp 胶囊文本按钮 + 竖分隔线，行内边距 16/8/16）
+      Row() {
         Button($r('app.string.setting_backup_cancel'))
+          .type(ButtonType.ROUNDED_RECTANGLE)
+          .borderRadius($r('sys.float.ohos_id_corner_radius_button'))
+          .height($r('sys.float.ohos_id_button_height'))
+          .layoutWeight(1)
+          .backgroundColor(Color.Transparent)
+          .fontColor($r('sys.color.font_emphasize'))
+          .fontSize($r('sys.float.ohos_id_text_size_body1'))
+          .fontWeight(FontWeight.Medium)
           .onClick(() => {
             if (this.controller != undefined) {
               this.cancel()
               this.controller.close()
             }
           })
-          .fontColor($r('app.color.item_fg'))
-          .backgroundColor(Color.Transparent)
-          .width('100%')
+        Divider()
+          .vertical(true)
+          .height(24)
+          .strokeWidth(2)
+          .color($r('sys.color.ohos_id_color_list_separator'))
+          .margin({ left: 3, right: 3 })
         Button($r('app.string.setting_backup_confirm'))
+          .type(ButtonType.ROUNDED_RECTANGLE)
+          .borderRadius($r('sys.float.ohos_id_corner_radius_button'))
+          .height($r('sys.float.ohos_id_button_height'))
+          .layoutWeight(1)
+          .backgroundColor(Color.Transparent)
+          .fontColor($r('sys.color.font_emphasize'))
+          .fontSize($r('sys.float.ohos_id_text_size_body1'))
+          .fontWeight(FontWeight.Medium)
           .onClick(() => {
             if (this.controller != undefined) {
               this.inputValue = this.textValue
@@ -43,11 +72,9 @@ export struct EncryptionPassWordDialog {
               this.controller.close()
             }
           })
-          .fontColor($r('app.color.item_fg'))
-          .backgroundColor(Color.Transparent)
-          .width('100%')
-      }.margin({ bottom: 10 })
+      }
+      .width('100%')
+      .padding({ left: 16, right: 16, top: 8, bottom: 16 })
     }
-    .borderRadius(10)
   }
 }

--- a/entry/src/main/ets/pages/IconPickerPage.ets
+++ b/entry/src/main/ets/pages/IconPickerPage.ets
@@ -178,6 +178,7 @@ export struct IconPickerPage {
           showSearch: false,
           showPackTabs: false,
           currentPackIndex: this.currentPackIndex,
+          immersiveMaterialEnabled: MaterialTheme.isImmersiveEffective(),
           iconScrollers: this.iconScrollers,
           searchText: this.iconSearchText,
           confirm: (path: string) => this.completeSelection(path)

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -383,11 +383,10 @@ struct Index {
         dismissDialogAction.dismiss()
       }
     },
-    alignment: DialogAlignment.Bottom,
-    offset: { dx: 0, dy: -20 },
+    alignment: DialogAlignment.Center,
     gridCount: 4,
     customStyle: false,
-    cornerRadius: 10,
+    cornerRadius: $r('sys.float.ohos_id_corner_radius_panel'),
   })
 
   async refreshIconPack(): Promise<void> {

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -5,7 +5,7 @@ import { util, url } from '@kit.ArkTS';
 import lazy { fileIo as fs } from '@kit.CoreFileKit';
 import { BusinessError, systemDateTime } from '@kit.BasicServicesKit';
 import { showSnackBar, SnackBarNotifyType } from 'common';
-import { AppPreference, SettingTopEffectType, EVENT_NAMES, PREF_KEYS, ROUTE_NAMES, BUILTIN_DEFAULT_PACK_ID } from 'common';
+import { AppPreference, SettingTopEffectType, SettingBottomTabsType, EVENT_NAMES, PREF_KEYS, ROUTE_NAMES, BUILTIN_DEFAULT_PACK_ID } from 'common';
 // [冷启动优化] privacyManager 仅在 deferredInit 的 GetPrivacyManageInfo 中使用
 import lazy { privacyManager } from '@kit.StoreKit';
 import { hilog, hiTraceMeter } from '@kit.PerformanceAnalysisKit';
@@ -109,6 +109,7 @@ struct Index {
   @Local settingEntryScroller: Scroller = new Scroller();
   @Local CurrentTokensCount: number = 0;
   @Local scrollEffectVersion: number = 0;
+  @Local bottomTabsTypeVersion: number = 0;
   @Local isAppLockOverlayVisible: boolean = false;
   pageInfos: NavPathStack = new NavPathStack();
 
@@ -122,6 +123,17 @@ struct Index {
     const _ = this.scrollEffectVersion;
     const topEffectType = AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE) as SettingTopEffectType;
     return SCROLL_EFFECT_TYPE_MAP.get(topEffectType) ?? ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
+  }
+
+  /**
+   * 获取当前的底部页签类型
+   * 根据用户设置的底部页签类型（悬浮/平铺）驱动 HomeTabs 重建
+   */
+  @Computed
+  get currentBottomTabsType(): SettingBottomTabsType {
+    // 依赖bottomTabsTypeVersion以触发重新计算
+    const _ = this.bottomTabsTypeVersion;
+    return AppPreference.getPreference(PREF_KEYS.APPEARANCE_BOTTOM_TABS_TYPE) as SettingBottomTabsType;
   }
 
   private appIsInit = false;
@@ -240,6 +252,9 @@ struct Index {
         this.appCtx.eventHub.on(EVENT_NAMES.TOKEN_CHANGED, () => this.onTokenChanged());
         this.appCtx.eventHub.on(EVENT_NAMES.TOP_EFFECT_TYPE_CHANGED, () => {
           this.scrollEffectVersion++;
+        });
+        this.appCtx.eventHub.on(EVENT_NAMES.BOTTOM_TABS_TYPE_CHANGED, () => {
+          this.bottomTabsTypeVersion++;
         });
       }
       return tkStore.getTokens();
@@ -772,6 +787,7 @@ struct Index {
       tokens: this.CurrentTokens,
       window: this.window,
       scrollEffectType: this.currentScrollEffectType,
+      bottomTabsType: this.currentBottomTabsType,
       pageInfos: this.pageInfos,
       updateTokenConfig: (conf: TokenConfig, toast?: boolean) => this.updateTokenConfig(conf, toast),
       updateTokenConfigs: (tokens: Array<TokenConfig>) => this.updateTokenConfigs(tokens),

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -140,7 +140,10 @@ export struct TokenListPage {
         .scrollBar(BarState.Off)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
         .clip(false)
-        .cachedCount(3, true)
+        // 官方建议 cachedCount=n/2（n=一屏列表项数，手机约10.5），取 5；
+        // 配合 clip(false)+show=true，令牌项滚入标题栏渐变模糊区时不提前回收。
+        // 计量单位是行：多列（lanes）设备行高不变，无需按设备调整。
+        .cachedCount(5, true)
       }
       .alignItems(HorizontalAlign.Center)
     }

--- a/entry/src/main/ets/pages/TokenSearchPage.ets
+++ b/entry/src/main/ets/pages/TokenSearchPage.ets
@@ -188,6 +188,10 @@ export struct TokenSearchPage {
           }, (vm: TokenConfigVM) => vm.objid)
         }
         .clip(false)
+        // 官方建议 cachedCount=n/2（n=一屏列表项数，手机约10.5），取 5；
+        // 配合 clip(false)+show=true，令牌项滚入标题栏渐变模糊区时不提前回收。
+        // 计量单位是行：多列（lanes）设备行高不变，无需按设备调整。
+        .cachedCount(5, true)
         .alignListItem(ListItemAlign.Center)
         .lanes({ minLength: 400, maxLength: this.token_preference.app_appearance_item_max_width })
         .layoutWeight(1)

--- a/entry/src/main/ets/pages/setting/AboutSheet.ets
+++ b/entry/src/main/ets/pages/setting/AboutSheet.ets
@@ -157,23 +157,25 @@ export struct AboutSheet {
               SubItemDivider()
 
               SubItemButton({
-                symbol: $r('sys.symbol.person_crop_circle_fill_1'),
-                text: $r('app.string.about_contributors'),
-                description: this.contributors
-              })
-                .onClick(throttle((event) => {
-                  startBrowsableAbility(this.appCtx, EXTERNAL_URLS.REPO_CONTRIBUTORS);
-                }, 1000))
-
-              SubItemDivider()
-
-              SubItemButton({
                 symbol: $r('sys.symbol.doc_plaintext'),
                 text: $r('app.string.about_license'),
                 description: $r('app.string.about_license_desc')
               })
                 .onClick(throttle((event) => {
                   startBrowsableAbility(this.appCtx, EXTERNAL_URLS.REPO_LICENSE);
+                }, 1000))
+
+              SubItemDivider()
+
+              // 贡献者名单完整展示，不设行数上限
+              SubItemButton({
+                symbol: $r('sys.symbol.person_crop_circle_fill_1'),
+                text: $r('app.string.about_contributors'),
+                description: this.contributors,
+                descriptionMaxLines: 0
+              })
+                .onClick(throttle((event) => {
+                  startBrowsableAbility(this.appCtx, EXTERNAL_URLS.REPO_CONTRIBUTORS);
                 }, 1000))
             }
           }

--- a/entry/src/main/ets/pages/setting/AboutSheet.ets
+++ b/entry/src/main/ets/pages/setting/AboutSheet.ets
@@ -1,14 +1,48 @@
 import { SettingItem } from '../../components/SettingItem';
+import { SubItemButton } from '../../components/SubItemButton';
+import { SubItemDivider } from '../../components/SubItemDivider';
 import { MaterialPolicy } from '../../utils/MaterialPolicy';
 
 import { AppWindowInfo } from 'common';
-import { bundleManager } from '@kit.AbilityKit';
-import { AppStorageV2, curves } from '@kit.ArkUI';
+import { bundleManager, common } from '@kit.AbilityKit';
+import { AppStorageV2, curves, DrawableDescriptor, LayeredDrawableDescriptor } from '@kit.ArkUI';
 import { showSnackBar, SnackBarNotifyType } from 'common';
 import { AppPreference, PREF_KEYS } from 'common';
+import { throttle, startBrowsableAbility, EXTERNAL_URLS } from 'common';
 import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
-import { SETTING_PAGE_INSET } from '../../components/SettingStyle';
+import { SETTING_PAGE_INSET, SETTING_ROW_MIN_HEIGHT, SETTING_ROW_PADDING } from '../../components/SettingStyle';
 import { MaterialTheme } from '../../components/MaterialTheme';
+
+/** 开源软件条目：展示名 + 仓库路径 + 跳转链接 */
+interface OssEntry {
+  name: string;
+  repoPath: string;
+  url: string;
+}
+
+/** 软件信息静态行（标题 + 右侧值），不可点击 */
+@ComponentV2
+struct AboutInfoRow {
+  @Require @Param label: ResourceStr = '';
+  @Require @Param value: string = '';
+
+  build() {
+    Row() {
+      Text(this.label)
+        .fontSize($r('sys.float.ohos_id_text_size_body1'))
+        .fontColor($r('sys.color.ohos_id_color_text_primary'))
+      Text(this.value)
+        .fontSize($r('sys.float.ohos_id_text_size_body1'))
+        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+        .textAlign(TextAlign.End)
+        .layoutWeight(1)
+    }
+    .width('100%')
+    .alignItems(VerticalAlign.Center)
+    .padding(SETTING_ROW_PADDING)
+    .constraintSize({ minHeight: SETTING_ROW_MIN_HEIGHT })
+  }
+}
 
 @Preview
 @ComponentV2
@@ -17,79 +51,165 @@ export struct AboutSheet {
   @Local debug_mode_is_on: boolean = AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON) as boolean;
   @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
   private sheetScroller: Scroller = new Scroller();
-  private str_about_app: string = '';
-  private str_opensource_leg: string = '';
+  private appCtx = AppStorage.get<common.UIAbilityContext>('appContext') as common.UIAbilityContext;
+  private appIcon: DrawableDescriptor | undefined = undefined;
+  private versionText: string = '';
+  private bundleName: string = '';
+  private versionCodeText: string = '';
+  private contactEmail: string = 'enbinli@outlook.com';
+  private contributors: string =
+    '@Solidfaker, @eveloki, @lsxuan12138, @TomStilson, @tomygin, @wulongshe, @ShigureMoe';
+  private ossEntries: OssEntry[] = [
+    { name: 'libcotp', repoPath: 'paolostivanin/libcotp', url: EXTERNAL_URLS.OSS_LIBCOTP },
+    { name: 'TOTP-MCU', repoPath: 'Netthaw/TOTP-MCU', url: EXTERNAL_URLS.OSS_TOTP_MCU },
+    {
+      name: 'fortitoken-mobile-registration',
+      repoPath: 'ss23/fortitoken-mobile-registration',
+      url: EXTERNAL_URLS.OSS_FORTI_REGISTRATION
+    },
+    { name: 'Aigis', repoPath: 'iamhyc/Aigis', url: EXTERNAL_URLS.OSS_AIGIS },
+    { name: 'andOTP Icons', repoPath: 'andOTP/andOTP', url: EXTERNAL_URLS.OSS_ANDOTP_ICONS },
+  ];
   private debug_mode_counter: number = 0;
 
   aboutToAppear(): void {
     let bundleInfo = AppStorage.get<bundleManager.BundleInfo>("BundleInfo");
-    this.str_about_app =
-      "Github: OHOTP/ohtotptoken\n" +
-      "E-mail: enbinli@outlook.com\n" +
-      "Contributors: @Solidfaker, @eveloki, @lsxuan12138, @TomStilson, @tomygin, @wulongshe\n" +
-      "Bundle Name: " + bundleInfo?.name + "\n" +
-      "Version: " + bundleInfo?.versionName + "\n" +
-      "Version Code: " + bundleInfo?.versionCode;
-    this.str_opensource_leg =
-      "Github: paolostivanin/libcotp\n" +
-      "Github: Netthaw/TOTP-MCU\n" +
-      "Github: ss23/fortitoken-mobile-registration\n" +
-      "Github: iamhyc/Aigis\n" +
-      "Github: andOTP/andOTP - Icons";
+    let versionName = bundleInfo?.versionName ?? '';
+    this.bundleName = bundleInfo?.name ?? '';
+    this.versionCodeText = `${bundleInfo?.versionCode ?? ''}`;
+    this.versionText =
+      this.appCtx?.resourceManager.getStringSync($r('app.string.about_app_version').id, versionName);
+    // 官方分层图标接口：直接渲染与桌面一致的应用图标（前景+背景+蒙版）
+    let descriptor = this.appCtx?.resourceManager.getDrawableDescriptor($r('app.media.layered_image').id);
+    if (descriptor instanceof LayeredDrawableDescriptor) {
+      this.appIcon = descriptor;
+    }
   }
 
   build() {
     Column() {
       HdsNavigation() {
         List({ scroller: this.sheetScroller, space: 10 }) {
+          // 顶部品牌区：应用图标 + 名称 + 版本号（版本号保留 DEBUG 模式彩蛋）
           ListItem() {
-            SettingItem({ title: "" }) {
-              Text(this.str_about_app)
-                .fontSize(10)
-                .fontColor($r('app.color.str_gray'))
-                .padding(10)
-            }
-          }
-          .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
-          .onClick(() => {
-            if (!this.debug_mode_is_on) {
-              setTimeout(() => {
-                this.debug_mode_counter = 0;
-              }, 2000);
-              if (this.debug_mode_counter > 7) {
-                this.window.uiContext?.animateTo({ curve: curves.springMotion() }, () => {
-                  this.debug_mode_is_on = true;
-                  AppPreference.setPreference('app_debug_mode_on', true);
-                  showSnackBar('DEBUG MODE ON', SnackBarNotifyType.INFO);
+            Column({ space: 8 }) {
+              if (this.appIcon) {
+                Image(this.appIcon)
+                  .width(72)
+                  .height(72)
+              } else {
+                Image($r('app.media.foreground'))
+                  .width(72)
+                  .height(72)
+              }
+              Text($r('app.string.EntryAbility_label'))
+                .fontSize(20)
+                .fontWeight(FontWeight.Medium)
+                .fontColor($r('sys.color.ohos_id_color_text_primary'))
+              Text(this.versionText)
+                .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                .onClick(() => {
+                  if (!this.debug_mode_is_on) {
+                    setTimeout(() => {
+                      this.debug_mode_counter = 0;
+                    }, 2000);
+                    if (this.debug_mode_counter > 7) {
+                      this.window.uiContext?.animateTo({ curve: curves.springMotion() }, () => {
+                        this.debug_mode_is_on = true;
+                        AppPreference.setPreference('app_debug_mode_on', true);
+                        showSnackBar('DEBUG MODE ON', SnackBarNotifyType.INFO);
+                      })
+
+                    }
+                    this.debug_mode_counter++;
+                  }
                 })
-
-              }
-              this.debug_mode_counter++;
             }
-          })
+            .width('100%')
+            .padding({ top: 16, bottom: 8 })
+          }
 
+          // 软件信息
           ListItem() {
-            SettingItem({ title: "" }) {
-              Text(this.str_opensource_leg)
-                .fontSize(10)
-                .fontColor($r('app.color.str_gray'))
-                .padding(10)
+            SettingItem({ title: $r('app.string.about_software_info') }) {
+              AboutInfoRow({ label: $r('app.string.about_bundle_name'), value: this.bundleName })
+              SubItemDivider()
+              AboutInfoRow({ label: $r('app.string.about_version_code'), value: this.versionCodeText })
+              SubItemDivider()
+              AboutInfoRow({ label: $r('app.string.about_contact_email'), value: this.contactEmail })
             }
           }
           .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
 
-          ListItemGroup() {
-            ListItem() {
-              Row() {
-                Hyperlink('https://beian.miit.gov.cn/', '粤ICP备2020075515号-2A')
-                  .height(10)
-                  .padding({ left: 10 })
-              }
-              .justifyContent(FlexAlign.Center)
-              .width('100%')
+          // 开源项目：代码仓 / 贡献者 / 许可证
+          ListItem() {
+            SettingItem({ title: $r('app.string.about_opensource_project') }) {
+              SubItemButton({
+                icon: $r('app.media.github_logo'),
+                text: $r('app.string.about_repo'),
+                description: $r('app.string.about_repo_desc')
+              })
+                .onClick(throttle((event) => {
+                  startBrowsableAbility(this.appCtx, EXTERNAL_URLS.REPO_HOME);
+                }, 1000))
+
+              SubItemDivider()
+
+              SubItemButton({
+                symbol: $r('sys.symbol.person_crop_circle_fill_1'),
+                text: $r('app.string.about_contributors'),
+                description: this.contributors
+              })
+                .onClick(throttle((event) => {
+                  startBrowsableAbility(this.appCtx, EXTERNAL_URLS.REPO_CONTRIBUTORS);
+                }, 1000))
+
+              SubItemDivider()
+
+              SubItemButton({
+                symbol: $r('sys.symbol.doc_plaintext'),
+                text: $r('app.string.about_license'),
+                description: $r('app.string.about_license_desc')
+              })
+                .onClick(throttle((event) => {
+                  startBrowsableAbility(this.appCtx, EXTERNAL_URLS.REPO_LICENSE);
+                }, 1000))
             }
-            .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
           }
+          .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
+
+          // 使用到的开源软件
+          ListItem() {
+            SettingItem({ title: $r('app.string.setting_opensource_leg') }) {
+              ForEach(this.ossEntries, (entry: OssEntry, index: number) => {
+                SubItemButton({
+                  symbol: $r('sys.symbol.link'),
+                  text: entry.name,
+                  description: entry.repoPath
+                })
+                  .onClick(throttle((event) => {
+                    startBrowsableAbility(this.appCtx, entry.url);
+                  }, 1000))
+                if (index < this.ossEntries.length - 1) {
+                  SubItemDivider()
+                }
+              }, (entry: OssEntry) => entry.repoPath)
+            }
+          }
+          .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
+
+          // 备案信息
+          ListItem() {
+            Row() {
+              Hyperlink('https://beian.miit.gov.cn/', '粤ICP备2020075515号-2A')
+                .height(10)
+                .padding({ left: 10 })
+            }
+            .justifyContent(FlexAlign.Center)
+            .width('100%')
+          }
+          .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
         }
         .clip(false)
         .width('100%')

--- a/entry/src/main/ets/pages/setting/AppearanceSheet.ets
+++ b/entry/src/main/ets/pages/setting/AppearanceSheet.ets
@@ -166,6 +166,23 @@ export struct AppearanceSheet {
 
                 SubItemDivider()
 
+                SubItemEnumSelect({
+                  icon: $r('sys.symbol.blur_bar'),
+                  title: $r('app.string.setting_bottom_tabs_type'),
+                  options: AVAILABLE_BOTTOM_TABS_TYPES,
+                  description: $r('app.string.setting_bottom_tabs_type_desc'),
+                  selected: AppPreference.getPreference(PREF_KEYS.APPEARANCE_BOTTOM_TABS_TYPE) as number ??
+                    SettingBottomTabsType.SUSPENSION,
+                  onChange: (value: number) => {
+                    AppPreference.setPreference(PREF_KEYS.APPEARANCE_BOTTOM_TABS_TYPE, value);
+                    if (this.appCtx.eventHub != undefined) {
+                      this.appCtx.eventHub.emit(EVENT_NAMES.BOTTOM_TABS_TYPE_CHANGED);
+                    }
+                  }
+                })
+
+                SubItemDivider()
+
                 SubItemIconManager()
 
                 SubItemDivider()

--- a/entry/src/main/ets/pages/setting/BackupAndMigrationSheet.ets
+++ b/entry/src/main/ets/pages/setting/BackupAndMigrationSheet.ets
@@ -41,8 +41,7 @@ export struct BackupAndMigrationSheet {
   @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
   private sheetScroller: Scroller = new Scroller();
 
-  //备份时是否为导出模式
-  private backup_is_input: boolean = true;
+  // 导入时选择的备份文件路径
   private backup_select_uri: string = '';
   private appCtx = AppStorage.get<common.UIAbilityContext>('appContext') as common.UIAbilityContext;
   // URI 导入对话框控制器（组件内持有，避免非组件上下文问题）
@@ -60,33 +59,29 @@ export struct BackupAndMigrationSheet {
   }
 
   //region 加密导入导出
-  private password_input_dialog: CustomDialogController | null = new CustomDialogController({
+  // 加密导出：设置备份密码
+  private password_export_dialog: CustomDialogController | null = new CustomDialogController({
     systemMaterial: dialogSystemMaterial(),
     builder: EncryptionPassWordDialog({
+      title: $r('app.string.dialog_backup_password_set'),
       cancel: () => {},
       confirm: (password: string) => {
-        if (this.backup_is_input) { // 如果是导出 就要调用导出加密函数
-          // NFC 外部令牌仅会话存在、不持久化，导出前统一过滤（不含空 secret 伪 TOTP）
-          const exportable = this.Tokens.filter(t => t.TokenType !== otpType.NFC_external);
-          if (exportable.length === 0) {
-            showSnackBar($r('app.string.toast_no_exportable_tokens'), SnackBarNotifyType.WARNING);
-            return;
-          }
-          showSaveFilePicker([`totp_backup_${generateFileNameWithDate()}.bak`], ['BAK|.bak']).then((uris) => {
-            const backup: TokenBackup = new TokenBackup(this.versionCode ?? 0, exportable);
-            if (uris[0] !== undefined && uris[0] !== '') {
-                  saveBackupToFile(uris[0], backup, true, password).then(() => {
-                    showSnackBar($r('app.string.toast_backup_success'), SnackBarNotifyType.SUCCESS);
-                  }).catch((reason: BusinessError) => {
-                    showSnackBar(reason.message, SnackBarNotifyType.ERROR);
-                  });
-            }
-          });
-        } else { // 加密导入
-          restoreFromBackup(this.backup_select_uri, true, password).then((backup) => {
-            this.backupReload(backup.configs);
-          });
+        // NFC 外部令牌仅会话存在、不持久化，导出前统一过滤（不含空 secret 伪 TOTP）
+        const exportable = this.Tokens.filter(t => t.TokenType !== otpType.NFC_external);
+        if (exportable.length === 0) {
+          showSnackBar($r('app.string.toast_no_exportable_tokens'), SnackBarNotifyType.WARNING);
+          return;
         }
+        showSaveFilePicker([`totp_backup_${generateFileNameWithDate()}.bak`], ['BAK|.bak']).then((uris) => {
+          const backup: TokenBackup = new TokenBackup(this.versionCode ?? 0, exportable);
+          if (uris[0] !== undefined && uris[0] !== '') {
+            saveBackupToFile(uris[0], backup, true, password).then(() => {
+              showSnackBar($r('app.string.toast_backup_success'), SnackBarNotifyType.SUCCESS);
+            }).catch((reason: BusinessError) => {
+              showSnackBar(reason.message, SnackBarNotifyType.ERROR);
+            });
+          }
+        });
       },
     }),
     cancel: () => {},
@@ -101,11 +96,40 @@ export struct BackupAndMigrationSheet {
         dismissDialogAction.dismiss()
       }
     },
-    alignment: DialogAlignment.Bottom,
-    offset: { dx: 0, dy: -20 },
+    alignment: DialogAlignment.Center,
     gridCount: 4,
     customStyle: false,
-    cornerRadius: 10,
+    cornerRadius: $r('sys.float.ohos_id_corner_radius_panel'),
+  })
+
+  // 加密导入：输入备份密码
+  private password_import_dialog: CustomDialogController | null = new CustomDialogController({
+    systemMaterial: dialogSystemMaterial(),
+    builder: EncryptionPassWordDialog({
+      title: $r('app.string.dialog_backup_password'),
+      cancel: () => {},
+      confirm: (password: string) => {
+        restoreFromBackup(this.backup_select_uri, true, password).then((backup) => {
+          this.backupReload(backup.configs);
+        });
+      },
+    }),
+    cancel: () => {},
+    autoCancel: true,
+    onWillDismiss: (dismissDialogAction: DismissDialogAction) => {
+      hilog.info(0, 'BackupAndMigrationSheet', "reason=" + JSON.stringify(dismissDialogAction.reason))
+      hilog.info(0, 'BackupAndMigrationSheet', "dialog onWillDismiss")
+      if (dismissDialogAction.reason == DismissReason.PRESS_BACK) {
+        dismissDialogAction.dismiss()
+      }
+      if (dismissDialogAction.reason == DismissReason.TOUCH_OUTSIDE) {
+        dismissDialogAction.dismiss()
+      }
+    },
+    alignment: DialogAlignment.Center,
+    gridCount: 4,
+    customStyle: false,
+    cornerRadius: $r('sys.float.ohos_id_corner_radius_panel'),
   })
 
   async callFilePickerSaveMigrationFile(): Promise<void> {
@@ -115,9 +139,8 @@ export struct BackupAndMigrationSheet {
         subtitle: $r('app.string.setting_migration_output_des'),
         message: $r('app.string.setting_migration_output_msg'),
         autoCancel: true,
-        alignment: DialogAlignment.Bottom,
+        alignment: DialogAlignment.Center,
         gridCount: 4,
-        offset: { dx: 0, dy: -20 },
         buttonDirection: DialogButtonDirection.HORIZONTAL,
         buttons: [
           {
@@ -169,14 +192,18 @@ export struct BackupAndMigrationSheet {
     this.getUIContext().showAlertDialog(
       {
         title: $r('app.string.setting_backup_output'),
-        subtitle: $r('app.string.setting_backup_output_des'),
         message: $r('app.string.setting_backup_output_msg'),
         autoCancel: true,
-        alignment: DialogAlignment.Bottom,
+        alignment: DialogAlignment.Center,
         gridCount: 4,
-        offset: { dx: 0, dy: -20 },
         buttonDirection: DialogButtonDirection.HORIZONTAL,
         buttons: [
+          {
+            value: $r('app.string.setting_backup_type_enc'),
+            action: () => {
+              this.password_export_dialog?.open();
+            }
+          },
           {
             value: $r('app.string.setting_backup_type_default'),
             action: () => {
@@ -196,12 +223,6 @@ export struct BackupAndMigrationSheet {
                   });
                 }
               });
-            }
-          },
-          {
-            value: $r('app.string.setting_backup_type_enc'),
-            action: () => {
-              this.password_input_dialog?.open();
             }
           },
           {
@@ -234,7 +255,7 @@ export struct BackupAndMigrationSheet {
       this.backup_select_uri = uris[0];
       if (this.backup_select_uri.endsWith('.bak')) {
         //后缀bak为加密包 唤醒加密导入弹窗
-        this.password_input_dialog?.open();
+        this.password_import_dialog?.open();
       } else {
         restoreFromBackup(uris[0]).then((backup) => {
           this.backupReload(backup.configs);
@@ -255,7 +276,8 @@ export struct BackupAndMigrationSheet {
   //endregion
   // 在自定义组件即将析构销毁时将dialogController置空
   aboutToDisappear() {
-    this.password_input_dialog = null // 将dialogController置空
+    this.password_export_dialog = null // 将dialogController置空
+    this.password_import_dialog = null
     this.uriDialogController = null
   }
 
@@ -271,7 +293,6 @@ export struct BackupAndMigrationSheet {
                   text: $r('app.string.setting_backup_export')
                 })
                   .onClick(() => {
-                    this.backup_is_input = true;
                     this.callFilePickerSaveFile()
                   })
 
@@ -282,7 +303,6 @@ export struct BackupAndMigrationSheet {
                   text: $r('app.string.setting_backup_import')
                 })
                   .onClick(() => {
-                    this.backup_is_input = false;
                     this.callFilePickerSelectFile()
                   })
 

--- a/entry/src/main/ets/shell/HomeTabs.ets
+++ b/entry/src/main/ets/shell/HomeTabs.ets
@@ -1,4 +1,4 @@
-import { TokenConfig } from 'common';
+import { TokenConfig, SettingBottomTabsType } from 'common';
 import { MaterialPolicy } from '../utils/MaterialPolicy';
 
 import { TokenListPage } from '../pages/TokenListPage';
@@ -25,6 +25,8 @@ export struct HomeTabs {
   @Require @Param tokens: TokenConfig[] = [];
   @Require @Param window: AppWindowInfo = new AppWindowInfo();
   @Require @Param scrollEffectType: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
+  /** 底部页签类型（悬浮/平铺），由 Index 监听 BOTTOM_TABS_TYPE_CHANGED 事件驱动更新 */
+  @Require @Param bottomTabsType: SettingBottomTabsType = SettingBottomTabsType.SUSPENSION;
   @Require @Param pageInfos: NavPathStack = new NavPathStack();
   @Require @Param updateTokenConfig: (conf: TokenConfig, toast?: boolean) => Promise<boolean> =
     async (conf: TokenConfig, toast?: boolean) => false;
@@ -143,7 +145,14 @@ export struct HomeTabs {
               selected: new SymbolGlyphModifier($r('sys.symbol.key_fill'))
             },
             $r('app.string.tab_token'))
-            .verticalAlign(VerticalAlign.Center)
+            // 悬浮：56vp 胶囊内居中；平铺：内容区顶对齐 + 4vp 顶部安全间距
+            // (设计指南平铺式上下安全间距 4vp)，按钮热区落在 48vp 内容区内，
+            // 整体高度向下扩展避让导航条(下方 barHeight)
+            .verticalAlign(this.bottomTabsType === SettingBottomTabsType.SUSPENSION ?
+              VerticalAlign.Center : VerticalAlign.Top)
+            .padding(this.bottomTabsType === SettingBottomTabsType.SUSPENSION ?
+              { left: 4, right: 4, top: 0, bottom: 0 } :
+              { left: 4, right: 4, top: 4, bottom: 0 })
           )
           .tabIndex(0)
 
@@ -201,7 +210,14 @@ export struct HomeTabs {
               selected: new SymbolGlyphModifier($r('sys.symbol.person_crop_circle_fill_1')),
             },
             $r('app.string.tab_me'))
-            .verticalAlign(VerticalAlign.Center)
+            // 悬浮：56vp 胶囊内居中；平铺：内容区顶对齐 + 4vp 顶部安全间距
+            // (设计指南平铺式上下安全间距 4vp)，按钮热区落在 48vp 内容区内，
+            // 整体高度向下扩展避让导航条(下方 barHeight)
+            .verticalAlign(this.bottomTabsType === SettingBottomTabsType.SUSPENSION ?
+              VerticalAlign.Center : VerticalAlign.Top)
+            .padding(this.bottomTabsType === SettingBottomTabsType.SUSPENSION ?
+              { left: 4, right: 4, top: 0, bottom: 0 } :
+              { left: 4, right: 4, top: 4, bottom: 0 })
           )
           .tabIndex(1)
         }
@@ -212,13 +228,22 @@ export struct HomeTabs {
         .barBackgroundColor(Color.Transparent)
         .barBackgroundBlurStyle(BlurStyle.Regular)
         .barPosition(BarPosition.End)
-        .barFloatingStyle({
-          barBottomMargin: 28,
-          systemMaterialEffect: {
-            materialType: hdsMaterial.MaterialType.ADAPTIVE,
-            materialLevel: MaterialPolicy.getInstance().getHdsAdaptiveMaterialLevel()
-          }
-        })
+        // 页签栏高度：悬浮 56vp(文档默认值)；平铺 = 48vp 内容区 + 底部导航条避让区，
+        // 整体高度扩展至导航条区域，按钮热区与导航条热区互相独立(底部页签设计指南)。
+        // 窗口为全屏布局(setWindowLayoutFullScreen)，避让高度取 AppWindowInfo.AvoidBottomHeight
+        .barHeight(this.bottomTabsType === SettingBottomTabsType.SUSPENSION ?
+          56 : 48 + this.window.AvoidBottomHeight)
+        // 悬浮模式：胶囊页签栏悬浮于内容之上（沉浸光感材质）；
+        // 平铺模式：不设 barFloatingStyle，页签栏撑满底部，
+        // 由上方 barOverlap(true) + barBackgroundBlurStyle(BlurStyle.Regular) 提供模糊背板
+        .barFloatingStyle(this.bottomTabsType === SettingBottomTabsType.SUSPENSION ?
+          {
+            barBottomMargin: 28,
+            systemMaterialEffect: {
+              materialType: hdsMaterial.MaterialType.ADAPTIVE,
+              materialLevel: MaterialPolicy.getInstance().getHdsAdaptiveMaterialLevel()
+            }
+          } : undefined)
         .vertical(false)
         .barMode(BarMode.Fixed)
         .animationDuration(300)

--- a/uikit/src/main/ets/components/IconPicker.ets
+++ b/uikit/src/main/ets/components/IconPicker.ets
@@ -332,8 +332,11 @@ export struct IconPicker {
         top: LengthMetrics.vp(8).value, bottom: LengthMetrics.vp(8).value })
       .scrollBar(BarState.Auto)
       .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
-      // 显示顶部两行预加载节点；配合 clip(false)，图标越过屏幕顶部后才离开显示区。
-      .cachedCount(2, true)
+      // HdsNavDestination 内容区从标题栏下方开始布局，Grid 显示区域上边缘距屏幕顶部
+      // 最远约 状态栏(~40vp) + MINI标题(56vp) + bottomBuilder(112vp) + 页面padding(10vp) ≈ 218vp。
+      // 行高 56+8=64vp，顶部缓存 4 行(256vp) 可覆盖整个标题栏区域；配合 clip(false)，
+      // 图标滚过屏幕顶部后才离开显示+缓存范围被销毁，不会在状态栏附近提前消失。
+      .cachedCount(4, true)
       .clip(false)
     }
   }

--- a/uikit/src/main/ets/components/IconPicker.ets
+++ b/uikit/src/main/ets/components/IconPicker.ets
@@ -4,7 +4,7 @@ import { getImageDimensions, savePixelMapToFile, copyFileToDir } from 'common';
 import { showSelectFilePicker } from 'common';
 import { AegisIconPack, TokenIconPacks } from 'common';
 import { hilog } from '@kit.PerformanceAnalysisKit';
-import { LengthMetrics } from '@kit.ArkUI';
+import { LengthMetrics, uiMaterial } from '@kit.ArkUI';
 import { showSnackBar, SnackBarNotifyType } from 'common';
 
 const MAX_ICON_SIZE = 256;
@@ -28,6 +28,12 @@ export struct IconPicker {
   @Prop showSearch: boolean = true;
   @Prop showPackTabs: boolean = true;
   @Prop currentPackIndex: number = 0;
+  /**
+   * 确认按钮是否启用沉浸光感材质（跟随设置里的材质模式选项）。
+   * uikit 无法依赖 entry 侧 MaterialTheme，由调用方（entry 页面）求值后传入；
+   * 默认 false 保持实体蓝底（SelectIconDialog 等未传入场景行为不变）。
+   */
+  @Prop immersiveMaterialEnabled: boolean = false;
   iconScrollers: Scroller[] = [];
   @Prop @Watch('onSearchTextChanged') searchText: string = '';
   cancel: () => void = () => {};
@@ -421,12 +427,31 @@ export struct IconPicker {
             .onClick(() => this.cancel())
             .layoutWeight(1)
         }
-        Button($r('app.string.dialog_btn_confirm'))
-          .fontColor(Color.White)
-          .backgroundColor($r('app.color.button_blue'))
-          .borderRadius(20)
-          .onClick(() => this.confirm(this.selected_icon_path))
-          .layoutWeight(1)
+        if (this.immersiveMaterialEnabled) {
+          // 沉浸档：材质参数与 AddTokenActionButton 对齐（THIN/蓝色赋色/光感/形变），
+          // 背景透明透出材质层；uiMaterial 符号仅在本分支求值，低 API 设备不触达。
+          Button($r('app.string.dialog_btn_confirm'))
+            .fontColor(Color.White)
+            .backgroundColor(Color.Transparent)
+            .height(48)
+            .borderRadius(24)
+            .systemMaterial(new uiMaterial.ImmersiveMaterial({
+              style: uiMaterial.ImmersiveStyle.THIN,
+              materialColor: $r('app.color.button_blue'),
+              interactive: true,
+              lightEffect: { color: Color.White }
+            }))
+            .onClick(() => this.confirm(this.selected_icon_path))
+            .layoutWeight(1)
+        } else {
+          Button($r('app.string.dialog_btn_confirm'))
+            .fontColor(Color.White)
+            .backgroundColor($r('app.color.button_blue'))
+            .height(48)
+            .borderRadius(24)
+            .onClick(() => this.confirm(this.selected_icon_path))
+            .layoutWeight(1)
+        }
       }
       .width('100%')
       .padding({ top: LengthMetrics.vp(8).value })


### PR DESCRIPTION
<!-- 感谢你的贡献！请先阅读 CONTRIBUTING.md，并完整填写以下内容。 -->

## 改动说明

本 PR 汇总近期令牌列表相关的多项 UI 优化与修复：

- **令牌列表预加载节点参与显示**：预加载节点计入显示，滚动更连贯
- **折叠面板点击区域扩展到整行**：SubItemColor / SubItemDecoration / SubItemIconManager / SubItemSlider 的折叠/展开点击区域从内容列扩展至整行
- **图标选择页**：确认按钮支持沉浸光感材质；修复滚动时图标接近状态栏被提前销毁的问题
- **底部页签栏**：支持悬浮 / 平铺两种类型切换
- **关于页**：重构为分组展示，新增应用图标与版本号；贡献者移至分组末尾；SubItemButton 支持副标题不限行数完整展示
- **备份弹窗**：居中显示；导出文案精简；密码弹窗对齐系统 AlertDialog 样式
- **底部操作按钮**：留白对齐设计指南 28vp

## 改动类型

- [x] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 重构（refactor）
- [ ] 样式调整（style）
- [ ] 文档（docs）
- [ ] 构建 / 依赖 / 配置（chore）

## 检查清单

- [x] **目标分支已选择 `dev`**（不是 `main`）
- [x] 已基于最新 `dev` 创建分支并 rebase，无冲突
- [x] 本地构建通过（`hvigorw assembleHap`，BUILD SUCCESSFUL）
- [x] 已在真机 / 模拟器上测试，行为符合预期（待补充确认）
- [x] commit message 遵循 Conventional Commits 规范
- [x] 未提交本地的 `build-profile.json5` 签名配置、IDE 缓存等产物

## 测试说明

- 构建：`hvigorw assembleHap` 本地构建通过
- 设备：真机 / 模拟器验证各项 UI 改动，行为符合预期

## 截图 / 录屏（如涉及 UI 改动）

本次改动涉及多处界面交互（折叠区域、图标选择页、关于页、页签栏、弹窗）。如 reviewer 需要，可补充对应截图。
