### PR TITLE
fix: 动态扩展令牌列表缓存并统一主页与窗口 UI 细节

### DIFF
--- a/common/src/main/ets/utils/AppPreference.ets
+++ b/common/src/main/ets/utils/AppPreference.ets
@@ -41,6 +41,8 @@ export enum EVENT_NAMES {
   START_TOKEN_SORT = 'onStartTokenSort',
   /** 华为账号状态变更事件（登录/登出/初始化完成后由 Index 广播,SheetCoordinator 监听同步） */
   HUAWEI_ACCOUNT_STATE_CHANGED = 'onHuaweiAccountStateChanged',
+  /** DEBUG 模式变更事件（令牌项等调试 UI 监听并即时刷新） */
+  DEBUG_MODE_CHANGED = 'onDebugModeChanged',
 }
 
 /**

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -1639,6 +1639,26 @@
     {
       "name": "card_config_no_token",
       "value": "No tokens available"
+    },
+    {
+      "name": "setting_group_developer_options",
+      "value": "Developer Options"
+    },
+    {
+      "name": "developer_add_test_tokens",
+      "value": "Add 100 Test Tokens"
+    },
+    {
+      "name": "developer_add_test_tokens_description",
+      "value": "Generate random token names and secrets for development and debugging."
+    },
+    {
+      "name": "developer_add_test_tokens_confirm_title",
+      "value": "Add Test Tokens?"
+    },
+    {
+      "name": "developer_add_test_tokens_confirm_message",
+      "value": "This will add 100 test tokens with random names and secrets. Continue?"
     }
   ]
 }

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -1141,6 +1141,18 @@
       "value": "Immersive Material"
     },
     {
+      "name": "setting_group_data_management",
+      "value": "Data Management"
+    },
+    {
+      "name": "setting_group_app_settings",
+      "value": "App Settings"
+    },
+    {
+      "name": "setting_group_support_about",
+      "value": "Support & About"
+    },
+    {
       "name": "setting_token_item_material",
       "value": "List Item Material"
     },

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -181,6 +181,14 @@
       "value": "input your password..."
     },
     {
+      "name": "dialog_backup_password_confirm_placeholder",
+      "value": "Confirm backup password..."
+    },
+    {
+      "name": "dialog_backup_password_mismatch",
+      "value": "Passwords do not match"
+    },
+    {
       "name": "warn_forti_dev_id_popup",
       "value": "FortiToken allows you to register a token only once with this device id"
     },

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -189,6 +189,10 @@
       "value": "Passwords do not match"
     },
     {
+      "name": "dialog_backup_password_empty",
+      "value": "Password cannot be empty"
+    },
+    {
       "name": "warn_forti_dev_id_popup",
       "value": "FortiToken allows you to register a token only once with this device id"
     },
@@ -1645,6 +1649,10 @@
       "value": "Developer Options"
     },
     {
+      "name": "setting_group_token_operations",
+      "value": "Token Operations"
+    },
+    {
       "name": "developer_add_test_tokens",
       "value": "Add 100 Test Tokens"
     },
@@ -1659,6 +1667,30 @@
     {
       "name": "developer_add_test_tokens_confirm_message",
       "value": "This will add 100 test tokens with random names and secrets. Continue?"
+    },
+    {
+      "name": "developer_remove_test_tokens",
+      "value": "Remove Test Tokens"
+    },
+    {
+      "name": "developer_remove_test_tokens_description",
+      "value": "Remove tokens whose issuer starts with Test-."
+    },
+    {
+      "name": "developer_remove_test_tokens_confirm_title",
+      "value": "Remove Test Tokens?"
+    },
+    {
+      "name": "developer_remove_test_tokens_confirm_message",
+      "value": "This will remove all tokens whose issuer starts with Test-. Continue?"
+    },
+    {
+      "name": "toast_test_tokens_removed",
+      "value": "%d test token(s) removed"
+    },
+    {
+      "name": "toast_no_test_tokens",
+      "value": "No test tokens to remove"
     }
   ]
 }

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -1639,6 +1639,26 @@
     {
       "name": "card_config_no_token",
       "value": "No tokens available"
+    },
+    {
+      "name": "setting_group_developer_options",
+      "value": "Developer Options"
+    },
+    {
+      "name": "developer_add_test_tokens",
+      "value": "Add 100 Test Tokens"
+    },
+    {
+      "name": "developer_add_test_tokens_description",
+      "value": "Generate random token names and secrets for development and debugging."
+    },
+    {
+      "name": "developer_add_test_tokens_confirm_title",
+      "value": "Add Test Tokens?"
+    },
+    {
+      "name": "developer_add_test_tokens_confirm_message",
+      "value": "This will add 100 test tokens with random names and secrets. Continue?"
     }
   ]
 }

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -181,6 +181,14 @@
       "value": "Enter backup file password..."
     },
     {
+      "name": "dialog_backup_password_confirm_placeholder",
+      "value": "Confirm backup password..."
+    },
+    {
+      "name": "dialog_backup_password_mismatch",
+      "value": "Passwords do not match"
+    },
+    {
       "name": "warn_forti_dev_id_popup",
       "value": "Forti only allows you to activate once and bind to this Device ID"
     },

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -1129,6 +1129,18 @@
       "value": "Immersive Material"
     },
     {
+      "name": "setting_group_data_management",
+      "value": "Data Management"
+    },
+    {
+      "name": "setting_group_app_settings",
+      "value": "App Settings"
+    },
+    {
+      "name": "setting_group_support_about",
+      "value": "Support & About"
+    },
+    {
       "name": "setting_token_item_material",
       "value": "List Item Material"
     },

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -189,6 +189,10 @@
       "value": "Passwords do not match"
     },
     {
+      "name": "dialog_backup_password_empty",
+      "value": "Password cannot be empty"
+    },
+    {
       "name": "warn_forti_dev_id_popup",
       "value": "Forti only allows you to activate once and bind to this Device ID"
     },
@@ -1645,6 +1649,10 @@
       "value": "Developer Options"
     },
     {
+      "name": "setting_group_token_operations",
+      "value": "Token Operations"
+    },
+    {
       "name": "developer_add_test_tokens",
       "value": "Add 100 Test Tokens"
     },
@@ -1659,6 +1667,30 @@
     {
       "name": "developer_add_test_tokens_confirm_message",
       "value": "This will add 100 test tokens with random names and secrets. Continue?"
+    },
+    {
+      "name": "developer_remove_test_tokens",
+      "value": "Remove Test Tokens"
+    },
+    {
+      "name": "developer_remove_test_tokens_description",
+      "value": "Remove tokens whose issuer starts with Test-."
+    },
+    {
+      "name": "developer_remove_test_tokens_confirm_title",
+      "value": "Remove Test Tokens?"
+    },
+    {
+      "name": "developer_remove_test_tokens_confirm_message",
+      "value": "This will remove all tokens whose issuer starts with Test-. Continue?"
+    },
+    {
+      "name": "toast_test_tokens_removed",
+      "value": "%d test tokens removed"
+    },
+    {
+      "name": "toast_no_test_tokens",
+      "value": "No test tokens to remove"
     }
   ]
 }

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -1129,6 +1129,18 @@
       "value": "光感材质"
     },
     {
+      "name": "setting_group_data_management",
+      "value": "数据管理"
+    },
+    {
+      "name": "setting_group_app_settings",
+      "value": "应用设置"
+    },
+    {
+      "name": "setting_group_support_about",
+      "value": "支持与关于"
+    },
+    {
       "name": "setting_token_item_material",
       "value": "列表项材质"
     },

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -189,6 +189,10 @@
       "value": "两次输入的密码不一致"
     },
     {
+      "name": "dialog_backup_password_empty",
+      "value": "密码不能为空"
+    },
+    {
       "name": "warn_forti_dev_id_popup",
       "value": "Forti只允许你激活一次并绑定此设备ID"
     },
@@ -1645,6 +1649,10 @@
       "value": "开发者选项"
     },
     {
+      "name": "setting_group_token_operations",
+      "value": "令牌操作"
+    },
+    {
       "name": "developer_add_test_tokens",
       "value": "添加100个测试令牌"
     },
@@ -1659,6 +1667,30 @@
     {
       "name": "developer_add_test_tokens_confirm_message",
       "value": "将添加100个名称和密钥均随机的测试令牌，是否继续？"
+    },
+    {
+      "name": "developer_remove_test_tokens",
+      "value": "移除测试令牌"
+    },
+    {
+      "name": "developer_remove_test_tokens_description",
+      "value": "移除发行者名称以Test-开头的令牌。"
+    },
+    {
+      "name": "developer_remove_test_tokens_confirm_title",
+      "value": "移除测试令牌？"
+    },
+    {
+      "name": "developer_remove_test_tokens_confirm_message",
+      "value": "将移除所有发行者名称以Test-开头的令牌，是否继续？"
+    },
+    {
+      "name": "toast_test_tokens_removed",
+      "value": "已移除%d个测试令牌"
+    },
+    {
+      "name": "toast_no_test_tokens",
+      "value": "没有可移除的测试令牌"
     }
   ]
 }

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -181,6 +181,14 @@
       "value": "输入备份文件的密码..."
     },
     {
+      "name": "dialog_backup_password_confirm_placeholder",
+      "value": "再次输入备份密码..."
+    },
+    {
+      "name": "dialog_backup_password_mismatch",
+      "value": "两次输入的密码不一致"
+    },
+    {
       "name": "warn_forti_dev_id_popup",
       "value": "Forti只允许你激活一次并绑定此设备ID"
     },

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -1639,6 +1639,26 @@
     {
       "name": "card_config_no_token",
       "value": "暂无可用令牌"
+    },
+    {
+      "name": "setting_group_developer_options",
+      "value": "开发者选项"
+    },
+    {
+      "name": "developer_add_test_tokens",
+      "value": "添加100个测试令牌"
+    },
+    {
+      "name": "developer_add_test_tokens_description",
+      "value": "生成随机名称和密钥，方便开发与调试。"
+    },
+    {
+      "name": "developer_add_test_tokens_confirm_title",
+      "value": "添加测试令牌？"
+    },
+    {
+      "name": "developer_add_test_tokens_confirm_message",
+      "value": "将添加100个名称和密钥均随机的测试令牌，是否继续？"
     }
   ]
 }

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -189,6 +189,10 @@
       "value": "兩次輸入的密碼不一致"
     },
     {
+      "name": "dialog_backup_password_empty",
+      "value": "密碼不能為空"
+    },
+    {
       "name": "warn_forti_dev_id_popup",
       "value": "Forti只允許你啟用一次並綁定此裝置ID"
     },
@@ -1645,6 +1649,10 @@
       "value": "開發者選項"
     },
     {
+      "name": "setting_group_token_operations",
+      "value": "令牌操作"
+    },
+    {
       "name": "developer_add_test_tokens",
       "value": "新增100個測試令牌"
     },
@@ -1659,6 +1667,30 @@
     {
       "name": "developer_add_test_tokens_confirm_message",
       "value": "將新增100個名稱和密鑰均隨機的測試令牌，是否繼續？"
+    },
+    {
+      "name": "developer_remove_test_tokens",
+      "value": "移除測試令牌"
+    },
+    {
+      "name": "developer_remove_test_tokens_description",
+      "value": "移除發行者名稱以Test-開頭的令牌。"
+    },
+    {
+      "name": "developer_remove_test_tokens_confirm_title",
+      "value": "移除測試令牌？"
+    },
+    {
+      "name": "developer_remove_test_tokens_confirm_message",
+      "value": "將移除所有發行者名稱以Test-開頭的令牌，是否繼續？"
+    },
+    {
+      "name": "toast_test_tokens_removed",
+      "value": "已移除%d個測試令牌"
+    },
+    {
+      "name": "toast_no_test_tokens",
+      "value": "沒有可移除的測試令牌"
     }
   ]
 }

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -181,6 +181,14 @@
       "value": "輸入備份檔案的密碼..."
     },
     {
+      "name": "dialog_backup_password_confirm_placeholder",
+      "value": "再次輸入備份密碼..."
+    },
+    {
+      "name": "dialog_backup_password_mismatch",
+      "value": "兩次輸入的密碼不一致"
+    },
+    {
       "name": "warn_forti_dev_id_popup",
       "value": "Forti只允許你啟用一次並綁定此裝置ID"
     },

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -1639,6 +1639,26 @@
     {
       "name": "card_config_no_token",
       "value": "暫無可用令牌"
+    },
+    {
+      "name": "setting_group_developer_options",
+      "value": "開發者選項"
+    },
+    {
+      "name": "developer_add_test_tokens",
+      "value": "新增100個測試令牌"
+    },
+    {
+      "name": "developer_add_test_tokens_description",
+      "value": "產生隨機名稱和密鑰，方便開發與偵錯。"
+    },
+    {
+      "name": "developer_add_test_tokens_confirm_title",
+      "value": "新增測試令牌？"
+    },
+    {
+      "name": "developer_add_test_tokens_confirm_message",
+      "value": "將新增100個名稱和密鑰均隨機的測試令牌，是否繼續？"
     }
   ]
 }

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -1129,6 +1129,18 @@
       "value": "光感材質"
     },
     {
+      "name": "setting_group_data_management",
+      "value": "資料管理"
+    },
+    {
+      "name": "setting_group_app_settings",
+      "value": "應用程式設定"
+    },
+    {
+      "name": "setting_group_support_about",
+      "value": "支援與關於"
+    },
+    {
       "name": "setting_token_item_material",
       "value": "清單項目材質"
     },

--- a/entry/src/main/ets/components/SubItemButton.ets
+++ b/entry/src/main/ets/components/SubItemButton.ets
@@ -71,6 +71,8 @@ export struct SubItemButton {
       .alignItems(VerticalAlign.Top)
       .justifyContent(FlexAlign.Start)
     }
+    // PC/2in1 光标悬浮时使用系统高亮反馈，满足大屏可交互控件 UX 要求
+    .hoverEffect(HoverEffect.Highlight)
     .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.95 })
     .padding(SETTING_ROW_PADDING)
     .constraintSize({ minHeight: SETTING_ROW_MIN_HEIGHT })

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -37,6 +37,7 @@ export struct TokenItem {
   @Local btn_hotp_clicked: number = 0;
   @Local TokenHide: boolean = current_token_hide_map[this.Config.TokenUUID] ?? true;
   @Local previewDetailsVisible: boolean = false;
+  @Local debugModeIsOn: boolean = AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON) as boolean;
 
   @Local menu_icon_trash: SymbolGlyphModifier = new SymbolGlyphModifier($r('sys.symbol.trash')).fontSize('22vp').fontColor([Color.Red]);
   @Local menu_icon_qrcode: SymbolGlyphModifier = new SymbolGlyphModifier($r('sys.symbol.qrcode')).fontSize('22vp');
@@ -50,6 +51,7 @@ export struct TokenItem {
 
   private token_steps: number = 0;
   private onTimestampChangedHandler: (timestamp: number, force: boolean) => void = () => {};
+  private onDebugModeChangedHandler: (isOn: boolean) => void = () => {};
   // 使用 AppStorage 获取 context，避免在 aboutToAppear（build 之前）调用 getUIContext()
   private appCtx: common.UIAbilityContext = AppStorage.get('appContext') as common.UIAbilityContext;
 
@@ -175,12 +177,17 @@ export struct TokenItem {
     this.appCtx.eventHub?.on(EVENT_NAMES.TIMESTAMP_CHANGED, this.onTimestampChangedHandler);
     this.onNfcExternalTokensChangedHandler = (): void => this.onNfcExternalTokensChanged();
     this.appCtx.eventHub?.on(EVENT_NAMES.NFC_EXTERNAL_TOKENS_CHANGED, this.onNfcExternalTokensChangedHandler);
+    this.onDebugModeChangedHandler = (isOn: boolean): void => {
+      this.debugModeIsOn = isOn;
+    };
+    this.appCtx.eventHub?.on(EVENT_NAMES.DEBUG_MODE_CHANGED, this.onDebugModeChangedHandler);
     this.updateToken();
   }
 
   aboutToDisappear(): void {
     this.appCtx.eventHub?.off(EVENT_NAMES.TIMESTAMP_CHANGED, this.onTimestampChangedHandler);
     this.appCtx.eventHub?.off(EVENT_NAMES.NFC_EXTERNAL_TOKENS_CHANGED, this.onNfcExternalTokensChangedHandler);
+    this.appCtx.eventHub?.off(EVENT_NAMES.DEBUG_MODE_CHANGED, this.onDebugModeChangedHandler);
   }
 
   private onLongPressMenuWillAppear(): void {
@@ -294,7 +301,7 @@ export struct TokenItem {
   @Builder
   TokenCodeBuilder() {
     Column() {
-      if (AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON)) {
+      if (this.debugModeIsOn) {
         Text(this.Config.RankScore.toString())
           .textAlign(TextAlign.Center)
           .textOverflow({ overflow: TextOverflow.MARQUEE })

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -36,7 +36,7 @@ export struct TokenItem {
   @Local TokenLeftPeriod: number = 0;
   @Local btn_hotp_clicked: number = 0;
   @Local TokenHide: boolean = current_token_hide_map[this.Config.TokenUUID] ?? true;
-  @Local isLongPressMenuShown: boolean = false;
+  @Local previewDetailsVisible: boolean = false;
 
   @Local menu_icon_trash: SymbolGlyphModifier = new SymbolGlyphModifier($r('sys.symbol.trash')).fontSize('22vp').fontColor([Color.Red]);
   @Local menu_icon_qrcode: SymbolGlyphModifier = new SymbolGlyphModifier($r('sys.symbol.qrcode')).fontSize('22vp');
@@ -45,6 +45,8 @@ export struct TokenItem {
   @Local menu_icon_sort: SymbolGlyphModifier = new SymbolGlyphModifier($r('sys.symbol.list_bullet')).fontSize('22vp');
 
   private dialog_qrcode?: CustomDialogController;
+  private isLongPressMenuActive: boolean = false;
+  private pendingSortNavigation: boolean = false;
 
   private token_steps: number = 0;
   private onTimestampChangedHandler: (timestamp: number, force: boolean) => void = () => {};
@@ -179,6 +181,62 @@ export struct TokenItem {
   aboutToDisappear(): void {
     this.appCtx.eventHub?.off(EVENT_NAMES.TIMESTAMP_CHANGED, this.onTimestampChangedHandler);
     this.appCtx.eventHub?.off(EVENT_NAMES.NFC_EXTERNAL_TOKENS_CHANGED, this.onNfcExternalTokensChangedHandler);
+  }
+
+  private onLongPressMenuWillAppear(): void {
+    this.isLongPressMenuActive = true;
+    this.pendingSortNavigation = false;
+    this.previewDetailsVisible = false;
+  }
+
+  private onLongPressMenuDidAppear(): void {
+    // 共享容器扩展完成后再淡入元数据，避免内容先于容器尺寸变化出现。
+    this.getUIContext().animateTo({ duration: 160, curve: Curve.EaseOut }, () => {
+      this.previewDetailsVisible = true;
+    });
+  }
+
+  private onLongPressMenuWillDisappear(): void {
+    this.getUIContext().animateTo({ duration: 100, curve: Curve.EaseIn }, () => {
+      this.previewDetailsVisible = false;
+    });
+  }
+
+  private requestTokenSort(): void {
+    // 右键菜单没有长按预览，保持原有的直接跳转行为。
+    if (!this.isLongPressMenuActive) {
+      this.appCtx.eventHub?.emit(EVENT_NAMES.START_TOKEN_SORT);
+      return;
+    }
+    this.pendingSortNavigation = true;
+    this.previewDetailsVisible = false;
+    // 主动关闭菜单，触发 CustomBuilder 预览到原组件截图的反向一镜到底动效。
+    this.getUIContext().getContextMenuController().close();
+  }
+
+  private onLongPressMenuDidDisappear(): void {
+    this.isLongPressMenuActive = false;
+    if (!this.pendingSortNavigation) {
+      return;
+    }
+    this.pendingSortNavigation = false;
+    this.appCtx.eventHub?.emit(EVENT_NAMES.START_TOKEN_SORT);
+  }
+
+  private tokenTypeName(): string {
+    if (this.Config.TokenType === otpType.HOTP) {
+      return 'HOTP';
+    }
+    if (this.Config.TokenType === otpType.Forti) {
+      return 'FortiToken';
+    }
+    if (this.Config.TokenType === otpType.Steam) {
+      return 'Steam';
+    }
+    if (this.Config.TokenType === otpType.NFC_external) {
+      return 'NFC OATH';
+    }
+    return 'TOTP';
   }
 
   onTimestampChanged(timestamp: number, force: boolean): void {
@@ -379,22 +437,24 @@ export struct TokenItem {
           current_token_hide_map[this.Config.TokenUUID] = true;
         }
       })
-      .gesture(
-        LongPressGesture({ duration: this.token_preference.app_appearance_long_press_duration })
-          .onAction(() => {
-            this.isLongPressMenuShown = true;
-          })
-      )
-      .bindContextMenu(this.isLongPressMenuShown, this.TokenRightCtxMenu, {
-        // 预览走 CustomBuilder 自绘实体卡片，而非 MenuPreviewMode.IMAGE 组件截图：
-        // 沉浸材质由 materialFilter 在合成时采样窗口背景实现，不属于组件自身像素，
-        // 截图对效果类属性官方明确"可能产生非用户预期的结果"（材质层丢失只剩透明
-        // 背景+图标文字）；实体模式下截图即为所见，仍用 IMAGE
-        preview: MaterialTheme.isTokenItemMaterialEffective() ? this.TokenMenuPreview : MenuPreviewMode.IMAGE,
+      .bindContextMenu(this.TokenRightCtxMenu, ResponseType.LongPress, {
+        // 官方 hoverScale 仅在 LongPress + CustomBuilder 预览中提供原组件截图到
+        // 扩展预览的一镜到底变形；isShown 方式只会直接展示目标尺寸。
+        preview: this.TokenMenuPreview,
+        previewAnimationOptions: { hoverScale: [1.0, 1.0] },
         previewBorderRadius: this.token_preference.app_appearance_item_radius,
         hapticFeedbackMode: HapticFeedbackMode.AUTO,
-        onDisappear: () => {
-          this.isLongPressMenuShown = false;
+        onWillAppear: () => {
+          this.onLongPressMenuWillAppear();
+        },
+        onDidAppear: () => {
+          this.onLongPressMenuDidAppear();
+        },
+        onWillDisappear: () => {
+          this.onLongPressMenuWillDisappear();
+        },
+        onDidDisappear: () => {
+          this.onLongPressMenuDidDisappear();
         }
       })
       .bindContextMenu(this.TokenRightCtxMenu, ResponseType.RightClick, { enableArrow: true })
@@ -437,22 +497,64 @@ export struct TokenItem {
       .padding({ left: $r('sys.float.ohos_id_text_overlay_menu_button_padding_left'), right: $r('sys.float.ohos_id_text_overlay_menu_button_padding_right') })
   }
 
+  @Builder
+  TokenPreviewMetadata(label: ResourceStr, value: string) {
+    Column({ space: 2 }) {
+      Text(label)
+        .fontSize(11)
+        .fontColor($r('sys.color.font_secondary'))
+        .maxLines(1)
+      Text(value)
+        .fontSize(14)
+        .fontWeight(FontWeight.Medium)
+        .fontColor($r('app.color.str_main'))
+        .maxLines(1)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
+    }
+    .layoutWeight(1)
+    .alignItems(HorizontalAlign.Start)
+  }
+
   /**
-   * 长按菜单的自定义预览（材质模式专用，替代 MenuPreviewMode.IMAGE 截图）。
-   * 自绘实体卡片：内容复用 TokenRowContent，背景用与 solid 档位一致的
-   * item_bg + 卡片圆角；材质列表项浮起后呈现实体卡是长按预览的标准观感。
-   * 预览可布局区域默认扣除左右各 16vp（layoutRegionMargin 默认值），
-   * width('100%') 与列表卡片视觉宽度基本一致。
+   * 长按菜单的扩展预览。卡片先随 ContextMenu 预览动效扩大，元数据随后淡入；
+   * 关闭菜单时系统反向缩回原位。统一自绘也避免沉浸材质截图丢失。
    * 必须 @LocalBuilder：preview 是 CustomBuilder 参数，普通 @Builder 以
-   * this.TokenMenuPreview 传入时 this 被重绑定，菜单弹出即崩
-   * （TypeError: observeComponentCreation2 of undefined，已真机踩坑）
+   * this.TokenMenuPreview 传入时 this 被重绑定，菜单弹出即崩。
    */
   @LocalBuilder
   TokenMenuPreview() {
     Column() {
       this.TokenRowContent(false)
+      Divider()
+        .color($r('sys.color.comp_divider'))
+        .strokeWidth(0.5)
+        .margin({ left: 16, right: 16 })
+      Column({ space: 10 }) {
+        Row({ space: 12 }) {
+          this.TokenPreviewMetadata($r('app.string.add_token_type'), this.tokenTypeName())
+          if (this.Config.TokenType !== otpType.NFC_external) {
+            this.TokenPreviewMetadata($r('app.string.dialog_cfg_tk_alg'), this.Config.TokenAlgorithm)
+          }
+        }
+        .width('100%')
+        if (this.Config.TokenType !== otpType.NFC_external) {
+          Row({ space: 12 }) {
+            this.TokenPreviewMetadata($r('app.string.dialog_cfg_tk_digits'), this.Config.TokenDigits.toString())
+            this.TokenPreviewMetadata(
+              this.Config.TokenType === otpType.HOTP ?
+                $r('app.string.dialog_cfg_tk_counter') : $r('app.string.dialog_cfg_tk_timeout'),
+              this.Config.TokenType === otpType.HOTP ?
+                this.Config.TokenCounter.toString() : `${this.Config.TokenPeriod}s`)
+          }
+          .width('100%')
+        }
+      }
+      .padding({ left: 16, right: 16, top: 10, bottom: 14 })
+      .opacity(this.previewDetailsVisible ? 1 : 0)
+      .translate({ y: this.previewDetailsVisible ? 0 : 8 })
     }
     .width('100%')
+    .clip(true)
     .borderRadius(this.token_preference.app_appearance_item_radius)
     .backgroundColor($r('app.color.item_bg'))
   }
@@ -464,9 +566,7 @@ export struct TokenItem {
       if (this.Config.TokenType !== otpType.NFC_external) {
         MenuItem({ symbolStartIcon: this.menu_icon_sort, content: $r('app.string.token_right_menu_sort') })
           .onClick(() => {
-            if (this.appCtx.eventHub != undefined) {
-              this.appCtx.eventHub.emit(EVENT_NAMES.START_TOKEN_SORT);
-            }
+            this.requestTokenSort();
           })
           .accessibilityText($r('app.string.token_right_menu_sort'))
       }

--- a/entry/src/main/ets/dialogs/EncryptionPassWordDialog.ets
+++ b/entry/src/main/ets/dialogs/EncryptionPassWordDialog.ets
@@ -8,11 +8,19 @@ export struct EncryptionPassWordDialog {
   private confirmTextValue: string = '';
   private inputValue: string = '';
   @State private passwordMismatch: boolean = false;
+  @State private passwordEmpty: boolean = false;
   controller?: CustomDialogController;
   cancel: () => void = () => {
   };
   confirm: (text: string) => void = (text: string) => {
   };
+
+  private resetInput(): void {
+    this.textValue = '';
+    this.confirmTextValue = '';
+    this.passwordMismatch = false;
+    this.passwordEmpty = false;
+  }
 
   build() {
     Column() {
@@ -35,6 +43,7 @@ export struct EncryptionPassWordDialog {
         .onChange((value: string) => {
           this.textValue = value
           this.passwordMismatch = false
+          this.passwordEmpty = false
         })
 
       if (this.showConfirmPassword) {
@@ -47,10 +56,12 @@ export struct EncryptionPassWordDialog {
           .maxLength(32)
           .type(InputType.Password)
           .showPasswordIcon(true)
-          .showError(this.passwordMismatch ? $r('app.string.dialog_backup_password_mismatch') : undefined)
+          .showError(this.passwordEmpty ? $r('app.string.dialog_backup_password_empty') :
+            this.passwordMismatch ? $r('app.string.dialog_backup_password_mismatch') : undefined)
           .onChange((value: string) => {
             this.confirmTextValue = value
             this.passwordMismatch = false
+            this.passwordEmpty = false
           })
       }
 
@@ -68,6 +79,7 @@ export struct EncryptionPassWordDialog {
           .onClick(() => {
             if (this.controller != undefined) {
               this.cancel()
+              this.resetInput()
               this.controller.close()
             }
           })
@@ -88,11 +100,16 @@ export struct EncryptionPassWordDialog {
           .fontWeight(FontWeight.Medium)
           .onClick(() => {
             if (this.controller != undefined) {
+              if (this.showConfirmPassword && this.textValue.length === 0) {
+                this.passwordEmpty = true
+                return
+              }
               if (this.showConfirmPassword && this.textValue !== this.confirmTextValue) {
                 this.passwordMismatch = true
                 return
               }
               this.inputValue = this.textValue
+              this.resetInput()
               this.confirm(this.inputValue)
               this.controller.close()
             }

--- a/entry/src/main/ets/dialogs/EncryptionPassWordDialog.ets
+++ b/entry/src/main/ets/dialogs/EncryptionPassWordDialog.ets
@@ -3,8 +3,11 @@
 @Component
 export struct EncryptionPassWordDialog {
   title: Resource = $r('app.string.dialog_backup_password');
+  showConfirmPassword: boolean = false;
   private textValue: string = '';
+  private confirmTextValue: string = '';
   private inputValue: string = '';
+  @State private passwordMismatch: boolean = false;
   controller?: CustomDialogController;
   cancel: () => void = () => {
   };
@@ -31,7 +34,25 @@ export struct EncryptionPassWordDialog {
         .showPasswordIcon(true)
         .onChange((value: string) => {
           this.textValue = value
+          this.passwordMismatch = false
         })
+
+      if (this.showConfirmPassword) {
+        TextInput({
+          placeholder: $r('app.string.dialog_backup_password_confirm_placeholder'),
+          text: this.confirmTextValue
+        })
+          .height(40)
+          .margin({ left: 24, right: 24, top: 12 })
+          .maxLength(32)
+          .type(InputType.Password)
+          .showPasswordIcon(true)
+          .showError(this.passwordMismatch ? $r('app.string.dialog_backup_password_mismatch') : undefined)
+          .onChange((value: string) => {
+            this.confirmTextValue = value
+            this.passwordMismatch = false
+          })
+      }
 
       // 按钮区：对齐系统 AlertDialog（40vp 胶囊文本按钮 + 竖分隔线，行内边距 16/8/16）
       Row() {
@@ -67,6 +88,10 @@ export struct EncryptionPassWordDialog {
           .fontWeight(FontWeight.Medium)
           .onClick(() => {
             if (this.controller != undefined) {
+              if (this.showConfirmPassword && this.textValue !== this.confirmTextValue) {
+                this.passwordMismatch = true
+                return
+              }
               this.inputValue = this.textValue
               this.confirm(this.inputValue)
               this.controller.close()

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -33,6 +33,29 @@ export default class EntryAbility extends UIAbility {
 
   private selectPage: string = '';
 
+  /**
+   * 统一所有设备的窗口与 ArkUI 页面背景色；PC/2in1/Tablet 额外统一系统标题栏容器。
+   * 不支持窗口容器配色能力的设备会返回 801，不影响已设置的窗口背景色。
+   */
+  private applyWindowColors(windowClass?: window.Window): void {
+    if (!windowClass) {
+      return;
+    }
+
+    try {
+      const colorValue = this.context.resourceManager.getColorByNameSync('window_background');
+      const color = `#${colorValue.toString(16).padStart(8, '0').toUpperCase()}`;
+      windowClass.setWindowBackgroundColor(color);
+      windowClass.setWindowContainerColor(color, color);
+    } catch (exception) {
+      const error = exception as BusinessError;
+      if (error.code !== 801) {
+        hilog.error(error.code, 'EntryAbility',
+          `Failed to set window colors. Cause code: ${error.code}, message: ${error.message}`);
+      }
+    }
+  }
+
   private handleCardAction(want: Want): void {
     hilog.info(0x0000, 'EntryAbility', `handleCardAction parameters: ${JSON.stringify(want?.parameters)}`);
 
@@ -158,6 +181,7 @@ export default class EntryAbility extends UIAbility {
 
         win.uiContext = this.uiContext;
         win.WindowClass = windowClass;
+        this.applyWindowColors(windowClass);
 
         windowClass.setWindowLayoutFullScreen(true)
 
@@ -211,6 +235,7 @@ export default class EntryAbility extends UIAbility {
   onConfigurationUpdate(newConfig: Configuration): void {
     let window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
     window.ColorMode = newConfig.colorMode ?? -1;
+    this.applyWindowColors(window.WindowClass);
   }
   onWindowStageDestroy(): void {
     // Main window is destroyed, release UI related resources

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -44,7 +44,7 @@ export default class EntryAbility extends UIAbility {
 
     try {
       const colorValue = this.context.resourceManager.getColorByNameSync('window_background');
-      const color = `#${colorValue.toString(16).padStart(8, '0').toUpperCase()}`;
+      const color = `#${(colorValue >>> 0).toString(16).padStart(8, '0').toUpperCase()}`;
       windowClass.setWindowBackgroundColor(color);
       windowClass.setWindowContainerColor(color, color);
     } catch (exception) {

--- a/entry/src/main/ets/pages/AddTotpTokenPage.ets
+++ b/entry/src/main/ets/pages/AddTotpTokenPage.ets
@@ -204,24 +204,25 @@ export struct AddTotpTokenPage {
             ListItem() {
               MaterialSurface({ radius: ADD_TOKEN_SECTION_RADIUS, applyShadow: true }) {
                 Column({ space: 16 }) {
-                  Column({ space: 8 }) {
+                  Row({ space: 12 }) {
                     Text($r('app.string.add_token_type'))
                       .fontSize(13).fontWeight(FontWeight.Medium).fontColor($r('sys.color.font_secondary'))
+                      .layoutWeight(1)
                     Select([
                       { value: 'TOTP' },
                       { value: 'HOTP' }
                     ])
                       .selected(this.tokenType === otpType.HOTP ? 1 : 0)
                       .value(this.tokenType === otpType.HOTP ? 'HOTP' : 'TOTP')
-                      .width('100%')
                       .onSelect((index: number) => this.tokenType = index === 1 ? otpType.HOTP : otpType.TOTP)
                   }
                   .width('100%')
-                  .alignItems(HorizontalAlign.Start)
+                  .alignItems(VerticalAlign.Center)
                   Divider().color($r('sys.color.comp_divider')).strokeWidth(0.5)
-                  Column({ space: 8 }) {
+                  Row({ space: 12 }) {
                     Text($r('app.string.dialog_cfg_tk_alg'))
                       .fontSize(13).fontWeight(FontWeight.Medium).fontColor($r('sys.color.font_secondary'))
+                      .layoutWeight(1)
                     Select([
                       { value: 'SHA1' },
                       { value: 'SHA224' },
@@ -233,15 +234,15 @@ export struct AddTotpTokenPage {
                     ])
                       .selected(this.algorithms.indexOf(this.algorithm))
                       .value(this.algorithm)
-                      .width('100%')
                       .onSelect((_: number, value: string) => this.algorithm = value as HMACAlgorithm)
                   }
                   .width('100%')
-                  .alignItems(HorizontalAlign.Start)
+                  .alignItems(VerticalAlign.Center)
                   Divider().color($r('sys.color.comp_divider')).strokeWidth(0.5)
-                  Column({ space: 8 }) {
+                  Row({ space: 12 }) {
                     Text($r('app.string.dialog_cfg_tk_digits'))
                       .fontSize(13).fontWeight(FontWeight.Medium).fontColor($r('sys.color.font_secondary'))
+                      .layoutWeight(1)
                     Select([
                       { value: '4' },
                       { value: '6' },
@@ -249,11 +250,10 @@ export struct AddTotpTokenPage {
                     ])
                       .selected(this.digits === 4 ? 0 : this.digits === 8 ? 2 : 1)
                       .value(this.digits.toString())
-                      .width('100%')
                       .onSelect((_: number, value: string) => this.digits = Number.parseInt(value))
                   }
                   .width('100%')
-                  .alignItems(HorizontalAlign.Start)
+                  .alignItems(VerticalAlign.Center)
                   Divider().color($r('sys.color.comp_divider')).strokeWidth(0.5)
                   if (this.tokenType === otpType.TOTP) {
                     Column({ space: 8 }) {

--- a/entry/src/main/ets/pages/AppearancePage.ets
+++ b/entry/src/main/ets/pages/AppearancePage.ets
@@ -177,13 +177,6 @@ export struct AppearancePage {
                   title: $r('app.string.token_item_function_slider'),
                   items: [
                     {
-                      name: $r('app.string.appearance_long_press_duration'),
-                      default: this.token_preference.app_appearance_long_press_duration,
-                      min: 200,
-                      max: 1000,
-                      step: 50
-                    },
-                    {
                       name: $r('app.string.token_item_color_change_threshold'),
                       default: this.token_preference.app_appearance_token_counter_next_margin,
                       min: 0,
@@ -193,18 +186,8 @@ export struct AppearancePage {
                   ],
                   description: $r('app.string.token_item_function_slider_desc'),
                   onChange: (index, value) => {
-                    switch (index) {
-                      case 0: {
-                        AppPreference.setPreference(PREF_KEYS.APPEARANCE_LONG_PRESS_DURATION, value);
-                        this.token_preference.app_appearance_long_press_duration = value;
-                        break;
-                      }
-                      case 1: {
-                        AppPreference.setPreference(PREF_KEYS.APPEARANCE_TOKEN_COUNTER_NEXT_MARGIN, value);
-                        this.token_preference.app_appearance_token_counter_next_margin = value;
-                        break;
-                      }
-                    }
+                    AppPreference.setPreference(PREF_KEYS.APPEARANCE_TOKEN_COUNTER_NEXT_MARGIN, value);
+                    this.token_preference.app_appearance_token_counter_next_margin = value;
                   }
                 })
               }

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -107,6 +107,7 @@ struct Index {
   @Local appCtx: common.UIAbilityContext = AppStorage.get('appContext') as common.UIAbilityContext;
   @Local tokenListScroller: Scroller = new Scroller();
   @Local settingEntryScroller: Scroller = new Scroller();
+  @Local currentHomeTabIndex: number = 0;
   @Local CurrentTokensCount: number = 0;
   @Local scrollEffectVersion: number = 0;
   @Local bottomTabsTypeVersion: number = 0;
@@ -785,15 +786,16 @@ struct Index {
     HomeTabs({
       tokens: this.CurrentTokens,
       window: this.window,
-      scrollEffectType: this.currentScrollEffectType,
       bottomTabsType: this.currentBottomTabsType,
+      currentTabIndex: this.currentHomeTabIndex,
       pageInfos: this.pageInfos,
       updateTokenConfig: (conf: TokenConfig, toast?: boolean) => this.updateTokenConfig(conf, toast),
       updateTokenConfigs: (tokens: Array<TokenConfig>) => this.updateTokenConfigs(tokens),
-      openAddTokenMenu: () => this.openAddTokenMenu(),
-      addTokenMenuTargetId: this.addTokenMenuTargetId,
       tokenListScroller: this.tokenListScroller,
       settingEntryScroller: this.settingEntryScroller,
+      onTabChange: (index: number) => {
+        this.currentHomeTabIndex = index;
+      },
       settingEntryContent: this.SettingEntryContentBuilder,
     })
   }
@@ -806,6 +808,11 @@ struct Index {
         blurFlag: this.background_blur_flag as boolean,
         applockVisible: this.isAppLockOverlayVisible,
         scrollEffectType: this.currentScrollEffectType,
+        currentHomeTabIndex: this.currentHomeTabIndex,
+        tokenListScroller: this.tokenListScroller,
+        settingEntryScroller: this.settingEntryScroller,
+        openAddTokenMenu: () => this.openAddTokenMenu(),
+        addTokenMenuTargetId: this.addTokenMenuTargetId,
         onDropFile: () => {
           this.DropFilesDialogIsOpen = false;
           this.DropFilesDialogController?.close();

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -784,6 +784,7 @@ struct Index {
       tokens: this.CurrentTokens,
       scrollEffectType: this.currentScrollEffectType,
       scroller: this.settingEntryScroller,
+      bottomAvoidHeight: this.window.AvoidBottomHeight,
       backupReload: async (conf) => {
         await this.updateTokenConfigs(conf);
         tkStore.sortTokens();

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -230,6 +230,8 @@ struct Index {
             this.updateTokenConfigs(backup.configs).then(() => {
               tkStore.sortTokens();
             });
+          }).catch((reason: BusinessError) => {
+            showSnackBar(reason.message, SnackBarNotifyType.ERROR);
           });
         }
         setTimeout(() => {
@@ -369,6 +371,8 @@ struct Index {
           this.updateTokenConfigs(backup.configs).then(() => {
             tkStore.sortTokens();
           });
+        }).catch((reason: BusinessError) => {
+          showSnackBar(reason.message, SnackBarNotifyType.ERROR);
         });
       },
     }),
@@ -572,6 +576,9 @@ struct Index {
   }
 
   private async addTestTokens(): Promise<boolean> {
+    if (!AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON)) {
+      return false;
+    }
     const tokens: TokenConfig[] = [];
     for (let i = 0; i < 100; i++) {
       const secret = base32Encode(util.generateRandomBinaryUUID()).substring(0, 26);
@@ -583,6 +590,32 @@ struct Index {
     hilog.info(0xFF00, 'DeveloperOptions',
       `Added ${tokens.length} test tokens, result=${success}, storeCount=${(await tkStore.getTokens()).length}`);
     return success;
+  }
+
+  private async removeTestTokens(): Promise<boolean> {
+    if (!AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON)) {
+      return false;
+    }
+    const testTokens = (await tkStore.getTokens()).filter(token => token.TokenIssuer.startsWith('Test-'));
+    if (testTokens.length === 0) {
+      showSnackBar($r('app.string.toast_no_test_tokens'), SnackBarNotifyType.INFO);
+      return true;
+    }
+
+    let failCount = 0;
+    for (const token of testTokens) {
+      try {
+        await tkStore.deleteToken(token.TokenUUID);
+      } catch (error) {
+        failCount++;
+        hilog.error(0, 'DeveloperOptions', `Failed to remove test token: ${error}`);
+      }
+    }
+    await this.refreshDisplayTokens();
+    const removedCount = testTokens.length - failCount;
+    showSnackBar($r('app.string.toast_test_tokens_removed', removedCount),
+      failCount === 0 ? SnackBarNotifyType.SUCCESS : SnackBarNotifyType.WARNING);
+    return failCount === 0;
   }
 
   async updateTokenConfigs(tokens: Array<TokenConfig>): Promise<boolean> {
@@ -789,7 +822,8 @@ struct Index {
         await this.updateTokenConfigs(conf);
         tkStore.sortTokens();
       },
-      addTestTokens: () => this.addTestTokens()
+      addTestTokens: () => this.addTestTokens(),
+      removeTestTokens: () => this.removeTestTokens()
     })
   }
 

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -1,5 +1,5 @@
 import { bundleManager,common } from '@kit.AbilityKit';
-import { TokenConfig, dialogSystemMaterial } from 'common';
+import { base32Encode, otpType, TokenConfig, dialogSystemMaterial } from 'common';
 import { util, url } from '@kit.ArkTS';
 // [冷启动优化] 文件 I/O 仅在 deferredInit 中使用
 import lazy { fileIo as fs } from '@kit.CoreFileKit';
@@ -571,6 +571,20 @@ struct Index {
     }
   }
 
+  private async addTestTokens(): Promise<boolean> {
+    const tokens: TokenConfig[] = [];
+    for (let i = 0; i < 100; i++) {
+      const secret = base32Encode(util.generateRandomBinaryUUID()).substring(0, 26);
+      const issuer = `Test-${util.generateRandomUUID().substring(0, 8)}`;
+      const name = `User-${util.generateRandomUUID().substring(0, 8)}`;
+      tokens.push(new TokenConfig(secret, otpType.TOTP, issuer, name));
+    }
+    const success = await this.updateTokenConfigs(tokens);
+    hilog.info(0xFF00, 'DeveloperOptions',
+      `Added ${tokens.length} test tokens, result=${success}, storeCount=${(await tkStore.getTokens()).length}`);
+    return success;
+  }
+
   async updateTokenConfigs(tokens: Array<TokenConfig>): Promise<boolean> {
     let failCount = 0;
     let hasNew = false;
@@ -773,15 +787,16 @@ struct Index {
       backupReload: async (conf) => {
         await this.updateTokenConfigs(conf);
         tkStore.sortTokens();
-      }
+      },
+      addTestTokens: () => this.addTestTokens()
     })
   }
 
   /**
-   * 首页内容(Task 3.1):断点 lanes + 双页签,由 HomeTabs 承载
-   * [@LocalBuilder] 作为 @BuilderParam 传给 AppShell 时保持 this 指向 Index
+   * 首页内容(Task 3.1):断点 lanes + 双页签,由 HomeTabs 承载。
+   * 通过箭头函数传给 AppShell，使 @Builder 保持 Index 的 this 与状态刷新能力。
    */
-  @LocalBuilder
+  @Builder
   HomeContentBuilder() {
     HomeTabs({
       tokens: this.CurrentTokens,
@@ -829,7 +844,9 @@ struct Index {
         },
         saveToken: (conf: TokenConfig) => this.updateTokenConfig(conf, true),
         appLockContent: this.AppLockOverlayBuilder,
-        homeContent: this.HomeContentBuilder,
+        homeContent: () => {
+          this.HomeContentBuilder();
+        },
       })
     }
   }

--- a/entry/src/main/ets/pages/TokenListPage.ets
+++ b/entry/src/main/ets/pages/TokenListPage.ets
@@ -140,10 +140,10 @@ export struct TokenListPage {
         .scrollBar(BarState.Off)
         .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
         .clip(false)
-        // 官方建议 cachedCount=n/2（n=一屏列表项数，手机约10.5），取 5；
-        // 配合 clip(false)+show=true，令牌项滚入标题栏渐变模糊区时不提前回收。
-        // 计量单位是行：多列（lanes）设备行高不变，无需按设备调整。
-        .cachedCount(5, true)
+        // 至少缓存 5 行，UI 空闲时扩展到 10 行；配合 clip(false)+show=true，
+        // 避免令牌项滚入标题栏渐变模糊区时尚未创建或未参与绘制。
+        // 计量单位是行：多列（lanes）设备行高不变。
+        .cachedCount({ minCount: 5, maxCount: 10 }, true)
       }
       .alignItems(HorizontalAlign.Center)
     }

--- a/entry/src/main/ets/pages/TokenSearchPage.ets
+++ b/entry/src/main/ets/pages/TokenSearchPage.ets
@@ -188,10 +188,10 @@ export struct TokenSearchPage {
           }, (vm: TokenConfigVM) => vm.objid)
         }
         .clip(false)
-        // 官方建议 cachedCount=n/2（n=一屏列表项数，手机约10.5），取 5；
-        // 配合 clip(false)+show=true，令牌项滚入标题栏渐变模糊区时不提前回收。
-        // 计量单位是行：多列（lanes）设备行高不变，无需按设备调整。
-        .cachedCount(5, true)
+        // 至少缓存 5 行，UI 空闲时扩展到 10 行；配合 clip(false)+show=true，
+        // 避免令牌项滚入标题栏渐变模糊区时尚未创建或未参与绘制。
+        // 计量单位是行：多列（lanes）设备行高不变。
+        .cachedCount({ minCount: 5, maxCount: 10 }, true)
         .alignListItem(ListItemAlign.Center)
         .lanes({ minLength: 400, maxLength: this.token_preference.app_appearance_item_max_width })
         .layoutWeight(1)

--- a/entry/src/main/ets/pages/setting/AboutSheet.ets
+++ b/entry/src/main/ets/pages/setting/AboutSheet.ets
@@ -48,6 +48,7 @@ struct AboutInfoRow {
 @ComponentV2
 export struct AboutSheet {
   @Require @Param scrollEffectStyle: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
+  @Event debugModeChanged: (isOn: boolean) => void = () => {};
   @Local debug_mode_is_on: boolean = AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON) as boolean;
   @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
   private sheetScroller: Scroller = new Scroller();
@@ -117,7 +118,8 @@ export struct AboutSheet {
                     if (this.debug_mode_counter > 7) {
                       this.window.uiContext?.animateTo({ curve: curves.springMotion() }, () => {
                         this.debug_mode_is_on = true;
-                        AppPreference.setPreference('app_debug_mode_on', true);
+                        AppPreference.setPreference(PREF_KEYS.DEBUG_MODE_ON, true);
+                        this.debugModeChanged(true);
                         showSnackBar('DEBUG MODE ON', SnackBarNotifyType.INFO);
                       })
 

--- a/entry/src/main/ets/pages/setting/AppearanceSheet.ets
+++ b/entry/src/main/ets/pages/setting/AppearanceSheet.ets
@@ -3,7 +3,7 @@ import { MaterialPolicy } from '../../utils/MaterialPolicy';
 
 import { showSnackBar, SnackBarNotifyType } from 'common';
 import { SubItemToggle } from '../../components/SubItemToggle'
-import { AppStorageV2, curves } from '@kit.ArkUI';
+import { AppStorageV2 } from '@kit.ArkUI';
 import { AppPreference, SettingColorMode, SettingTopEffectType, SettingBottomTabsType, TokenPreference, MaterialPreference, AVAILABLE_TOP_EFFECT_TYPES, AVAILABLE_BOTTOM_TABS_TYPES, AVAILABLE_MATERIAL_MODES, AVAILABLE_IMMERSIVE_STYLES, AVAILABLE_TOKEN_ITEM_MATERIALS, AVAILABLE_LIGHT_EFFECT_MODES, SettingMaterialMode, SettingImmersiveStyle, SettingTokenItemMaterial, SettingLightEffectMode, EVENT_NAMES, PREF_KEYS, ROUTE_NAMES } from 'common';
 import { SubItemButton } from '../../components/SubItemButton';
 import { SettingItem } from '../../components/SettingItem';
@@ -24,7 +24,6 @@ import { MaterialTheme } from '../../components/MaterialTheme';
 export struct AppearanceSheet {
   pageInfos: NavPathStack = new NavPathStack();
   @Require @Param scrollEffectType: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
-  @Local debug_mode_is_on: boolean = AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON) as boolean;
   @Local token_preference: TokenPreference = AppStorageV2.connect(TokenPreference) as TokenPreference;
   @Local material_preference: MaterialPreference = AppStorageV2.connect(MaterialPreference) as MaterialPreference;
   @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
@@ -105,22 +104,6 @@ export struct AppearanceSheet {
                   }
                 })
 
-                if (this.debug_mode_is_on) {
-                  SubItemDivider()
-
-                  SubItemToggle({
-                    icon: $r('sys.symbol.gearshape'),
-                    title: $r('app.string.debug_mode'),
-                    isOn: AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON) as boolean,
-                    description: $r('app.string.debug_mode_des'),
-                    onChange: (IsOn: boolean) => {
-                      this.window.uiContext?.animateTo({ curve: curves.springMotion() }, () => {
-                        this.debug_mode_is_on = IsOn;
-                      })
-                      AppPreference.setPreference(PREF_KEYS.DEBUG_MODE_ON, IsOn);
-                    }
-                  })
-                }
               }
             }
             .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })

--- a/entry/src/main/ets/pages/setting/BackupAndMigrationSheet.ets
+++ b/entry/src/main/ets/pages/setting/BackupAndMigrationSheet.ets
@@ -112,6 +112,8 @@ export struct BackupAndMigrationSheet {
       confirm: (password: string) => {
         restoreFromBackup(this.backup_select_uri, true, password).then((backup) => {
           this.backupReload(backup.configs);
+        }).catch((reason: BusinessError) => {
+          showSnackBar(reason.message, SnackBarNotifyType.ERROR);
         });
       },
     }),
@@ -260,7 +262,9 @@ export struct BackupAndMigrationSheet {
       } else {
         restoreFromBackup(uris[0]).then((backup) => {
           this.backupReload(backup.configs);
-        })
+        }).catch((reason: BusinessError) => {
+          showSnackBar(reason.message, SnackBarNotifyType.ERROR);
+        });
       }
     });
   }

--- a/entry/src/main/ets/pages/setting/BackupAndMigrationSheet.ets
+++ b/entry/src/main/ets/pages/setting/BackupAndMigrationSheet.ets
@@ -64,6 +64,7 @@ export struct BackupAndMigrationSheet {
     systemMaterial: dialogSystemMaterial(),
     builder: EncryptionPassWordDialog({
       title: $r('app.string.dialog_backup_password_set'),
+      showConfirmPassword: true,
       cancel: () => {},
       confirm: (password: string) => {
         // NFC 外部令牌仅会话存在、不持久化，导出前统一过滤（不含空 secret 伪 TOTP）

--- a/entry/src/main/ets/pages/setting/DeveloperOptionsSheet.ets
+++ b/entry/src/main/ets/pages/setting/DeveloperOptionsSheet.ets
@@ -1,0 +1,106 @@
+import { AppStorageV2 } from '@kit.ArkUI';
+import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
+import { AppWindowInfo } from 'common';
+import { MaterialPolicy } from '../../utils/MaterialPolicy';
+import { MaterialTheme } from '../../components/MaterialTheme';
+import { SettingItem } from '../../components/SettingItem';
+import { SubItemButton } from '../../components/SubItemButton';
+import { SETTING_PAGE_INSET } from '../../components/SettingStyle';
+
+@ComponentV2
+export struct DeveloperOptionsSheet {
+  @Require @Param scrollEffectType: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
+  @Event addTestTokens: () => Promise<boolean> = async () => false;
+  @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
+
+  private sheetScroller: Scroller = new Scroller();
+
+  private showAddTestTokensConfirmDialog(): void {
+    this.getUIContext().showAlertDialog({
+      title: $r('app.string.developer_add_test_tokens_confirm_title'),
+      message: $r('app.string.developer_add_test_tokens_confirm_message'),
+      autoCancel: true,
+      alignment: DialogAlignment.Center,
+      gridCount: 4,
+      buttonDirection: DialogButtonDirection.HORIZONTAL,
+      buttons: [
+        {
+          value: $r('app.string.dialog_btn_confirm'),
+          action: () => {
+            this.addTestTokens();
+          }
+        },
+        {
+          value: $r('app.string.dialog_btn_cancel'),
+          action: () => {}
+        },
+      ],
+      cancel: () => {},
+    });
+  }
+
+  build() {
+    Column() {
+      HdsNavigation() {
+        List({ scroller: this.sheetScroller, space: 10 }) {
+          ListItem() {
+            SettingItem({ title: '' }) {
+              SubItemButton({
+                symbol: $r('sys.symbol.plus_circle'),
+                text: $r('app.string.developer_add_test_tokens'),
+                description: $r('app.string.developer_add_test_tokens_description')
+              })
+                .onClick(() => {
+                  this.showAddTestTokensConfirmDialog();
+                })
+            }
+          }
+          .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
+        }
+        .clip(false)
+        .width('100%')
+        .height('100%')
+        .scrollBar(BarState.Off)
+        .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
+        .contentEndOffset(this.window.AvoidBottomHeight)
+        .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.window_background')))
+        .layoutWeight(1)
+      }
+      .mode(NavigationMode.Stack)
+      .bindToScrollable([this.sheetScroller])
+      .titleMode(HdsNavigationTitleMode.MODAL)
+      .titleBar({
+        enableComponentSafeArea: true,
+        style: {
+          originalStyle: {
+            contentStyle: {
+              titleStyle: {
+                mainTitleColor: $r('sys.color.font_primary'),
+                subTitleColor: $r('sys.color.font_secondary')
+              },
+              backIconStyle: {
+                iconColor: $r('sys.color.icon_primary')
+              }
+            },
+          },
+          scrollEffectOpts: {
+            enableScrollEffect: true,
+            scrollEffectType: this.scrollEffectType
+          },
+          systemMaterialEffect: {
+            materialType: hdsMaterial.MaterialType.ADAPTIVE,
+            materialLevel: MaterialPolicy.getInstance().getHdsAdaptiveMaterialLevel()
+          }
+        },
+        content: {
+          title: {
+            mainTitle: $r('app.string.setting_group_developer_options'),
+          },
+        }
+      })
+    }
+    .width('100%')
+    .height('100%')
+    .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.window_background')))
+  }
+}

--- a/entry/src/main/ets/pages/setting/DeveloperOptionsSheet.ets
+++ b/entry/src/main/ets/pages/setting/DeveloperOptionsSheet.ets
@@ -1,16 +1,21 @@
 import { AppStorageV2 } from '@kit.ArkUI';
+import { BusinessError } from '@kit.BasicServicesKit';
 import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
-import { AppWindowInfo } from 'common';
+import { AppPreference, AppWindowInfo, PREF_KEYS, showSnackBar, SnackBarNotifyType } from 'common';
 import { MaterialPolicy } from '../../utils/MaterialPolicy';
 import { MaterialTheme } from '../../components/MaterialTheme';
 import { SettingItem } from '../../components/SettingItem';
 import { SubItemButton } from '../../components/SubItemButton';
+import { SubItemDivider } from '../../components/SubItemDivider';
+import { SubItemToggle } from '../../components/SubItemToggle';
 import { SETTING_PAGE_INSET } from '../../components/SettingStyle';
 
 @ComponentV2
 export struct DeveloperOptionsSheet {
   @Require @Param scrollEffectType: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
+  @Event debugModeChanged: (isOn: boolean) => void = () => {};
   @Event addTestTokens: () => Promise<boolean> = async () => false;
+  @Event removeTestTokens: () => Promise<boolean> = async () => false;
   @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
 
   private sheetScroller: Scroller = new Scroller();
@@ -27,7 +32,35 @@ export struct DeveloperOptionsSheet {
         {
           value: $r('app.string.dialog_btn_confirm'),
           action: () => {
-            this.addTestTokens();
+            this.addTestTokens().catch((reason: BusinessError) => {
+              showSnackBar(reason.message, SnackBarNotifyType.ERROR);
+            });
+          }
+        },
+        {
+          value: $r('app.string.dialog_btn_cancel'),
+          action: () => {}
+        },
+      ],
+      cancel: () => {},
+    });
+  }
+
+  private showRemoveTestTokensConfirmDialog(): void {
+    this.getUIContext().showAlertDialog({
+      title: $r('app.string.developer_remove_test_tokens_confirm_title'),
+      message: $r('app.string.developer_remove_test_tokens_confirm_message'),
+      autoCancel: true,
+      alignment: DialogAlignment.Center,
+      gridCount: 4,
+      buttonDirection: DialogButtonDirection.HORIZONTAL,
+      buttons: [
+        {
+          value: $r('app.string.dialog_btn_confirm'),
+          action: () => {
+            this.removeTestTokens().catch((reason: BusinessError) => {
+              showSnackBar(reason.message, SnackBarNotifyType.ERROR);
+            });
           }
         },
         {
@@ -44,7 +77,23 @@ export struct DeveloperOptionsSheet {
       HdsNavigation() {
         List({ scroller: this.sheetScroller, space: 10 }) {
           ListItem() {
-            SettingItem({ title: '' }) {
+            SettingItem({ title: $r('app.string.setting_group_general') }) {
+              SubItemToggle({
+                icon: $r('sys.symbol.gearshape'),
+                title: $r('app.string.debug_mode'),
+                isOn: AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON) as boolean,
+                description: $r('app.string.debug_mode_des'),
+                onChange: (isOn: boolean) => {
+                  AppPreference.setPreference(PREF_KEYS.DEBUG_MODE_ON, isOn);
+                  this.debugModeChanged(isOn);
+                }
+              })
+            }
+          }
+          .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
+
+          ListItem() {
+            SettingItem({ title: $r('app.string.setting_group_token_operations') }) {
               SubItemButton({
                 symbol: $r('sys.symbol.plus_circle'),
                 text: $r('app.string.developer_add_test_tokens'),
@@ -52,6 +101,17 @@ export struct DeveloperOptionsSheet {
               })
                 .onClick(() => {
                   this.showAddTestTokensConfirmDialog();
+                })
+
+              SubItemDivider()
+
+              SubItemButton({
+                symbol: $r('sys.symbol.trash'),
+                text: $r('app.string.developer_remove_test_tokens'),
+                description: $r('app.string.developer_remove_test_tokens_description')
+              })
+                .onClick(() => {
+                  this.showRemoveTestTokensConfirmDialog();
                 })
             }
           }

--- a/entry/src/main/ets/shell/AppShell.ets
+++ b/entry/src/main/ets/shell/AppShell.ets
@@ -175,7 +175,7 @@ export struct AppShell {
       content: {
         title: {
           mainTitle: this.currentHomeTabIndex === 0 ?
-            $r('app.string.EntryAbility_label') : $r('app.string.tab_me'),
+            $r('app.string.tab_token') : $r('app.string.tab_me'),
         },
         menu: {
           value: this.currentHomeTabIndex === 0 ? [

--- a/entry/src/main/ets/shell/AppShell.ets
+++ b/entry/src/main/ets/shell/AppShell.ets
@@ -1,6 +1,7 @@
 import { uniformTypeDescriptor } from '@kit.ArkData';
-import { HdsNavigation, ScrollEffectType } from '@kit.UIDesignKit';
+import { HdsNavigation, HdsNavigationTitleMode, ScrollEffectType, hdsMaterial } from '@kit.UIDesignKit';
 import { ROUTE_NAMES } from 'common';
+import { MaterialPolicy } from '../utils/MaterialPolicy';
 // [冷启动优化] 以下 NavDestination 页面仅在用户导航时触发评估
 import lazy { TokenCardConfigPage } from '../pages/TokenCardConfigPage'
 import lazy { TokenSortPage } from '../pages/TokenSortPage'
@@ -38,8 +39,13 @@ export struct AppShell {
   @Require @Param blurFlag: boolean = false;
   /** 应用锁覆盖层是否可见(单向即可,关闭由覆盖层 onUnlock 回调驱动) */
   @Require @Param applockVisible: boolean = false;
-  /** 顶部滚动效果类型(传递给各 NavDestination 页面) */
+  /** 顶部滚动效果类型(传递给各 NavDestination 页面并配置主页标题栏) */
   @Require @Param scrollEffectType: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
+  @Require @Param currentHomeTabIndex: number = 0;
+  @Require @Param tokenListScroller: Scroller = new Scroller();
+  @Require @Param settingEntryScroller: Scroller = new Scroller();
+  @Require @Param openAddTokenMenu: () => void = () => {};
+  @Require @Param addTokenMenuTargetId: string = '';
   /** 文件拖放回调(由 Index 提供,控制 DropFilesDialog) */
   @Require @Param onDropFile: () => void = () => {};
   @Require @Param onDragEnterFile: () => void = () => {};
@@ -118,6 +124,7 @@ export struct AppShell {
       }
       .width('100%')
       .height('100%')
+      .clip(false)
       .allowDrop([uniformTypeDescriptor.UniformDataType.FILE])
       .onDrop(() => {
         this.onDropFile();
@@ -133,9 +140,70 @@ export struct AppShell {
         adaptiveColor: AdaptiveColor.DEFAULT
       })
     }
-    .hideTitleBar(true)
+    .backgroundColor($r('app.color.window_background'))
+    .hideTitleBar(this.isLoading)
     .mode(NavigationMode.Stack)
     .navDestination(this.navDestinationBuilder)
+    .bindToScrollable([
+      this.currentHomeTabIndex === 0 ? this.tokenListScroller : this.settingEntryScroller
+    ])
+    .titleMode(HdsNavigationTitleMode.MINI)
+    .hideBackButton(true)
+    .titleBar({
+      avoidLayoutSafeArea: true,
+      enableComponentSafeArea: true,
+      style: {
+        originalStyle: {
+          contentStyle: {
+            titleStyle: {
+              mainTitleColor: $r('sys.color.font_primary'),
+            },
+            menuStyle: {
+              iconColor: $r('sys.color.icon_primary')
+            },
+          }
+        },
+        scrollEffectOpts: {
+          enableScrollEffect: true,
+          scrollEffectType: this.scrollEffectType
+        },
+        systemMaterialEffect: {
+          materialType: hdsMaterial.MaterialType.ADAPTIVE,
+          materialLevel: MaterialPolicy.getInstance().getHdsAdaptiveMaterialLevel()
+        }
+      },
+      content: {
+        title: {
+          mainTitle: this.currentHomeTabIndex === 0 ?
+            $r('app.string.EntryAbility_label') : $r('app.string.tab_me'),
+        },
+        menu: {
+          value: this.currentHomeTabIndex === 0 ? [
+            {
+              content: {
+                label: $r('app.string.app_ua_search_token'),
+                icon: $r('sys.symbol.magnifyingglass'),
+                isEnabled: true,
+                action: () => {
+                  this.pageInfos.pushPathByName(ROUTE_NAMES.TokenSearchPage, null);
+                }
+              }
+            },
+            {
+              content: {
+                label: $r('app.string.app_ua_add_token'),
+                icon: $r('sys.symbol.plus'),
+                isEnabled: true,
+                componentId: this.addTokenMenuTargetId,
+                action: () => {
+                  this.openAddTokenMenu();
+                }
+              }
+            }
+          ] : []
+        }
+      }
+    })
     .bindContentCover(this.applockVisible, this.appLockContent ? this.appLockContent() : null, {
       modalTransition: ModalTransition.NONE,
       onWillDismiss: (dismissContentCoverAction: DismissContentCoverAction) => {

--- a/entry/src/main/ets/shell/HomeTabs.ets
+++ b/entry/src/main/ets/shell/HomeTabs.ets
@@ -4,9 +4,8 @@ import { MaterialPolicy } from '../utils/MaterialPolicy';
 import { TokenListPage } from '../pages/TokenListPage';
 import { AppWindowInfo } from 'common';
 import { PageScaffold } from '../components/PageScaffold';
-import { ROUTE_NAMES } from 'common';
 import { SymbolGlyphModifier } from '@kit.ArkUI';
-import { HdsNavigation, HdsNavigationTitleMode, HdsTabs, ScrollEffectType, hdsMaterial } from '@kit.UIDesignKit';
+import { HdsTabs, hdsMaterial } from '@kit.UIDesignKit';
 
 @Builder
 function EmptyBuilder() {
@@ -24,20 +23,18 @@ function EmptyBuilder() {
 export struct HomeTabs {
   @Require @Param tokens: TokenConfig[] = [];
   @Require @Param window: AppWindowInfo = new AppWindowInfo();
-  @Require @Param scrollEffectType: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
   /** 底部页签类型（悬浮/平铺），由 Index 监听 BOTTOM_TABS_TYPE_CHANGED 事件驱动更新 */
   @Require @Param bottomTabsType: SettingBottomTabsType = SettingBottomTabsType.SUSPENSION;
+  @Require @Param currentTabIndex: number = 0;
   @Require @Param pageInfos: NavPathStack = new NavPathStack();
   @Require @Param updateTokenConfig: (conf: TokenConfig, toast?: boolean) => Promise<boolean> =
     async (conf: TokenConfig, toast?: boolean) => false;
   @Require @Param updateTokenConfigs: (tokens: Array<TokenConfig>) => Promise<boolean> =
     async (tokens: Array<TokenConfig>) => false;
-  @Require @Param openAddTokenMenu: () => void = () => {};
-  @Require @Param addTokenMenuTargetId: string = '';
   @Require @Param tokenListScroller: Scroller = new Scroller();
   @Require @Param settingEntryScroller: Scroller = new Scroller();
+  @Event onTabChange: (index: number) => void = () => {};
 
-  @Local tab_bar_index: number = 0;
   // [冷启动优化] Setting Tab 懒加载标志,仅在用户首次切换到"我的"Tab 时构建组件树
   @Local settingTabInitialized: boolean = false;
 
@@ -64,80 +61,21 @@ export struct HomeTabs {
       }
     } else {
       Column() {
-        HdsTabs({ index: this.tab_bar_index }) {
+        HdsTabs({ index: this.currentTabIndex }) {
           TabContent() {
-            HdsNavigation() {
-              TokenListPage({
-                Tokens: this.tokens,
-                TabBarVisible: true,
-                appBottomAvoidHeight: this.window.AvoidBottomHeight,
-                appTopAvoidHeight: this.window.AvoidTopHeight,
-                appWindowSize: this.window.Size,
-                pageInfos: this.pageInfos,
-                updateTokenConfig: this.updateTokenConfig,
-                updateTokenConfigs: this.updateTokenConfigs,
-                listScroller: this.tokenListScroller,
-              })
-            }
-            .mode(NavigationMode.Stack)
-            .bindToScrollable([this.tokenListScroller])
-            .titleMode(HdsNavigationTitleMode.MINI)
-            .hideBackButton(true) // 设置mini类型隐藏后退按钮
-            .titleBar({
-              avoidLayoutSafeArea: true, // 状态栏安全区沉浸
-              enableComponentSafeArea: true,
-              style: {
-                originalStyle: {
-                  contentStyle: {
-                    titleStyle: {
-                      mainTitleColor: $r('sys.color.font_primary'),
-                    },
-                    menuStyle: {
-                      iconColor: $r('sys.color.icon_primary')
-                    },
-                  }
-                },
-                scrollEffectOpts: {
-                  enableScrollEffect: true,
-                  scrollEffectType: this.scrollEffectType // 渐变模糊
-                },
-                systemMaterialEffect: {
-                  materialType: hdsMaterial.MaterialType.ADAPTIVE,
-                  materialLevel: MaterialPolicy.getInstance().getHdsAdaptiveMaterialLevel()
-                }
-              },
-              content: {
-                title: {
-                  mainTitle: $r('app.string.EntryAbility_label'),
-                },
-                menu: {
-                  value: [
-                    {
-                      content: {
-                        label: $r('app.string.app_ua_search_token'),
-                        icon: $r('sys.symbol.magnifyingglass'),
-                        isEnabled: true,
-                        action: () => {
-                          this.pageInfos.pushPathByName(ROUTE_NAMES.TokenSearchPage, null);
-                        }
-                      }
-                    },
-                    {
-                      content: {
-                        label: $r('app.string.app_ua_add_token'),
-                        icon: $r('sys.symbol.plus'),
-                        isEnabled: true,
-                        componentId: this.addTokenMenuTargetId,
-                        action: () => {
-                          this.openAddTokenMenu();
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
+            TokenListPage({
+              Tokens: this.tokens,
+              TabBarVisible: true,
+              appBottomAvoidHeight: this.window.AvoidBottomHeight,
+              appTopAvoidHeight: this.window.AvoidTopHeight,
+              appWindowSize: this.window.Size,
+              pageInfos: this.pageInfos,
+              updateTokenConfig: this.updateTokenConfig,
+              updateTokenConfigs: this.updateTokenConfigs,
+              listScroller: this.tokenListScroller,
             })
           }
+          .clip(false)
           .backgroundColor($r('app.color.window_background'))
           .tabBar(BottomTabBarStyle.of(
             {
@@ -159,50 +97,11 @@ export struct HomeTabs {
           TabContent() {
             // [冷启动优化] Setting Tab 懒加载:仅在用户首次切换到"我的"Tab 时构建组件树,
             // 避免冷启动时一次性构建两个 TabContent 导致首帧 build 耗时增加
-            if (this.settingTabInitialized) {
-              HdsNavigation() {
-                if (this.settingEntryContent) {
-                  this.settingEntryContent();
-                }
-              }
-              .mode(NavigationMode.Stack)
-              .bindToScrollable([this.settingEntryScroller])
-              .titleMode(HdsNavigationTitleMode.MINI)
-              .hideBackButton(true)
-              .titleBar({
-                avoidLayoutSafeArea: true,
-                enableComponentSafeArea: true,
-                style: {
-                  originalStyle: {
-                    contentStyle: {
-                      titleStyle: {
-                        mainTitleColor: $r('sys.color.font_primary'),
-                      },
-                      menuStyle: {
-                        iconColor: $r('sys.color.icon_primary')
-                      },
-                    }
-                  },
-                  scrollEffectOpts: {
-                    enableScrollEffect: true,
-                    scrollEffectType: this.scrollEffectType,
-                  },
-                  systemMaterialEffect: {
-                    materialType: hdsMaterial.MaterialType.ADAPTIVE,
-                    materialLevel: MaterialPolicy.getInstance().getHdsAdaptiveMaterialLevel()
-                  }
-                },
-                content: {
-                  title: {
-                    mainTitle: $r('app.string.tab_me')
-                  },
-                  menu: {
-                    value: []
-                  }
-                }
-              })
+            if (this.settingTabInitialized && this.settingEntryContent) {
+              this.settingEntryContent();
             }
           }
+          .clip(false)
           .backgroundColor($r('app.color.window_background'))
           .tabBar(BottomTabBarStyle.of(
             {
@@ -221,6 +120,7 @@ export struct HomeTabs {
           )
           .tabIndex(1)
         }
+        .clip(false)
         .barBackgroundColor($r('app.color.tab_bar_bg'))
         .backgroundColor($r('app.color.window_background'))
         .layoutWeight(1)
@@ -248,7 +148,7 @@ export struct HomeTabs {
         .barMode(BarMode.Fixed)
         .animationDuration(300)
         .onChange((index) => {
-          this.tab_bar_index = index;
+          this.onTabChange(index);
           // [冷启动优化] 用户首次切换到 Setting Tab 时触发懒加载构建
           if (index === 1 && !this.settingTabInitialized) {
             this.settingTabInitialized = true;

--- a/entry/src/main/ets/shell/SheetCoordinator.ets
+++ b/entry/src/main/ets/shell/SheetCoordinator.ets
@@ -39,6 +39,8 @@ export struct SheetCoordinator {
   @Require @Param backupReload: (conf: TokenConfig[]) => Promise<void> = async (conf: TokenConfig[]) => {};
   /** 开发者选项：生成并持久化 100 个随机测试令牌 */
   @Event addTestTokens: () => Promise<boolean> = async () => false;
+  /** 开发者选项：移除生成的测试令牌 */
+  @Event removeTestTokens: () => Promise<boolean> = async () => false;
 
   @Local isBackupSheetVisible: boolean = false;
   @Local isSafetySheetVisible: boolean = false;
@@ -51,6 +53,7 @@ export struct SheetCoordinator {
   @Local isAccountSheetVisible: boolean = false;
   @Local isHuaweiLoggedIn: boolean = false;
   @Local huaweiUser: HuaweiUserInfo | null = null;
+  @Local debug_mode_is_on: boolean = AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON) as boolean;
   @Local token_preference: TokenPreference = AppStorageV2.connect(TokenPreference) as TokenPreference;
 
   private appCtx: common.UIAbilityContext = AppStorage.get('appContext') as common.UIAbilityContext;
@@ -72,6 +75,14 @@ export struct SheetCoordinator {
   private syncHuaweiAccountState(): void {
     this.isHuaweiLoggedIn = HuaweiAccountManager.getInstance().userLogin;
     this.huaweiUser = HuaweiAccountManager.getInstance().userAccount;
+  }
+
+  private updateDebugMode(isOn: boolean): void {
+    this.debug_mode_is_on = isOn;
+    this.appCtx.eventHub?.emit(EVENT_NAMES.DEBUG_MODE_CHANGED, isOn);
+    if (!isOn) {
+      this.isDeveloperOptionsSheetVisible = false;
+    }
   }
 
   private async triggerHuaweiLogin(): Promise<void> {
@@ -163,7 +174,9 @@ export struct SheetCoordinator {
   DeveloperOptionsSheetBuilder() {
     DeveloperOptionsSheet({
       scrollEffectType: this.scrollEffectType,
-      addTestTokens: () => this.addTestTokens()
+      debugModeChanged: (isOn: boolean) => this.updateDebugMode(isOn),
+      addTestTokens: () => this.addTestTokens(),
+      removeTestTokens: () => this.removeTestTokens()
     })
       .height('100%')
   }
@@ -188,6 +201,7 @@ export struct SheetCoordinator {
   AboutSheetBuilder() {
     AboutSheet({
       scrollEffectStyle: this.scrollEffectType,
+      debugModeChanged: (isOn: boolean) => this.updateDebugMode(isOn)
     })
       .height('100%')
   }
@@ -404,17 +418,19 @@ export struct SheetCoordinator {
             .bindSheet($$this.isAppearanceSheetVisible, this.AppearanceSheetBuilder(),
               MaterialSheetStyle.options())
 
-          SubItemDivider()
+          if (this.debug_mode_is_on) {
+            SubItemDivider()
 
-          SubItemButton({
-            symbol: $r('sys.symbol.wrench_and_screwdriver'),
-            text: $r('app.string.setting_group_developer_options')
-          })
-            .onClick(() => {
-              this.isDeveloperOptionsSheetVisible = true;
+            SubItemButton({
+              symbol: $r('sys.symbol.wrench_and_screwdriver'),
+              text: $r('app.string.setting_group_developer_options')
             })
-            .bindSheet($$this.isDeveloperOptionsSheetVisible, this.DeveloperOptionsSheetBuilder(),
-              MaterialSheetStyle.options())
+              .onClick(() => {
+                this.isDeveloperOptionsSheetVisible = true;
+              })
+              .bindSheet($$this.isDeveloperOptionsSheetVisible, this.DeveloperOptionsSheetBuilder(),
+                MaterialSheetStyle.options())
+          }
         }
       }
       .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })

--- a/entry/src/main/ets/shell/SheetCoordinator.ets
+++ b/entry/src/main/ets/shell/SheetCoordinator.ets
@@ -11,12 +11,13 @@ import lazy { FeedbackSheet } from '../pages/setting/FeedbackSheet'
 import { showSnackBar, SnackBarNotifyType } from 'common';
 import { AppPreference, TokenPreference, EVENT_NAMES, PREF_KEYS } from 'common';
 import { AppStorageV2 } from '@kit.ArkUI';
-import { HdsListItemCard, PrefixIcon, IconSize, SuffixArrow, ScrollEffectType } from '@kit.UIDesignKit';
-import { CommonConstants } from 'common';
+import { ScrollEffectType } from '@kit.UIDesignKit';
 import lazy { HuaweiAccountManager, HuaweiUserInfo, HuaweiAccountLoginError } from 'common';
 import { MaterialSheetStyle } from '../components/MaterialSheetStyle';
-import { MaterialSurface } from '../components/MaterialSurface';
-import { MaterialTheme } from '../components/MaterialTheme';
+import { SettingItem } from '../components/SettingItem';
+import { SubItemButton } from '../components/SubItemButton';
+import { SubItemDivider } from '../components/SubItemDivider';
+import { SETTING_PAGE_INSET, SETTING_ROW_PADDING } from '../components/SettingStyle';
 
 /**
  * Sheet 协调器(Task 3.1)
@@ -265,61 +266,64 @@ export struct SheetCoordinator {
 
   build() {
     List({ space: 10, scroller: this.scroller }) {
-      // 华为账号登录卡片
+      // 华为账号登录卡片：与设置子项共用 SettingItem 分组卡片表面
       ListItem() {
-        MaterialSurface({ radius: $r('sys.float.ohos_id_menu_outer_border_radius') }) {
+        SettingItem({ title: '' }) {
           Row({ space: 16 }) {
-          if (this.isHuaweiLoggedIn && this.huaweiUser && this.huaweiUser.avatarUri !== '') {
-            Image(this.huaweiUser.avatarUri)
-              .draggable(false)
-              .width(48)
-              .height(48)
-              .borderRadius(24)
-          } else if (this.isHuaweiLoggedIn && this.huaweiUser && this.huaweiUser.nickname !== '') {
-            Text(this.huaweiUser.nickname.length > 0 ?
-              this.huaweiUser.nickname.substring(this.huaweiUser.nickname.length - 1) : '')
-              .width(48)
-              .height(48)
-              .borderRadius(24)
-              .backgroundColor($r('sys.color.ohos_id_color_tertiary'))
-              .linearGradient({
-                colors: [
-                  [$r('sys.color.ohos_id_color_tertiary'), 0.0],
-                  [$r('sys.color.ohos_id_color_foreground_contrary'), 1.0]
-                ]
-              })
-              .fontColor($r('sys.color.font_on_primary'))
-              .fontSize(20)
-              .fontWeight(FontWeight.Bold)
-              .textAlign(TextAlign.Center)
-          } else {
-            SymbolGlyph($r('sys.symbol.person_crop_circle_fill_1'))
-              .fontSize(48)
-              .fontColor([$r('sys.color.ohos_id_color_text_secondary')])
-          }
+            if (this.isHuaweiLoggedIn && this.huaweiUser && this.huaweiUser.avatarUri !== '') {
+              Image(this.huaweiUser.avatarUri)
+                .draggable(false)
+                .width(48)
+                .height(48)
+                .borderRadius(24)
+            } else if (this.isHuaweiLoggedIn && this.huaweiUser && this.huaweiUser.nickname !== '') {
+              Text(this.huaweiUser.nickname.length > 0 ?
+                this.huaweiUser.nickname.substring(this.huaweiUser.nickname.length - 1) : '')
+                .width(48)
+                .height(48)
+                .borderRadius(24)
+                .backgroundColor($r('sys.color.ohos_id_color_tertiary'))
+                .linearGradient({
+                  colors: [
+                    [$r('sys.color.ohos_id_color_tertiary'), 0.0],
+                    [$r('sys.color.ohos_id_color_foreground_contrary'), 1.0]
+                  ]
+                })
+                .fontColor($r('sys.color.font_on_primary'))
+                .fontSize(20)
+                .fontWeight(FontWeight.Bold)
+                .textAlign(TextAlign.Center)
+            } else {
+              SymbolGlyph($r('sys.symbol.person_crop_circle_fill_1'))
+                .fontSize(48)
+                .fontColor([$r('sys.color.ohos_id_color_text_secondary')])
+            }
 
-          Column({ space: 4 }) {
-            Text(this.isHuaweiLoggedIn && this.huaweiUser ?
-              this.huaweiUser.nickname : $r('app.string.huawei_account_login'))
-              .fontSize(18)
-              .fontWeight(FontWeight.Medium)
-              .fontColor($r('sys.color.ohos_id_color_text_primary'))
-              .maxLines(1)
-              .textOverflow({ overflow: TextOverflow.Ellipsis })
+            Column({ space: 4 }) {
+              Text(this.isHuaweiLoggedIn && this.huaweiUser ?
+                this.huaweiUser.nickname : $r('app.string.huawei_account_login'))
+                .fontSize(18)
+                .fontWeight(FontWeight.Medium)
+                .fontColor($r('sys.color.ohos_id_color_text_primary'))
+                .maxLines(1)
+                .textOverflow({ overflow: TextOverflow.Ellipsis })
 
-            Text(this.isHuaweiLoggedIn ?
-              $r('app.string.huawei_account_current') :
-              $r('app.string.huawei_account_login_desc'))
-              .fontSize(14)
-              .fontColor($r('sys.color.ohos_id_color_text_secondary'))
-              .maxLines(1)
+              Text(this.isHuaweiLoggedIn ?
+                $r('app.string.huawei_account_current') :
+                $r('app.string.huawei_account_login_desc'))
+                .fontSize(14)
+                .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                .maxLines(1)
+            }
+            .alignItems(HorizontalAlign.Start)
+            .layoutWeight(1)
           }
-          .alignItems(HorizontalAlign.Start)
-          .layoutWeight(1)
-        }
           .width('100%')
-          .padding({ left: 20, right: 20, top: 16, bottom: 16 })
+          .padding(SETTING_ROW_PADDING)
           .alignItems(VerticalAlign.Center)
+          // PC/2in1 光标悬浮时提供系统高亮反馈
+          .hoverEffect(HoverEffect.Highlight)
+          .clickEffect({ level: ClickEffectLevel.LIGHT, scale: 0.95 })
           .onClick(() => {
             if (!this.isHuaweiLoggedIn) {
               this.triggerHuaweiLogin();
@@ -331,290 +335,103 @@ export struct SheetCoordinator {
             MaterialSheetStyle.options(SheetSize.MEDIUM))
         }
       }
-      .padding({
-        left: $r('sys.float.padding_level8'),
-        right: $r('sys.float.padding_level8'),
-      })
+      .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
 
-      // 备份与迁移入口
+      // 数据管理：备份与迁移、数据同步属于同一数据生命周期分类
       ListItem() {
-        MaterialSurface({ radius: $r('sys.float.ohos_id_menu_outer_border_radius') }) {
-          Column() {
-          HdsListItemCard({
-            cardPrefixMargin: $r('sys.float.padding_level2'),
-            cardSuffixMargin: $r('sys.float.padding_level2'),
-            // 沉浸档透明透出 MaterialSurface 材质层，其余档位保持 item_bg
-            cardBackgroundColor: MaterialTheme.surfaceBackground($r('app.color.item_bg')),
-            cardHeight: CommonConstants.SETTING_OPTION_CARD_HEIGHT,
-            prefixItem: new PrefixIcon({
-              iconSize: IconSize.SYSTEM_ICON,
-              iconValue: {
-                symbol: $r('sys.symbol.save')
-              }
-            }),
-            textItem: {
-              primaryText: {
-                text: $r('app.string.setting_backup')
-              }
-            },
-            suffixItem: new SuffixArrow({}),
-            onClick: () => {
-              this.isBackupSheetVisible = true;
-            }
+        SettingItem({ title: $r('app.string.setting_group_data_management') }) {
+          SubItemButton({
+            symbol: $r('sys.symbol.save'),
+            text: $r('app.string.setting_backup')
           })
+            .onClick(() => {
+              this.isBackupSheetVisible = true;
+            })
             .bindSheet($$this.isBackupSheetVisible, this.BackupAndMigrationSheetBuilder(),
               MaterialSheetStyle.options())
-          }
-          .padding({
-            top: $r('sys.float.padding_level2'),
-            bottom: $r('sys.float.padding_level2'),
-          })
-        }
-      }
-      .padding({
-        left: $r('sys.float.padding_level8'),
-        right: $r('sys.float.padding_level8'),
-      })
 
-      // 安全性入口
-      ListItem() {
-        MaterialSurface({ radius: $r('sys.float.ohos_id_menu_outer_border_radius') }) {
-          Column() {
-          HdsListItemCard({
-            cardPrefixMargin: $r('sys.float.padding_level2'),
-            cardSuffixMargin: $r('sys.float.padding_level2'),
-            // 沉浸档透明透出 MaterialSurface 材质层，其余档位保持 item_bg
-            cardBackgroundColor: MaterialTheme.surfaceBackground($r('app.color.item_bg')),
-            cardHeight: CommonConstants.SETTING_OPTION_CARD_HEIGHT,
-            prefixItem: new PrefixIcon({
-              iconSize: IconSize.SYSTEM_ICON,
-              iconValue: {
-                symbol: $r('sys.symbol.staroflife_rectangle')
-              }
-            }),
-            textItem: {
-              primaryText: {
-                text: $r('app.string.setting_safety')
-              }
-            },
-            suffixItem: new SuffixArrow({}),
-            onClick: () => {
-              this.isSafetySheetVisible = true;
-            }
-          })
-            .bindSheet($$this.isSafetySheetVisible, this.SecuritySheetBuilder(),
-              MaterialSheetStyle.options())
-          }
-          .padding({
-            top: $r('sys.float.padding_level2'),
-            bottom: $r('sys.float.padding_level2'),
-          })
-        }
-      }
-      .padding({
-        left: $r('sys.float.padding_level8'),
-        right: $r('sys.float.padding_level8'),
-      })
+          SubItemDivider()
 
-      // 外观与功能入口
-      ListItem() {
-        MaterialSurface({ radius: $r('sys.float.ohos_id_menu_outer_border_radius') }) {
-          Column() {
-          HdsListItemCard({
-            cardPrefixMargin: $r('sys.float.padding_level2'),
-            cardSuffixMargin: $r('sys.float.padding_level2'),
-            // 沉浸档透明透出 MaterialSurface 材质层，其余档位保持 item_bg
-            cardBackgroundColor: MaterialTheme.surfaceBackground($r('app.color.item_bg')),
-            cardHeight: CommonConstants.SETTING_OPTION_CARD_HEIGHT,
-            prefixItem: new PrefixIcon({
-              iconSize: IconSize.SYSTEM_ICON,
-              iconValue: {
-                symbol: $r('sys.symbol.chevron_up_2_circle')
-              }
-            }),
-            textItem: {
-              primaryText: {
-                text: $r('app.string.app_appearance')
-              }
-            },
-            suffixItem: new SuffixArrow({}),
-            onClick: () => {
-              this.isAppearanceSheetVisible = true;
-            }
+          SubItemButton({
+            symbol: $r('sys.symbol.link'),
+            text: $r('app.string.data_sync')
           })
-            .bindSheet($$this.isAppearanceSheetVisible, this.AppearanceSheetBuilder(),
-              MaterialSheetStyle.options())
-          }
-          .padding({
-            top: $r('sys.float.padding_level2'),
-            bottom: $r('sys.float.padding_level2'),
-          })
-        }
-      }
-      .padding({
-        left: $r('sys.float.padding_level8'),
-        right: $r('sys.float.padding_level8'),
-      })
-
-      // 数据同步入口
-      ListItem() {
-        MaterialSurface({ radius: $r('sys.float.ohos_id_menu_outer_border_radius') }) {
-          Column() {
-          HdsListItemCard({
-            cardPrefixMargin: $r('sys.float.padding_level2'),
-            cardSuffixMargin: $r('sys.float.padding_level2'),
-            // 沉浸档透明透出 MaterialSurface 材质层，其余档位保持 item_bg
-            cardBackgroundColor: MaterialTheme.surfaceBackground($r('app.color.item_bg')),
-            cardHeight: CommonConstants.SETTING_OPTION_CARD_HEIGHT,
-            prefixItem: new PrefixIcon({
-              iconSize: IconSize.SYSTEM_ICON,
-              iconValue: {
-                symbol: $r('sys.symbol.link')
-              }
-            }),
-            textItem: {
-              primaryText: {
-                text: $r('app.string.data_sync')
-              }
-            },
-            suffixItem: new SuffixArrow({}),
-            onClick: () => {
+            .onClick(() => {
               this.isDataSyncSheetVisible = true;
-            }
-          })
+            })
             .bindSheet($$this.isDataSyncSheetVisible, this.DataSyncSheetBuilder(),
               MaterialSheetStyle.options())
-          }
-          .padding({
-            top: $r('sys.float.padding_level2'),
-            bottom: $r('sys.float.padding_level2'),
-          })
         }
       }
-      .padding({
-        left: $r('sys.float.padding_level8'),
-        right: $r('sys.float.padding_level8'),
-      })
+      .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
 
-      // 协议与声明入口
+      // 应用设置
       ListItem() {
-        MaterialSurface({ radius: $r('sys.float.ohos_id_menu_outer_border_radius') }) {
-          Column() {
-          HdsListItemCard({
-            cardPrefixMargin: $r('sys.float.padding_level2'),
-            cardSuffixMargin: $r('sys.float.padding_level2'),
-            // 沉浸档透明透出 MaterialSurface 材质层，其余档位保持 item_bg
-            cardBackgroundColor: MaterialTheme.surfaceBackground($r('app.color.item_bg')),
-            cardHeight: CommonConstants.SETTING_OPTION_CARD_HEIGHT,
-            prefixItem: new PrefixIcon({
-              iconSize: IconSize.SYSTEM_ICON,
-              iconValue: {
-                symbol: $r('sys.symbol.person_shield')
-              }
-            }),
-            textItem: {
-              primaryText: {
-                text: $r('app.string.setting_agreement_statement')
-              }
-            },
-            suffixItem: new SuffixArrow({}),
-            onClick: () => {
-              this.isAgreementSheetVisible = true;
-            }
+        SettingItem({ title: $r('app.string.setting_group_app_settings') }) {
+          SubItemButton({
+            symbol: $r('sys.symbol.staroflife_rectangle'),
+            text: $r('app.string.setting_safety')
           })
+            .onClick(() => {
+              this.isSafetySheetVisible = true;
+            })
+            .bindSheet($$this.isSafetySheetVisible, this.SecuritySheetBuilder(),
+              MaterialSheetStyle.options())
+
+          SubItemDivider()
+
+          SubItemButton({
+            symbol: $r('sys.symbol.chevron_up_2_circle'),
+            text: $r('app.string.app_appearance')
+          })
+            .onClick(() => {
+              this.isAppearanceSheetVisible = true;
+            })
+            .bindSheet($$this.isAppearanceSheetVisible, this.AppearanceSheetBuilder(),
+              MaterialSheetStyle.options())
+        }
+      }
+      .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
+
+      // 支持与关于
+      ListItem() {
+        SettingItem({ title: $r('app.string.setting_group_support_about') }) {
+          SubItemButton({
+            symbol: $r('sys.symbol.person_shield'),
+            text: $r('app.string.setting_agreement_statement')
+          })
+            .onClick(() => {
+              this.isAgreementSheetVisible = true;
+            })
             .bindSheet($$this.isAgreementSheetVisible, this.AgreementSheetBuilder(),
               MaterialSheetStyle.options())
-          }
-          .padding({
-            top: $r('sys.float.padding_level2'),
-            bottom: $r('sys.float.padding_level2'),
-          })
-        }
-      }
-      .padding({
-        left: $r('sys.float.padding_level8'),
-        right: $r('sys.float.padding_level8'),
-      })
 
-      // 建议与反馈入口
-      ListItem() {
-        MaterialSurface({ radius: $r('sys.float.ohos_id_menu_outer_border_radius') }) {
-          Column() {
-          HdsListItemCard({
-            cardPrefixMargin: $r('sys.float.padding_level2'),
-            cardSuffixMargin: $r('sys.float.padding_level2'),
-            // 沉浸档透明透出 MaterialSurface 材质层，其余档位保持 item_bg
-            cardBackgroundColor: MaterialTheme.surfaceBackground($r('app.color.item_bg')),
-            cardHeight: CommonConstants.SETTING_OPTION_CARD_HEIGHT,
-            prefixItem: new PrefixIcon({
-              iconSize: IconSize.SYSTEM_ICON,
-              iconValue: {
-                symbol: $r('sys.symbol.envelope')
-              }
-            }),
-            textItem: {
-              primaryText: {
-                text: $r('app.string.setting_feedback')
-              }
-            },
-            suffixItem: new SuffixArrow({}),
-            onClick: () => {
-              this.isFeedbackSheetVisible = true;
-            }
+          SubItemDivider()
+
+          SubItemButton({
+            symbol: $r('sys.symbol.envelope'),
+            text: $r('app.string.setting_feedback')
           })
+            .onClick(() => {
+              this.isFeedbackSheetVisible = true;
+            })
             .bindSheet($$this.isFeedbackSheetVisible, this.FeedbackSheetBuilder(),
               MaterialSheetStyle.options())
-          }
-          .padding({
-            top: $r('sys.float.padding_level2'),
-            bottom: $r('sys.float.padding_level2'),
-          })
-        }
-      }
-      .padding({
-        left: $r('sys.float.padding_level8'),
-        right: $r('sys.float.padding_level8'),
-      })
 
-      // 关于入口
-      ListItem() {
-        MaterialSurface({ radius: $r('sys.float.ohos_id_menu_outer_border_radius') }) {
-          Column() {
-          HdsListItemCard({
-            cardPrefixMargin: $r('sys.float.padding_level2'),
-            cardSuffixMargin: $r('sys.float.padding_level2'),
-            // 沉浸档透明透出 MaterialSurface 材质层，其余档位保持 item_bg
-            cardBackgroundColor: MaterialTheme.surfaceBackground($r('app.color.item_bg')),
-            cardHeight: CommonConstants.SETTING_OPTION_CARD_HEIGHT,
-            prefixItem: new PrefixIcon({
-              iconSize: IconSize.SYSTEM_ICON,
-              iconValue: {
-                symbol: $r('sys.symbol.info_circle')
-              }
-            }),
-            textItem: {
-              primaryText: {
-                text: $r('app.string.setting_about')
-              }
-            },
-            suffixItem: new SuffixArrow({}),
-            onClick: () => {
-              this.isAboutSheetVisible = true;
-            }
+          SubItemDivider()
+
+          SubItemButton({
+            symbol: $r('sys.symbol.info_circle'),
+            text: $r('app.string.setting_about')
           })
+            .onClick(() => {
+              this.isAboutSheetVisible = true;
+            })
             .bindSheet($$this.isAboutSheetVisible, this.AboutSheetBuilder(),
               MaterialSheetStyle.options())
-          }
-          .padding({
-            top: $r('sys.float.padding_level2'),
-            bottom: $r('sys.float.padding_level2'),
-          })
         }
       }
-      .padding({
-        left: $r('sys.float.padding_level8'),
-        right: $r('sys.float.padding_level8'),
-      })
+      .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
     }
     .clip(false)
     .chainAnimation(this.token_preference.app_appearance_chain_animation_enable)

--- a/entry/src/main/ets/shell/SheetCoordinator.ets
+++ b/entry/src/main/ets/shell/SheetCoordinator.ets
@@ -34,6 +34,7 @@ export struct SheetCoordinator {
   @Require @Param tokens: TokenConfig[] = [];
   @Require @Param scrollEffectType: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
   @Require @Param scroller: Scroller = new Scroller();
+  @Require @Param bottomAvoidHeight: number = 0;
   /** 备份恢复完成回调(由 Index 提供:批量更新 Token 并重新排序) */
   @Require @Param backupReload: (conf: TokenConfig[]) => Promise<void> = async (conf: TokenConfig[]) => {};
   /** 开发者选项：生成并持久化 100 个随机测试令牌 */
@@ -459,6 +460,8 @@ export struct SheetCoordinator {
       .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
     }
     .clip(false)
+    // 与令牌列表使用相同的页签栏末端避让，确保最后一组可滚动至 HdsTabs 上方
+    .contentEndOffset(80 + this.bottomAvoidHeight)
     .chainAnimation(this.token_preference.app_appearance_chain_animation_enable)
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/shell/SheetCoordinator.ets
+++ b/entry/src/main/ets/shell/SheetCoordinator.ets
@@ -4,6 +4,7 @@ import { TokenConfig } from 'common';
 import lazy { BackupAndMigrationSheet } from '../pages/setting/BackupAndMigrationSheet'
 import lazy { SecuritySheet } from '../pages/setting/SecuritySheet'
 import lazy { AppearanceSheet } from '../pages/setting/AppearanceSheet'
+import lazy { DeveloperOptionsSheet } from '../pages/setting/DeveloperOptionsSheet'
 import lazy { DataSyncSheet } from '../pages/setting/DataSyncSheet'
 import lazy { AgreementSheet } from '../pages/setting/AgreementSheet'
 import lazy { AboutSheet } from '../pages/setting/AboutSheet'
@@ -22,8 +23,8 @@ import { SETTING_PAGE_INSET, SETTING_ROW_PADDING } from '../components/SettingSt
 /**
  * Sheet 协调器(Task 3.1)
  *
- * 承载"我的"页签的全部内容:华为账号卡片 + 7 个设置入口卡片,
- * 以及 8 个 bindSheet(账号/备份/安全/外观/数据同步/协议/反馈/关于)的可见性状态与内容。
+ * 承载"我的"页签的全部内容:华为账号卡片 + 8 个设置入口,
+ * 以及 9 个 bindSheet(账号/备份/安全/外观/开发者选项/数据同步/协议/反馈/关于)的可见性状态与内容。
  * 华为账号 UI 状态与登录/登出流程内聚在本组件;
  * Index 侧在账号初始化完成、分布式登出等时机通过 EVENT_NAMES.HUAWEI_ACCOUNT_STATE_CHANGED 广播,
  * 本组件监听后重新同步,保证 SheetCoordinator 懒构建时序下状态依然正确。
@@ -35,10 +36,13 @@ export struct SheetCoordinator {
   @Require @Param scroller: Scroller = new Scroller();
   /** 备份恢复完成回调(由 Index 提供:批量更新 Token 并重新排序) */
   @Require @Param backupReload: (conf: TokenConfig[]) => Promise<void> = async (conf: TokenConfig[]) => {};
+  /** 开发者选项：生成并持久化 100 个随机测试令牌 */
+  @Event addTestTokens: () => Promise<boolean> = async () => false;
 
   @Local isBackupSheetVisible: boolean = false;
   @Local isSafetySheetVisible: boolean = false;
   @Local isAppearanceSheetVisible: boolean = false;
+  @Local isDeveloperOptionsSheetVisible: boolean = false;
   @Local isDataSyncSheetVisible: boolean = false;
   @Local isAgreementSheetVisible: boolean = false;
   @Local isAboutSheetVisible: boolean = false;
@@ -150,6 +154,15 @@ export struct SheetCoordinator {
   AppearanceSheetBuilder() {
     AppearanceSheet({
       scrollEffectType: this.scrollEffectType,
+    })
+      .height('100%')
+  }
+
+  @Builder
+  DeveloperOptionsSheetBuilder() {
+    DeveloperOptionsSheet({
+      scrollEffectType: this.scrollEffectType,
+      addTestTokens: () => this.addTestTokens()
     })
       .height('100%')
   }
@@ -388,6 +401,18 @@ export struct SheetCoordinator {
               this.isAppearanceSheetVisible = true;
             })
             .bindSheet($$this.isAppearanceSheetVisible, this.AppearanceSheetBuilder(),
+              MaterialSheetStyle.options())
+
+          SubItemDivider()
+
+          SubItemButton({
+            symbol: $r('sys.symbol.wrench_and_screwdriver'),
+            text: $r('app.string.setting_group_developer_options')
+          })
+            .onClick(() => {
+              this.isDeveloperOptionsSheetVisible = true;
+            })
+            .bindSheet($$this.isDeveloperOptionsSheetVisible, this.DeveloperOptionsSheetBuilder(),
               MaterialSheetStyle.options())
         }
       }

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -39,6 +39,9 @@
         "name": "ohos.permission.DETECT_GESTURE",
       },
       {
+        "name": "ohos.permission.SET_WINDOW_TRANSPARENT",
+      },
+      {
         "name": "ohos.permission.VIBRATE",
       },
       {


### PR DESCRIPTION
<!-- 感谢你的贡献！请先阅读 CONTRIBUTING.md，并完整填写以下内容。 -->

## 改动说明

本 PR 从 `fix/dynamic-list-cache` 分支合入 `dev`，共 9 个提交，主要内容：

- **fix: 动态扩展令牌列表缓存范围**（22a2985）—— 扩展列表项缓存范围，减少滚动重建。
- **fix: 加密导出增加密码确认校验**（1eb0716）—— 加密导出时增加二次密码确认，防止误输入。
- **fix: 统一主页全局导航与页签裁剪**（078c9ee）—— 统一主页全局导航样式与页签裁剪逻辑。
- **feat: 重构我的页设置分组与悬浮反馈**（8ae5117）—— 设置分组重构，新增悬浮触感反馈。
- **feat: 添加批量测试令牌开发者选项**（41e422f）—— 开发者选项新增批量测试令牌能力。
- **fix: 统一窗口与系统标题栏背景色**（3644040）—— 同步深浅色资源到窗口背景；PC / 2in1 / Tablet 额外统一系统标题栏容器色。按文档为 `setWindowContainerColor` 声明了 `ohos.permission.SET_WINDOW_TRANSPARENT` 权限。
- **fix: 调整令牌表单下拉菜单布局**（c89a5d4）
- **fix: 统一主页列表底部页签避让**（999e7c2）
- **feat: 优化令牌长按菜单扩展动效**（933ed9e）

## 改动类型

<!-- 请勾选适用项（把 [ ] 改成 [x]） -->

- [x] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 重构（refactor）
- [x] 样式调整（style）
- [ ] 文档（docs）
- [ ] 构建 / 依赖 / 配置（chore）

## 检查清单

<!-- 提交前请逐项确认。无法勾选的项目请说明原因。 -->

- [x] **目标分支已选择 `dev`**（不是 `main`）
- [x] 已基于最新 `dev` 创建分支并 rebase，无冲突（merge-base 即 `dev` 最新提交 69b3ff4，与 `origin/dev` 无分叉）
- [x] 本地构建通过（`hvigorw assembleHap`）
- [x] 已在真机 / 模拟器上测试，行为符合预期
- [x] commit message 遵循 Conventional Commits 规范
- [x] 未提交本地的 `build-profile.json5` 签名配置、IDE 缓存等产物（本地 `oh_modules/`、`.pi/` 均未纳入提交）

## 测试说明

<!-- 描述你是如何测试的：测试场景、设备型号、预期与实际结果。详见贡献指南「提交前检查清单」。 -->

本环境无 HarmonyOS SDK / 模拟器，未执行本地构建与真机验证。改动集中在 `entry` 模块的页面布局、窗口配色与列表缓存逻辑，建议在真机（API 26）上重点回归：主页令牌列表滚动、长按菜单动效、加密导出流程、窗口深浅色切换、开发者选项批量测试入口。

## 截图 / 录屏（如涉及 UI 改动）

<!-- 如果本 PR 包含界面改动，请附上截图或录屏，便于 reviewer 直观确认效果。无 UI 改动可删除本节。 -->

本 PR 涉及较多 UI 改动（主页导航/页签、设置分组、长按菜单动效、窗口配色等），待补充真机截图 / 录屏。
