### PR TITLE
feat: 手表同步按通道拆分验证页(BLE / P2P 各一页)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ hvigorw
 # OpenSpec 本地配置
 openspec/
 /.pi/
+
+# AI 会话本地产物
+.codegenie/
+.local/

--- a/common/Index.ets
+++ b/common/Index.ets
@@ -3,6 +3,7 @@ export * from './src/main/ets/utils/AppPreference';
 export * from './src/main/ets/utils/AssetSecretStore';
 export * from './src/main/ets/utils/BackupRestoreHelper';
 export * from './src/main/ets/utils/Base64Util';
+export * from './src/main/ets/utils/BleTokenTransfer';
 export * from './src/main/ets/utils/CloudBackupCrypto';
 export * from './src/main/ets/utils/CloudBackupManager';
 export * from './src/main/ets/utils/CloudSyncTask';

--- a/common/src/main/ets/utils/AppPreference.ets
+++ b/common/src/main/ets/utils/AppPreference.ets
@@ -501,6 +501,8 @@ export enum ROUTE_NAMES {
   IconPickerPage = 'IconPickerPage',
   /** 手表同步页面 */
   WatchSyncPage = 'WatchSyncPage',
+  /** 手表同步(BLE)验证页面 */
+  BleWatchSyncPage = 'BleWatchSyncPage',
   /** “我的”页华为账号详情 */
   SettingAccount = 'setting/account',
   /** “我的”页备份与迁移详情 */

--- a/common/src/main/ets/utils/BleTokenTransfer.ets
+++ b/common/src/main/ets/utils/BleTokenTransfer.ets
@@ -547,8 +547,13 @@ export class BleTokenClient {
         }
         this.onDevicesChanged?.(this.getFoundDevices());
       });
-      // 配对状态订阅: 生命周期与扫描一致(页面存活期间持续监听)
+      // 配对状态订阅: 生命周期与扫描一致(页面存活期间持续监听);
+      // 只转发当前连接设备的事件(其他设备的配对/解绑不干扰当前连接的配对态,
+      // 页面侧据此可不对回调参数做 deviceId 严格过滤)
       connection.on('bondStateChange', (data: connection.BondStateParam) => {
+        if (data.deviceId !== this.currentDeviceId) {
+          return;
+        }
         const isBonded: boolean = data.state === connection.BondState.BOND_STATE_BONDED;
         this.bonded.set(data.deviceId, isBonded);
         hilog.info(DOMAIN, TAG, `client bond state: ${data.deviceId} -> ${isBonded}`);
@@ -647,6 +652,23 @@ export class BleTokenClient {
   }
 
   /**
+   * 查询当前连接设备的系统配对状态(bonded). 连接态下的权威判定,
+   * 不依赖配对回调时序: 配对事件偶发缺失时页面可据此兜底收敛.
+   */
+  public isCurrentDeviceBonded(): boolean {
+    if (this.currentDeviceId === '') {
+      return false;
+    }
+    try {
+      return connection.getPairState(this.currentDeviceId) === connection.BondState.BOND_STATE_BONDED;
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.warn(e.code, TAG, `isCurrentDeviceBonded getPairState failed: ${e.message}`);
+      return false;
+    }
+  }
+
+  /**
    * 连接指定设备(先释放旧连接).
    */
   public connect(deviceId: string): void {
@@ -655,8 +677,16 @@ export class BleTokenClient {
       this.currentDeviceId = deviceId;
       const client: ble.GattClientDevice = ble.createGattClientDevice(deviceId);
       client.on('BLEConnectionStateChange', (state: ble.BLEConnectionChangeState) => {
-        const connected: boolean = state.state === constant.ProfileConnectionState.STATE_CONNECTED;
         hilog.info(DOMAIN, TAG, `client connection state: ${state.state}`);
+        // 只上报终态: CONNECTING(1)/DISCONNECTING(3) 是过程态, 建连发起后必先
+        // 收到一次 CONNECTING; 若按 connected=false 上报, 页面会误判建连失败并
+        // 弹"手表端未就绪", 而实际随后 CONNECTED 到达、连接成功(真实失败无事件
+        // 时由调用方的建连超时兜底)
+        if (state.state !== constant.ProfileConnectionState.STATE_CONNECTED &&
+            state.state !== constant.ProfileConnectionState.STATE_DISCONNECTED) {
+          return;
+        }
+        const connected: boolean = state.state === constant.ProfileConnectionState.STATE_CONNECTED;
         if (connected) {
           // 连接后协商更大 MTU, 使 480 字节分片写入可行(setBLEMtuSize 为同步接口)
           try {

--- a/common/src/main/ets/utils/BleTokenTransfer.ets
+++ b/common/src/main/ets/utils/BleTokenTransfer.ets
@@ -1,0 +1,694 @@
+import { ble, connection, constant } from '@kit.ConnectivityKit';
+import { BusinessError } from '@kit.BasicServicesKit';
+import { util } from '@kit.ArkTS';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { TokenConfig } from './TokenConfig';
+import { AppPreference } from './AppPreference';
+import { decryptBlePayload, encryptBlePayload } from './CryptoUtils';
+import { WEAR_SYNC_PREF_KEYS, SettingValuePair, saveTokensBatch, applyWearSettings } from './WearEngineTransfer';
+
+const TAG = 'BleTokenTransfer';
+const DOMAIN = 0xFF01;
+
+/**
+ * 手机→手表 蓝牙(BLE)令牌传输方案(P2P 之外的独立验证通道).
+ *
+ * 背景: 分布式 KV 同步受"数据库安全等级 ≤ 对端设备安全等级"约束,
+ * 手表为低安全设备, S4 存储(令牌属认证凭据, 不能降级)无法与其跨设备同步.
+ * 因此改用 BLE 手动传输: 手表端 GATT Server 广播接收, 手机端 GATT Client 扫描连接后写入.
+ *
+ * 安全模型(双层):
+ * - 系统 BLE 配对(connection.pairDevice, LE Secure Connections): 链路层由系统 LTK 加密,
+ *   未 bonded 的设备禁止传输 secret 载荷
+ * - 应用层 AES-256-GCM(encryptBlePayload/decryptBlePayload): 链路被降级/未加密时的纵深防御,
+ *   防被动嗅探与内容篡改(tag 校验)
+ *
+ * 传输协议(分片):
+ * - 首帧: JSON 头 {"total": 数据总字节数, "count": 令牌数, "type": "tokens"|"settings"}
+ * - 后续帧: ≤ MAX_CHUNK 字节的加密数据分片(AES-256-GCM, 载荷格式 [MAGIC][iv][tag][ciphertext])
+ * - 接收方按 total 重组, 解密后按 type 分发; 令牌入库/设置应用复用 WearEngineTransfer 共享实现
+ * - 最后一个数据帧的写应答延后到重组处理完成: 成功回 status 0, 失败回非 0,
+ *   使手机端写入结果与手表端实际入库结果一致(防"页面成功、手表无数据"的假成功)
+ */
+
+/** 自定义 GATT 服务 UUID(两端必须一致) */
+export const BLE_SERVICE_UUID = 'aabbccdd-0000-1000-8000-00805f9b34fb';
+/** 自定义 GATT 写特征 UUID */
+export const BLE_CHAR_UUID = 'aabbccdd-0001-1000-8000-00805f9b34fb';
+/** 广播响应包中携带设备名的自定义服务 UUID(手机端经 ScanResult.serviceDataMap 解析) */
+export const BLE_NAME_UUID = 'aabbccdd-0002-1000-8000-00805f9b34fb';
+/** 手表端广播的显示名(legacy 广播包 31B 限制: 主包放 128 位服务 UUID, 名字走响应包) */
+const BLE_ADV_DEVICE_NAME = 'OHOTP Watch';
+
+/**
+ * 解析设备显示名: 广播名 → 响应包自定义名 → 系统已知名 → deviceId 兜底.
+ * 手表端广播未携带标准设备名时, deviceName 为空会显示一串数字, 本函数逐级兜底.
+ */
+export function getDeviceDisplayName(device: ble.ScanResult): string {
+  if (device.deviceName.length > 0) {
+    return device.deviceName;
+  }
+  const nameBytes = device.serviceDataMap?.get(BLE_NAME_UUID);
+  if (nameBytes !== undefined && nameBytes.byteLength > 0) {
+    return new util.TextDecoder('utf-8').decodeToString(nameBytes);
+  }
+  try {
+    const remoteName = connection.getRemoteDeviceName(device.deviceId);
+    if (remoteName.length > 0) {
+      return remoteName;
+    }
+  } catch (err) {
+    // 未配对设备查询远端名可能失败, 忽略走兜底
+  }
+  return device.deviceId;
+}
+
+/** 单次 GATT 写入最大载荷(默认 MTU 下留安全余量) */
+const MAX_CHUNK = 480;
+/** 单次传输数据上限保护(512KB) */
+const MAX_RECEIVE = 512 * 1024;
+/**
+ * GATT 单次操作超时(ms): 连接断开/手表锁屏时写入 Promise 可能长期挂起,
+ * 无超时保护会让主线程 await 冻结导致 ANR(THREAD_BLOCK); 超时后立即失败,
+ * 由调用方提示用户重试. 收尾帧应答延后到处理完成, 5 秒同样覆盖解密/入库耗时.
+ */
+const GATT_OP_TIMEOUT_MS = 5000;
+
+/**
+ * 带超时的 Promise 封装: 超时或操作完成/失败均清理定时器,
+ * 避免成功路径下定时器悬挂至超时时刻才触发.
+ */
+function withTimeout<T>(op: Promise<T>, timeoutMs: number, timeoutMsg: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timerId = setTimeout(() => reject(new Error(timeoutMsg)), timeoutMs);
+    op.then((value: T) => {
+      clearTimeout(timerId);
+      resolve(value);
+    }, (err: Error) => {
+      clearTimeout(timerId);
+      reject(err);
+    });
+  });
+}
+
+/** 传输头部帧结构 */
+interface TransferHeader {
+  total: number;
+  count: number;
+  /** 消息类型: 缺省为 tokens(向后兼容旧版发送端) */
+  type?: string;
+}
+
+interface ReceiveState {
+  inProgress: boolean;
+  total: number;
+  count: number;
+  type: string;
+  received: number;
+  chunks: Array<Uint8Array>;
+}
+
+/** 消息类型常量 */
+const MSG_TYPE_TOKENS = 'tokens';
+const MSG_TYPE_SETTINGS = 'settings';
+
+/** 手表端 BLE 接收状态(驱动列表页同步状态文本, 接收中/成功/失败) */
+export enum BleSyncStatus {
+  /** 已收到传输头, 正在接收数据分片 */
+  RECEIVING = 0,
+  /** 批次完整接收并处理成功 */
+  SUCCESS = 1,
+  /** 接收失败(解密失败/数据异常/处理异常), 本批次已丢弃 */
+  FAILED = 2
+}
+
+/**
+ * 手表端 BLE GATT Server: 广播令牌接收服务, 手机写入的令牌数据重组后入库.
+ *
+ * 接收状态机以"批次"为隔离单元: 连接建立与每个批次开始时重置 inProgress/chunks,
+ * 任何失败路径(头非法/分片越界/解密失败/重组异常)下未完整接收的批次均不入库,
+ * 防止中断重试后残留分片拼入新批次造成"手机端成功、手表无数据"的假成功.
+ */
+export class BleTokenServer {
+  private static instance: BleTokenServer;
+  private gattServer: ble.GattServer | undefined = undefined;
+  private receive: ReceiveState = BleTokenServer.newReceiveState();
+  private onTokensSaved: ((count: number) => void) | undefined = undefined;
+  private onSettingsApplied: (() => void) | undefined = undefined;
+  private onSyncStatus: ((status: BleSyncStatus, count: number) => void) | undefined = undefined;
+
+  /** 空白接收状态(批次开始/结束/失败时统一以此重置) */
+  private static newReceiveState(): ReceiveState {
+    return { inProgress: false, total: 0, count: 0, type: MSG_TYPE_TOKENS, received: 0, chunks: [] };
+  }
+
+  public static getInstance(): BleTokenServer {
+    if (!BleTokenServer.instance) {
+      BleTokenServer.instance = new BleTokenServer();
+    }
+    return BleTokenServer.instance;
+  }
+
+  /** 注册令牌入库完成回调(UI 提示用); 传 undefined 注销 */
+  public setOnTokensSaved(cb: ((count: number) => void) | undefined): void {
+    this.onTokensSaved = cb;
+  }
+
+  /** 注册设置应用完成回调(UI 提示用); 传 undefined 注销 */
+  public setOnSettingsApplied(cb: (() => void) | undefined): void {
+    this.onSettingsApplied = cb;
+  }
+
+  /** 注册接收状态回调(接收中/成功/失败, UI 状态文本用); 传 undefined 注销 */
+  public setOnSyncStatus(cb: ((status: BleSyncStatus, count: number) => void) | undefined): void {
+    this.onSyncStatus = cb;
+  }
+
+  /**
+   * 启动 GATT Server 并开始广播. 幂等: 已启动则直接返回.
+   * 启动竞态保护: 蓝牙权限/开关未就绪时以 5 次 × 1 秒延时重试, 全部失败仅记日志
+   * (调用方 P2P/BLE 并行启动, BLE 失败不得影响 P2P 接收).
+   * 每次失败尝试均注销/close 已创建的 GattServer, 避免重试路径泄漏监听与实例.
+   */
+  public async start(): Promise<void> {
+    if (this.gattServer) {
+      return;
+    }
+    for (let attempt = 0; attempt < 5; attempt++) {
+      let server: ble.GattServer | undefined = undefined;
+      try {
+        server = ble.createGattServer();
+        // await 服务注册完成: 注册失败(蓝牙未就绪)进入 catch 走重试与清理
+        await server.addService({
+          serviceUuid: BLE_SERVICE_UUID,
+          isPrimary: true,
+          characteristics: [{
+            serviceUuid: BLE_SERVICE_UUID,
+            characteristicUuid: BLE_CHAR_UUID,
+            characteristicValue: new ArrayBuffer(0),
+            descriptors: [],
+            properties: { write: true },
+            permissions: { write: true },
+          }],
+        });
+        server.on('characteristicWrite', (req: ble.CharacteristicWriteRequest) => {
+          this.handleWrite(req);
+        });
+        server.on('connectionStateChange', (state: ble.BLEConnectionChangeState) => {
+          hilog.info(DOMAIN, TAG, `connection state: ${state.state}`);
+          // 建连/断连均重置接收状态机: 断连可能发生在批次中途, 残留分片不得跨连接拼入
+          this.resetReceive();
+          try {
+            hilog.info(DOMAIN, TAG, `pair state: ${connection.getPairState(state.deviceId)}`);
+          } catch (err) {
+            let e: BusinessError = err as BusinessError;
+            hilog.warn(e.code, TAG, `getPairState failed: ${e.message}`);
+          }
+        });
+        this.gattServer = server;
+        // 设备名走广播响应包(scan response): legacy 广播包 31 字节限制下,
+        // 主包放 128 位服务 UUID, 名字放响应包(扫描端聚合后经 serviceDataMap 读取)
+        const nameBytes = new util.TextEncoder().encodeInto(BLE_ADV_DEVICE_NAME);
+        ble.startAdvertising(
+          { interval: 100, txPower: 0, connectable: true },
+          { serviceUuids: [BLE_SERVICE_UUID], manufactureData: [], serviceData: [] },
+          {
+            serviceUuids: [], manufactureData: [],
+            serviceData: [{ serviceUuid: BLE_NAME_UUID, serviceValue: nameBytes.buffer as ArrayBuffer }]
+          }
+        );
+        // 配对状态订阅: 仅日志记录(配对发起顺序两端可能不同步, 服务器端不做强制拦截);
+        // 全局监听仅在启动成功后注册一次, 与 stop 的注销成对
+        connection.on('bondStateChange', (data: connection.BondStateParam) => {
+          hilog.info(DOMAIN, TAG, `bond state change: ${data.deviceId} -> ${data.state}`);
+        });
+        hilog.info(DOMAIN, TAG, 'BLE server started, advertising token receive service');
+        return;
+      } catch (err) {
+        let e: BusinessError = err as BusinessError;
+        hilog.error(e.code, TAG, `BleTokenServer.start attempt ${attempt} failed: ${e.message}`);
+        // 清理本次尝试已创建的实例/监听/广播, 避免重试路径泄漏
+        if (server) {
+          try {
+            server.off('characteristicWrite');
+            server.off('connectionStateChange');
+            server.close();
+          } catch (cleanupErr) {
+            let ce: BusinessError = cleanupErr as BusinessError;
+            hilog.warn(ce.code, TAG, `gatt server cleanup failed: ${ce.message}`);
+          }
+        }
+        try {
+          ble.stopAdvertising();
+        } catch (cleanupErr) {
+          // 未开始广播时 stop 会抛错, 忽略
+        }
+        this.gattServer = undefined;
+        if (attempt < 4) {
+          await new Promise<void>((resolve) => setTimeout(resolve, 1000));
+        }
+      }
+    }
+  }
+
+  /**
+   * 停止广播并释放监听(与 start 注册一一成对注销).
+   */
+  public async stop(): Promise<void> {
+    try {
+      ble.stopAdvertising();
+      connection.off('bondStateChange');
+      if (this.gattServer) {
+        this.gattServer.off('characteristicWrite');
+        this.gattServer.off('connectionStateChange');
+        this.gattServer.close();
+        this.gattServer = undefined;
+      }
+      this.resetReceive();
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.error(e.code, TAG, `BleTokenServer.stop failed: ${e.message}`);
+    }
+  }
+
+  /** 重置接收状态机: 丢弃未完整接收的批次残留 */
+  private resetReceive(): void {
+    this.receive = BleTokenServer.newReceiveState();
+  }
+
+  /**
+   * 分片协议接收: 首帧为头 JSON, 之后为数据分片, 收满后重组分发.
+   * 头帧到达即视为新批次开始(重置接收状态), 并上报"接收中"状态.
+   * 收尾帧(收满 total)的写应答延后到处理完成后回发, 使手机端拿到真实入库结果.
+   */
+  private handleWrite(req: ble.CharacteristicWriteRequest): void {
+    let batchComplete = false;
+    try {
+      const bytes: Uint8Array = new Uint8Array(req.value);
+      if (!this.receive.inProgress) {
+        // 首帧: 头 JSON {"total":N,"count":M,"type":T}
+        const decoder = new util.TextDecoder('utf-8');
+        const header = JSON.parse(decoder.decodeToString(bytes)) as TransferHeader;
+        if (header.total <= 0 || header.total > MAX_RECEIVE) {
+          hilog.error(DOMAIN, TAG, `invalid transfer header: ${JSON.stringify(header)}`);
+          this.resetReceive();
+          this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
+          this.sendWriteResponse(req, false);
+          return;
+        }
+        this.receive = {
+          inProgress: true, total: header.total, count: header.count,
+          type: header.type ?? MSG_TYPE_TOKENS, received: 0, chunks: []
+        };
+        this.onSyncStatus?.(BleSyncStatus.RECEIVING, 0);
+        hilog.info(DOMAIN, TAG, `receive start: total=${header.total}, count=${header.count}, type=${this.receive.type}`);
+      } else {
+        this.receive.chunks.push(bytes);
+        this.receive.received += bytes.byteLength;
+        if (this.receive.received >= this.receive.total) {
+          batchComplete = true;
+        }
+      }
+      if (batchComplete) {
+        // 收尾帧: 应答延后到处理完成(成功 status 0 / 失败非 0), 手机端据此给出真实反馈
+        this.assembleAndSave(req);
+      } else {
+        // 非收尾帧: GATT 写事务必须有响应, 否则客户端写入会阻塞直至超时失败
+        this.sendWriteResponse(req, true);
+      }
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.error(e.code, TAG, `handleWrite failed: ${e.message}`);
+      this.resetReceive();
+      this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
+      this.sendWriteResponse(req, false);
+    }
+  }
+
+  /** 回发写应答: status 0 表示成功, 非 0 使手机端写入失败(真实结果反馈) */
+  private sendWriteResponse(req: ble.CharacteristicWriteRequest, success: boolean): void {
+    if (!req.needRsp || !this.gattServer) {
+      return;
+    }
+    try {
+      this.gattServer.sendResponse({
+        deviceId: req.deviceId,
+        transId: req.transId,
+        status: success ? 0 : 1,
+        offset: req.offset,
+        value: new ArrayBuffer(0),
+      });
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.warn(e.code, TAG, `sendResponse failed: ${e.message}`);
+    }
+  }
+
+  /**
+   * 重组全部数据分片, 解密后按 type 分发: 令牌走共享入库, 设置走共享应用.
+   * 分片先快照到局部变量并立即重置接收状态机(后续新批次可立即开始, 互不残留),
+   * 重组/解密/处理的任何失败路径均上报失败并丢弃本批次, 收尾帧回失败应答.
+   *
+   * @param finalReq 收尾帧写请求(处理完成后回发应答; 无则静默处理)
+   */
+  private async assembleAndSave(finalReq?: ble.CharacteristicWriteRequest): Promise<void> {
+    const chunks: Array<Uint8Array> = this.receive.chunks;
+    const total: number = this.receive.total;
+    const msgType: string = this.receive.type;
+    this.resetReceive();
+    let ok = false;
+    try {
+      const full: Uint8Array = new Uint8Array(total);
+      let offset: number = 0;
+      for (let i = 0; i < chunks.length; i++) {
+        full.set(chunks[i], offset);
+        offset += chunks[i].byteLength;
+      }
+      if (offset !== total) {
+        // 分片总量与头不符(交叠写入/异常发送方): 判失败, 丢弃本批次
+        hilog.error(DOMAIN, TAG, `chunk size mismatch: got ${offset}, expect ${total}`);
+        this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
+        return;
+      }
+      // 应用层解密(AES-256-GCM): 失败视为载荷被篡改或密钥版本不匹配, 丢弃且不入库
+      const plain: Uint8Array | null = await decryptBlePayload(full);
+      if (plain === null) {
+        hilog.error(DOMAIN, TAG, 'decryptBlePayload failed: data may be tampered or key version mismatch, discarding');
+        this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
+        return;
+      }
+      const decoder = new util.TextDecoder('utf-8');
+      if (msgType === MSG_TYPE_SETTINGS) {
+        const pairs = JSON.parse(decoder.decodeToString(plain)) as Array<SettingValuePair>;
+        await applyWearSettings(pairs);
+        this.onSettingsApplied?.();
+      } else {
+        const tokens = JSON.parse(decoder.decodeToString(plain)) as TokenConfig[];
+        hilog.info(DOMAIN, TAG, `received ${tokens.length} tokens, saving...`);
+        const saved = await saveTokensBatch(tokens);
+        this.onTokensSaved?.(saved);
+        this.onSyncStatus?.(BleSyncStatus.SUCCESS, saved);
+      }
+      ok = true;
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.error(e.code, TAG, `assembleAndSave failed: ${e.message}`);
+      this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
+    } finally {
+      if (finalReq) {
+        this.sendWriteResponse(finalReq, ok);
+      }
+    }
+  }
+}
+
+/**
+ * 手机端 BLE GATT Client: 扫描手表服务 → 连接 → 分片写入令牌数据.
+ */
+export class BleTokenClient {
+  private static instance: BleTokenClient;
+  private gattClient: ble.GattClientDevice | undefined = undefined;
+  private found: Map<string, ble.ScanResult> = new Map();
+  private onDevicesChanged: ((devices: Array<ble.ScanResult>) => void) | undefined = undefined;
+  private onConnectionChanged: ((deviceId: string, connected: boolean) => void) | undefined = undefined;
+  /** 当前连接的设备ID(配对门禁用) */
+  private currentDeviceId: string = '';
+  /** 设备配对状态缓存(deviceId → bonded) */
+  private bonded: Map<string, boolean> = new Map();
+  private onPairChanged: ((deviceId: string, bonded: boolean) => void) | undefined = undefined;
+  private onPairFailed: ((deviceId: string) => void) | undefined = undefined;
+
+  public static getInstance(): BleTokenClient {
+    if (!BleTokenClient.instance) {
+      BleTokenClient.instance = new BleTokenClient();
+    }
+    return BleTokenClient.instance;
+  }
+
+  /** 扫描结果变化回调(UI 刷新设备列表用); 传 undefined 注销 */
+  public setOnDevicesChanged(cb: ((devices: Array<ble.ScanResult>) => void) | undefined): void {
+    this.onDevicesChanged = cb;
+  }
+
+  /** 连接状态变化回调; 传 undefined 注销 */
+  public setOnConnectionChanged(cb: ((deviceId: string, connected: boolean) => void) | undefined): void {
+    this.onConnectionChanged = cb;
+  }
+
+  /** 配对状态变化回调(UI 配对提示用); 传 undefined 注销 */
+  public setOnPairChanged(cb: ((deviceId: string, bonded: boolean) => void) | undefined): void {
+    this.onPairChanged = cb;
+  }
+
+  /** 配对流程失败回调(用户取消/系统拒绝, UI 提示重试用); 传 undefined 注销 */
+  public setOnPairFailed(cb: ((deviceId: string) => void) | undefined): void {
+    this.onPairFailed = cb;
+  }
+
+  /** 当前扫描到的设备(按 deviceId 去重) */
+  public getFoundDevices(): Array<ble.ScanResult> {
+    return Array.from(this.found.values());
+  }
+
+  /** 清空扫描结果(重新扫描前调用, 避免展示陈旧广播) */
+  public clearFoundDevices(): void {
+    this.found.clear();
+    this.onDevicesChanged?.(this.getFoundDevices());
+  }
+
+  /**
+   * 开始扫描(按服务 UUID 过滤, 只发现手表).
+   * 监听注册与 stopScan 的注销一一成对.
+   *
+   * @returns 扫描是否成功启动(蓝牙未就绪等失败返回 false, 调用方复位扫描态)
+   */
+  public startScan(): boolean {
+    try {
+      ble.on('BLEDeviceFind', (results: Array<ble.ScanResult>) => {
+        for (let i = 0; i < results.length; i++) {
+          this.found.set(results[i].deviceId, results[i]);
+        }
+        this.onDevicesChanged?.(this.getFoundDevices());
+      });
+      // 配对状态订阅: 生命周期与扫描一致(页面存活期间持续监听)
+      connection.on('bondStateChange', (data: connection.BondStateParam) => {
+        const isBonded: boolean = data.state === connection.BondState.BOND_STATE_BONDED;
+        this.bonded.set(data.deviceId, isBonded);
+        hilog.info(DOMAIN, TAG, `client bond state: ${data.deviceId} -> ${isBonded}`);
+        this.onPairChanged?.(data.deviceId, isBonded);
+      });
+      ble.startBLEScan([{ serviceUuid: BLE_SERVICE_UUID }], { interval: 100 });
+      hilog.info(DOMAIN, TAG, 'BLE scan started');
+      return true;
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.error(e.code, TAG, `startScan failed: ${e.message}`);
+      return false;
+    }
+  }
+
+  /**
+   * 停止扫描并注销监听(与 startScan 注册一一成对注销).
+   */
+  public stopScan(): void {
+    try {
+      ble.stopBLEScan();
+      ble.off('BLEDeviceFind');
+      connection.off('bondStateChange');
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.error(e.code, TAG, `stopScan failed: ${e.message}`);
+    }
+  }
+
+  /**
+   * 确保设备已完成系统 BLE 配对(bonded); 未配对调用 connection.pairDevice 拉起
+   * 系统配对流程(配对对话框由系统弹出, 手表端自动弹确认).
+   *
+   * @throws 配对失败(用户取消/系统拒绝)时抛出, 由调用方决定反馈方式
+   */
+  private async ensureBonded(deviceId: string): Promise<void> {
+    try {
+      if (connection.getPairState(deviceId) === connection.BondState.BOND_STATE_BONDED) {
+        this.bonded.set(deviceId, true);
+        this.onPairChanged?.(deviceId, true);
+        return;
+      }
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.warn(e.code, TAG, `getPairState failed: ${e.message}`);
+    }
+    await connection.pairDevice(deviceId);
+    this.bonded.set(deviceId, true);
+    this.onPairChanged?.(deviceId, true);
+    hilog.info(DOMAIN, TAG, `paired with ${deviceId}`);
+  }
+
+  /**
+   * 重新发起系统配对(配对失败后的重试入口, 需已连接该设备).
+   *
+   * @throws 配对流程再次失败时抛出
+   */
+  public async retryPairing(deviceId: string): Promise<void> {
+    if (this.gattClient === undefined || this.currentDeviceId !== deviceId) {
+      throw new Error('BLE device not connected');
+    }
+    this.bonded.set(deviceId, false);
+    await this.ensureBonded(deviceId);
+  }
+
+  /**
+   * 释放旧 GATT Client: 注销监听 → 断开 → close(注销设备并清理回调).
+   * 切换设备/页面退出时必须先释放, 避免 GATT 连接与监听泄漏.
+   */
+  private releaseClient(): void {
+    if (!this.gattClient) {
+      return;
+    }
+    try {
+      this.gattClient.off('BLEConnectionStateChange');
+      this.gattClient.disconnect();
+      this.gattClient.close();
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.warn(e.code, TAG, `release gatt client failed: ${e.message}`);
+    }
+    this.gattClient = undefined;
+  }
+
+  /** 当前是否已连接指定设备 */
+  public isConnected(deviceId: string): boolean {
+    return this.gattClient !== undefined && this.currentDeviceId === deviceId;
+  }
+
+  /**
+   * 连接指定设备(先释放旧连接).
+   */
+  public connect(deviceId: string): void {
+    try {
+      this.releaseClient();
+      this.currentDeviceId = deviceId;
+      const client: ble.GattClientDevice = ble.createGattClientDevice(deviceId);
+      client.on('BLEConnectionStateChange', (state: ble.BLEConnectionChangeState) => {
+        const connected: boolean = state.state === constant.ProfileConnectionState.STATE_CONNECTED;
+        hilog.info(DOMAIN, TAG, `client connection state: ${state.state}`);
+        if (connected) {
+          // 连接后协商更大 MTU, 使 480 字节分片写入可行(setBLEMtuSize 为同步接口)
+          try {
+            client.setBLEMtuSize(512);
+          } catch (mtuErr) {
+            let me: BusinessError = mtuErr as BusinessError;
+            hilog.warn(me.code, TAG, `setBLEMtuSize failed: ${me.message}`);
+          }
+          // 连接成功后确保系统配对(bonded), 未配对则拉起系统配对流程;
+          // 配对失败(用户取消/系统拒绝)回调 onPairFailed 供 UI 提示重试
+          this.ensureBonded(deviceId).catch((err: BusinessError) => {
+            hilog.error(err.code, TAG, `ensureBonded failed: ${err.message}`);
+            this.bonded.set(deviceId, false);
+            this.onPairChanged?.(deviceId, false);
+            this.onPairFailed?.(deviceId);
+          });
+        }
+        this.onConnectionChanged?.(deviceId, connected);
+      });
+      this.gattClient = client;
+      client.connect();
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.error(e.code, TAG, `connect failed: ${e.message}`);
+      this.gattClient = undefined;
+      this.onConnectionChanged?.(deviceId, false);
+    }
+  }
+
+  /**
+   * 断开当前连接并释放客户端(与 connect 的监听/连接成对清理).
+   */
+  public disconnect(): void {
+    this.releaseClient();
+    if (this.currentDeviceId !== '') {
+      this.onConnectionChanged?.(this.currentDeviceId, false);
+      this.currentDeviceId = '';
+    }
+  }
+
+  /**
+   * 分片写入令牌数据: 首帧头 + 数据分片, 逐帧等待写入完成保证顺序.
+   *
+   * @param tokens 要传输的令牌列表
+   * @throws 未连接/未配对或写入失败(含手表端处理失败的非 0 应答)时抛出
+   */
+  public async sendTokens(tokens: TokenConfig[]): Promise<void> {
+    const encoder = new util.TextEncoder();
+    await this.sendPayload(encoder.encodeInto(JSON.stringify(tokens)), tokens.length, MSG_TYPE_TOKENS);
+  }
+
+  /**
+   * 同步设置到手表: 读取 WEAR_SYNC_PREF_KEYS 白名单键的当前值, 加密后分片传输.
+   *
+   * @throws 未连接/未配对或写入失败(含手表端处理失败的非 0 应答)时抛出
+   */
+  public async sendSettings(): Promise<void> {
+    const pairs: Array<SettingValuePair> = [];
+    for (let i = 0; i < WEAR_SYNC_PREF_KEYS.length; i++) {
+      pairs.push({ key: WEAR_SYNC_PREF_KEYS[i], value: AppPreference.getPreference(WEAR_SYNC_PREF_KEYS[i]) });
+    }
+    const encoder = new util.TextEncoder();
+    await this.sendPayload(encoder.encodeInto(JSON.stringify(pairs)), pairs.length, MSG_TYPE_SETTINGS);
+    hilog.info(DOMAIN, TAG, `sendSettings done: ${pairs.length} keys`);
+  }
+
+  /**
+   * 分片协议公共实现: 配对门禁 → 服务发现 → 应用层加密 → 首帧头(type) → 数据分片.
+   */
+  private async sendPayload(plain: Uint8Array, count: number, type: string): Promise<void> {
+    if (!this.gattClient) {
+      throw new Error('BLE client not connected');
+    }
+    // 配对门禁: 系统 BLE 配对(bonded)后才允许传输 secret/设置载荷
+    if (!this.bonded.get(this.currentDeviceId)) {
+      throw new Error('BLE device not bonded, pair first');
+    }
+    // 服务发现, 确认对端特征存在(超时保护: 连接断开时可能挂起)
+    const services: Array<ble.GattService> =
+      await withTimeout(this.gattClient.getServices(), GATT_OP_TIMEOUT_MS, 'BLE getServices timeout');
+    hilog.info(DOMAIN, TAG, `services discovered: ${services.length}`);
+
+    const encoder = new util.TextEncoder();
+    // 应用层加密(AES-256-GCM): 载荷格式 [MAGIC][iv][tag][ciphertext], 分片协议不变
+    const encrypted: Uint8Array = await encryptBlePayload(plain);
+    const total: number = encrypted.byteLength;
+
+    // 首帧: 头 {"total":N,"count":M,"type":T}
+    const headerBytes: Uint8Array = encoder.encodeInto(JSON.stringify({ total: total, count: count, type: type }));
+    await this.writeFrame(headerBytes);
+
+    // 数据分片
+    let offset: number = 0;
+    while (offset < total) {
+      const end: number = Math.min(offset + MAX_CHUNK, total);
+      const chunk: Uint8Array = new Uint8Array(end - offset);
+      chunk.set(encrypted.subarray(offset, end));
+      await this.writeFrame(chunk);
+      offset = end;
+    }
+    hilog.info(DOMAIN, TAG, `sendPayload done: type=${type}, count=${count}, ${total} encrypted bytes`);
+  }
+
+  private async writeFrame(data: Uint8Array): Promise<void> {
+    const buf: ArrayBuffer = new ArrayBuffer(data.byteLength);
+    new Uint8Array(buf).set(data);
+    const characteristic: ble.BLECharacteristic = {
+      serviceUuid: BLE_SERVICE_UUID,
+      characteristicUuid: BLE_CHAR_UUID,
+      characteristicValue: buf,
+      descriptors: [],
+    };
+    // 超时保护: 连接断开/手表锁屏时 GATT 写入 Promise 可能长期挂起,
+    // 无超时会让主线程 await 冻结(THREAD_BLOCK_6S ANR); 超时即失败中断整次传输
+    await withTimeout(
+      this.gattClient!.writeCharacteristicValue(characteristic, ble.GattWriteType.WRITE),
+      GATT_OP_TIMEOUT_MS,
+      'BLE write timeout');
+  }
+}

--- a/common/src/main/ets/utils/BleTokenTransfer.ets
+++ b/common/src/main/ets/utils/BleTokenTransfer.ets
@@ -73,6 +73,12 @@ const MAX_RECEIVE = 512 * 1024;
  * 由调用方提示用户重试. 收尾帧应答延后到处理完成, 5 秒同样覆盖解密/入库耗时.
  */
 const GATT_OP_TIMEOUT_MS = 5000;
+/**
+ * 收尾帧超时(ms): 收尾帧的写应答延后到手表端重组/解密/入库完成, 大批次
+ * (逐条 upsert 含 ASSET 双写)耗时超过单帧 5 秒, 放宽到 15 秒; 超时仍判失败,
+ * 用户重发为幂等覆盖, 无脏数据.
+ */
+const GATT_FINAL_OP_TIMEOUT_MS = 15000;
 
 /**
  * 带超时的 Promise 封装: 超时或操作完成/失败均清理定时器,
@@ -132,6 +138,8 @@ export enum BleSyncStatus {
 export class BleTokenServer {
   private static instance: BleTokenServer;
   private gattServer: ble.GattServer | undefined = undefined;
+  /** 进行中的启动流程(单飞: 并发 start 共享同一结果, 收敛后按需补启) */
+  private startPromise: Promise<void> | undefined = undefined;
   private receive: ReceiveState = BleTokenServer.newReceiveState();
   private onTokensSaved: ((count: number) => void) | undefined = undefined;
   private onSettingsApplied: (() => void) | undefined = undefined;
@@ -166,15 +174,39 @@ export class BleTokenServer {
 
   /**
    * 启动 GATT Server 并开始广播. 幂等: 已启动则直接返回.
-   * 启动竞态保护: 蓝牙权限/开关未就绪时以 5 次 × 1 秒延时重试, 全部失败仅记日志
-   * (调用方 P2P/BLE 并行启动, BLE 失败不得影响 P2P 接收).
-   * 每次失败尝试均注销/close 已创建的 GattServer, 避免重试路径泄漏监听与实例.
+   * 单飞保护: initDataSync 启动重试与页面授权后启动可能并发, 共享同一次启动流程,
+   * 收敛后仍未就绪(如先前无权限、现已授权)再补启, 避免双 GattServer/双广播竞态.
    */
   public async start(): Promise<void> {
     if (this.gattServer) {
       return;
     }
+    if (this.startPromise) {
+      // 等待进行中的启动收敛(可能因蓝牙未就绪而失败), 失败则由本调用补启
+      await this.startPromise;
+    }
+    if (this.gattServer) {
+      return;
+    }
+    this.startPromise = this.doStart();
+    try {
+      await this.startPromise;
+    } finally {
+      this.startPromise = undefined;
+    }
+  }
+
+  /**
+   * 启动重试主体: 蓝牙权限/开关未就绪时以 5 次 × 1 秒延时重试, 全部失败仅记日志
+   * (调用方 P2P/BLE 并行启动, BLE 失败不得影响 P2P 接收).
+   * 每次失败尝试均注销/close 已创建的 GattServer; 每轮尝试前复核就绪态,
+   * 防止并发路径已启动后本循环重复创建覆盖.
+   */
+  private async doStart(): Promise<void> {
     for (let attempt = 0; attempt < 5; attempt++) {
+      if (this.gattServer) {
+        return;
+      }
       let server: ble.GattServer | undefined = undefined;
       try {
         server = ble.createGattServer();
@@ -253,21 +285,29 @@ export class BleTokenServer {
 
   /**
    * 停止广播并释放监听(与 start 注册一一成对注销).
+   * 先置空引用再分段清理: 单段失败(如未广播时 stop 抛错)不影响其余段执行,
+   * 避免滞留死实例使后续 start() 的幂等检查短路.
    */
   public async stop(): Promise<void> {
+    const server = this.gattServer;
+    this.gattServer = undefined;
+    this.resetReceive();
+    if (server) {
+      try {
+        server.off('characteristicWrite');
+        server.off('connectionStateChange');
+        server.close();
+      } catch (err) {
+        let e: BusinessError = err as BusinessError;
+        hilog.warn(e.code, TAG, `release gatt server failed: ${e.message}`);
+      }
+    }
     try {
       ble.stopAdvertising();
       connection.off('bondStateChange');
-      if (this.gattServer) {
-        this.gattServer.off('characteristicWrite');
-        this.gattServer.off('connectionStateChange');
-        this.gattServer.close();
-        this.gattServer = undefined;
-      }
-      this.resetReceive();
     } catch (err) {
       let e: BusinessError = err as BusinessError;
-      hilog.error(e.code, TAG, `BleTokenServer.stop failed: ${e.message}`);
+      hilog.warn(e.code, TAG, `stop advertising failed: ${e.message}`);
     }
   }
 
@@ -296,17 +336,21 @@ export class BleTokenServer {
           this.sendWriteResponse(req, false);
           return;
         }
-        this.receive = {
-          inProgress: true, total: header.total, count: header.count,
-          type: header.type ?? MSG_TYPE_TOKENS, received: 0, chunks: []
-        };
-        this.onSyncStatus?.(BleSyncStatus.RECEIVING, 0);
-        hilog.info(DOMAIN, TAG, `receive start: total=${header.total}, count=${header.count}, type=${this.receive.type}`);
+        this.startBatch(header);
       } else {
-        this.receive.chunks.push(bytes);
-        this.receive.received += bytes.byteLength;
-        if (this.receive.received >= this.receive.total) {
-          batchComplete = true;
+        // 批次中途检测新头帧: 手机端超时中断后立即重试时, 上一半批残留 inProgress,
+        // 新头帧若被当数据分片并入会致本次重试必败; 数据分片为加密随机字节,
+        // 不可能解析出合法头, 解析成功即视为新批次开始(残留丢弃, 干净重启)
+        const retryHeader = this.tryParseHeader(bytes);
+        if (retryHeader !== null) {
+          hilog.warn(DOMAIN, TAG, `stale batch discarded, new batch header received: total=${retryHeader.total}`);
+          this.startBatch(retryHeader);
+        } else {
+          this.receive.chunks.push(bytes);
+          this.receive.received += bytes.byteLength;
+          if (this.receive.received >= this.receive.total) {
+            batchComplete = true;
+          }
         }
       }
       if (batchComplete) {
@@ -323,6 +367,30 @@ export class BleTokenServer {
       this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
       this.sendWriteResponse(req, false);
     }
+  }
+
+  /** 开启新批次: 重置接收状态机并上报"接收中" */
+  private startBatch(header: TransferHeader): void {
+    this.receive = {
+      inProgress: true, total: header.total, count: header.count,
+      type: header.type ?? MSG_TYPE_TOKENS, received: 0, chunks: []
+    };
+    this.onSyncStatus?.(BleSyncStatus.RECEIVING, 0);
+    hilog.info(DOMAIN, TAG, `receive start: total=${header.total}, count=${header.count}, type=${this.receive.type}`);
+  }
+
+  /** 尝试把帧解析为合法传输头(批次中途新头帧检测用); 非头帧/非法头返回 null */
+  private tryParseHeader(bytes: Uint8Array): TransferHeader | null {
+    try {
+      const decoder = new util.TextDecoder('utf-8');
+      const header = JSON.parse(decoder.decodeToString(bytes)) as TransferHeader;
+      if (header && typeof header.total === 'number' && header.total > 0 && header.total <= MAX_RECEIVE) {
+        return header;
+      }
+    } catch (err) {
+      // 加密数据分片解码/解析必然失败, 属正常路径
+    }
+    return null;
   }
 
   /** 回发写应答: status 0 表示成功, 非 0 使手机端写入失败(真实结果反馈) */
@@ -663,19 +731,19 @@ export class BleTokenClient {
     const headerBytes: Uint8Array = encoder.encodeInto(JSON.stringify({ total: total, count: count, type: type }));
     await this.writeFrame(headerBytes);
 
-    // 数据分片
+    // 数据分片(收尾帧用放宽超时: 其应答延后到手表端处理完成)
     let offset: number = 0;
     while (offset < total) {
       const end: number = Math.min(offset + MAX_CHUNK, total);
       const chunk: Uint8Array = new Uint8Array(end - offset);
       chunk.set(encrypted.subarray(offset, end));
-      await this.writeFrame(chunk);
+      await this.writeFrame(chunk, offset + chunk.byteLength >= total);
       offset = end;
     }
     hilog.info(DOMAIN, TAG, `sendPayload done: type=${type}, count=${count}, ${total} encrypted bytes`);
   }
 
-  private async writeFrame(data: Uint8Array): Promise<void> {
+  private async writeFrame(data: Uint8Array, isFinal: boolean = false): Promise<void> {
     const buf: ArrayBuffer = new ArrayBuffer(data.byteLength);
     new Uint8Array(buf).set(data);
     const characteristic: ble.BLECharacteristic = {
@@ -688,7 +756,7 @@ export class BleTokenClient {
     // 无超时会让主线程 await 冻结(THREAD_BLOCK_6S ANR); 超时即失败中断整次传输
     await withTimeout(
       this.gattClient!.writeCharacteristicValue(characteristic, ble.GattWriteType.WRITE),
-      GATT_OP_TIMEOUT_MS,
+      isFinal ? GATT_FINAL_OP_TIMEOUT_MS : GATT_OP_TIMEOUT_MS,
       'BLE write timeout');
   }
 }

--- a/common/src/main/ets/utils/BleTokenTransfer.ets
+++ b/common/src/main/ets/utils/BleTokenTransfer.ets
@@ -181,8 +181,9 @@ export class BleTokenServer {
     if (this.gattServer) {
       return;
     }
-    if (this.startPromise) {
-      // 等待进行中的启动收敛(可能因蓝牙未就绪而失败), 失败则由本调用补启
+    while (this.startPromise) {
+      // 等待进行中的启动收敛(可能因蓝牙未就绪而失败); 收敛后仍就绪则返回,
+      // 失败且未被其他等待方接管时由本调用补启
       await this.startPromise;
     }
     if (this.gattServer) {
@@ -261,14 +262,7 @@ export class BleTokenServer {
         hilog.error(e.code, TAG, `BleTokenServer.start attempt ${attempt} failed: ${e.message}`);
         // 清理本次尝试已创建的实例/监听/广播, 避免重试路径泄漏
         if (server) {
-          try {
-            server.off('characteristicWrite');
-            server.off('connectionStateChange');
-            server.close();
-          } catch (cleanupErr) {
-            let ce: BusinessError = cleanupErr as BusinessError;
-            hilog.warn(ce.code, TAG, `gatt server cleanup failed: ${ce.message}`);
-          }
+          this.releaseGattServer(server);
         }
         try {
           ble.stopAdvertising();
@@ -293,14 +287,7 @@ export class BleTokenServer {
     this.gattServer = undefined;
     this.resetReceive();
     if (server) {
-      try {
-        server.off('characteristicWrite');
-        server.off('connectionStateChange');
-        server.close();
-      } catch (err) {
-        let e: BusinessError = err as BusinessError;
-        hilog.warn(e.code, TAG, `release gatt server failed: ${e.message}`);
-      }
+      this.releaseGattServer(server);
     }
     try {
       ble.stopAdvertising();
@@ -316,6 +303,28 @@ export class BleTokenServer {
     this.receive = BleTokenServer.newReceiveState();
   }
 
+  /** 释放 GattServer 实例: 逐段注销监听并 close, 单段失败不阻断其余段(防句柄滞留) */
+  private releaseGattServer(server: ble.GattServer): void {
+    try {
+      server.off('characteristicWrite');
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.warn(e.code, TAG, `off characteristicWrite failed: ${e.message}`);
+    }
+    try {
+      server.off('connectionStateChange');
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.warn(e.code, TAG, `off connectionStateChange failed: ${e.message}`);
+    }
+    try {
+      server.close();
+    } catch (err) {
+      let e: BusinessError = err as BusinessError;
+      hilog.warn(e.code, TAG, `close gatt server failed: ${e.message}`);
+    }
+  }
+
   /**
    * 分片协议接收: 首帧为头 JSON, 之后为数据分片, 收满后重组分发.
    * 头帧到达即视为新批次开始(重置接收状态), 并上报"接收中"状态.
@@ -326,11 +335,11 @@ export class BleTokenServer {
     try {
       const bytes: Uint8Array = new Uint8Array(req.value);
       if (!this.receive.inProgress) {
-        // 首帧: 头 JSON {"total":N,"count":M,"type":T}
-        const decoder = new util.TextDecoder('utf-8');
-        const header = JSON.parse(decoder.decodeToString(bytes)) as TransferHeader;
-        if (header.total <= 0 || header.total > MAX_RECEIVE) {
-          hilog.error(DOMAIN, TAG, `invalid transfer header: ${JSON.stringify(header)}`);
+        // 首帧: 头 JSON {"total":N,"count":M,"type":T}; 复用 tryParseHeader 校验
+        // (JSON 标量如 "5" 经 typeof 守卫拒绝, 避免写 total=undefined 卡住批次)
+        const header = this.tryParseHeader(bytes);
+        if (header === null) {
+          hilog.error(DOMAIN, TAG, 'invalid transfer header');
           this.resetReceive();
           this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
           this.sendWriteResponse(req, false);
@@ -551,6 +560,14 @@ export class BleTokenClient {
     } catch (err) {
       let e: BusinessError = err as BusinessError;
       hilog.error(e.code, TAG, `startScan failed: ${e.message}`);
+      // 启动失败回滚已注册监听, 避免下次 startScan 重复注册
+      try {
+        ble.off('BLEDeviceFind');
+        connection.off('bondStateChange');
+      } catch (cleanupErr) {
+        let ce: BusinessError = cleanupErr as BusinessError;
+        hilog.warn(ce.code, TAG, `scan listener cleanup failed: ${ce.message}`);
+      }
       return false;
     }
   }

--- a/common/src/main/ets/utils/WearEngineTransfer.ets
+++ b/common/src/main/ets/utils/WearEngineTransfer.ets
@@ -363,13 +363,13 @@ export class WearEngineServer {
     return WearEngineServer.instance;
   }
 
-  /** 注册令牌入库完成回调(UI 提示用) */
-  public setOnTokensSaved(cb: (count: number) => void): void {
+  /** 注册令牌入库完成回调(UI 提示用); 传 undefined 注销 */
+  public setOnTokensSaved(cb: ((count: number) => void) | undefined): void {
     this.onTokensSaved = cb;
   }
 
-  /** 注册设置应用完成回调(UI 提示用) */
-  public setOnSettingsApplied(cb: () => void): void {
+  /** 注册设置应用完成回调(UI 提示用); 传 undefined 注销 */
+  public setOnSettingsApplied(cb: (() => void) | undefined): void {
     this.onSettingsApplied = cb;
   }
 

--- a/common/src/main/ets/utils/WearEngineTransfer.ets
+++ b/common/src/main/ets/utils/WearEngineTransfer.ets
@@ -73,9 +73,57 @@ export const WEAR_SYNC_PREF_KEYS: string[] = [
 ];
 
 /** 设置同步载荷项 */
-interface SettingValuePair {
+export interface SettingValuePair {
   key: string;
   value: SettingValue;
+}
+
+/**
+ * 令牌批次入库(P2P/BLE 两通道共享): 按 issuer+name 匹配本地令牌并复用其 UUID,
+ * 逐条 upsert(内部完成 TokenSecret 双写 ASSET + 加密 KV)后全量重排序.
+ *
+ * 手机端与手表端令牌 UUID 不同(各端独立生成), 直接 updateToken 会按 UUID 判为
+ * 新增导致重复令牌; 复用本地 UUID 同时维持排序/删除等引用的稳定性.
+ *
+ * @returns 入库令牌数
+ */
+export async function saveTokensBatch(tokens: TokenConfig[]): Promise<number> {
+  const tkStore: TokenStore = TokenStore.getInstance();
+  const existing = await tkStore.getTokens();
+  for (let i = 0; i < tokens.length; i++) {
+    for (let j = 0; j < existing.length; j++) {
+      if (existing[j].TokenIssuer === tokens[i].TokenIssuer &&
+        existing[j].TokenName === tokens[i].TokenName) {
+        tokens[i].TokenUUID = existing[j].TokenUUID;
+        break;
+      }
+    }
+  }
+  for (let i = 0; i < tokens.length; i++) {
+    await tkStore.updateToken(tokens[i]);
+  }
+  tkStore.sortTokens();
+  return tokens.length;
+}
+
+/**
+ * 应用手机端下发的设置载荷(P2P/BLE 两通道共享): 仅应用 WEAR_SYNC_PREF_KEYS
+ * 白名单内的键(防手机端扩展键误写入手表), 逐键写入后刷新 TokenPreference
+ * (@Trace 字段), 手表 UI 立即按新设置重绘.
+ *
+ * @returns 实际应用的键数
+ */
+export async function applyWearSettings(pairs: Array<SettingValuePair>): Promise<number> {
+  let applied: number = 0;
+  for (let i = 0; i < pairs.length; i++) {
+    if (WEAR_SYNC_PREF_KEYS.includes(pairs[i].key)) {
+      AppPreference.setPreference(pairs[i].key, pairs[i].value);
+      applied++;
+    }
+  }
+  AppPreference.loadTokenAppearance();
+  hilog.info(DOMAIN, TAG, `wear settings applied: ${applied}/${pairs.length} keys`);
+  return applied;
 }
 
 /**
@@ -489,44 +537,21 @@ export class WearEngineServer {
       const decoder = new util.TextDecoder('utf-8');
       const tokens = JSON.parse(decoder.decodeToString(plain)) as TokenConfig[];
       hilog.info(DOMAIN, TAG, `received ${tokens.length} tokens, saving...`);
-      const tkStore: TokenStore = TokenStore.getInstance();
-      // 已存在令牌覆盖: 按 issuer+name 匹配本地令牌, 复用本地 TokenUUID 更新
-      const existing = await tkStore.getTokens();
-      for (let i = 0; i < tokens.length; i++) {
-        for (let j = 0; j < existing.length; j++) {
-          if (existing[j].TokenIssuer === tokens[i].TokenIssuer &&
-            existing[j].TokenName === tokens[i].TokenName) {
-            tokens[i].TokenUUID = existing[j].TokenUUID;
-            break;
-          }
-        }
-      }
-      for (let i = 0; i < tokens.length; i++) {
-        await tkStore.updateToken(tokens[i]);
-      }
-      tkStore.sortTokens();
-      this.onTokensSaved?.(tokens.length);
+      // 共享入库: issuer+name 覆盖、updateToken(ASSET 双写)、sortTokens
+      const saved = await saveTokensBatch(tokens);
+      this.onTokensSaved?.(saved);
     } catch (err) {
       const e = err as BusinessError;
       hilog.error(e.code, TAG, `assembleAndDispatch failed: ${e.message}`);
     }
   }
 
-  /** 应用手机端下发的设置载荷(白名单过滤后写入手表 Preferences) */
+  /** 应用手机端下发的设置载荷(白名单过滤后写入手表 Preferences, 共享实现) */
   private async applySettings(plain: Uint8Array): Promise<void> {
     try {
       const decoder = new util.TextDecoder('utf-8');
       const pairs = JSON.parse(decoder.decodeToString(plain)) as Array<SettingValuePair>;
-      let applied: number = 0;
-      for (let i = 0; i < pairs.length; i++) {
-        if (WEAR_SYNC_PREF_KEYS.includes(pairs[i].key)) {
-          AppPreference.setPreference(pairs[i].key, pairs[i].value);
-          applied++;
-        }
-      }
-      // 刷新 TokenPreference(@Trace 字段), 手表 UI 立即按新设置重绘
-      AppPreference.loadTokenAppearance();
-      hilog.info(DOMAIN, TAG, `settings applied: ${applied}/${pairs.length} keys`);
+      await applyWearSettings(pairs);
       this.onSettingsApplied?.();
     } catch (err) {
       const e = err as BusinessError;

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -1102,7 +1102,11 @@
     },
     {
       "name": "watch_sync_title",
-      "value": "Watch Sync"
+      "value": "Watch Sync (P2P)"
+    },
+    {
+      "name": "watch_sync_title_ble",
+      "value": "Watch Sync (BLE)"
     },
     {
       "name": "watch_sync_connect_section",
@@ -1121,16 +1125,36 @@
       "value": "Scan"
     },
     {
+      "name": "watch_sync_scan_hint",
+      "value": "Tap scan to find nearby watch"
+    },
+    {
       "name": "watch_sync_scanning",
       "value": "Scanning…"
+    },
+    {
+      "name": "watch_sync_connecting",
+      "value": "Connecting…"
     },
     {
       "name": "watch_sync_connect",
       "value": "Connect"
     },
     {
+      "name": "watch_sync_pairing",
+      "value": "Pairing… confirm on the watch if prompted"
+    },
+    {
+      "name": "watch_sync_pair_failed",
+      "value": "Pairing failed, try again"
+    },
+    {
       "name": "watch_sync_not_connected_warn",
       "value": "Connect a watch first"
+    },
+    {
+      "name": "watch_sync_watch_not_ready",
+      "value": "Watch app not ready, try again"
     },
     {
       "name": "watch_sync_token_list",
@@ -1174,15 +1198,27 @@
     },
     {
       "name": "setting_watch_sync",
-      "value": "Watch Sync"
+      "value": "Watch Sync (P2P)"
+    },
+    {
+      "name": "setting_watch_sync_ble",
+      "value": "Watch Sync (BLE)"
     },
     {
       "name": "app_wearable_ble_waiting",
       "value": "Waiting for phone sync"
     },
     {
+      "name": "app_wearable_ble_receiving",
+      "value": "Receiving tokens…"
+    },
+    {
       "name": "app_wearable_ble_received",
       "value": "Tokens received, refreshing"
+    },
+    {
+      "name": "app_wearable_ble_failed",
+      "value": "Receive failed, resend from phone"
     },
     {
       "name": "app_wearable_ble_settings_done",

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -1125,32 +1125,12 @@
       "value": "Scanning…"
     },
     {
-      "name": "watch_sync_scan_hint",
-      "value": "Tap scan to find nearby watch"
-    },
-    {
       "name": "watch_sync_connect",
       "value": "Connect"
     },
     {
-      "name": "watch_sync_reconnect",
-      "value": "Reconnect"
-    },
-    {
-      "name": "watch_sync_connecting",
-      "value": "Connecting…"
-    },
-    {
       "name": "watch_sync_not_connected_warn",
       "value": "Connect a watch first"
-    },
-    {
-      "name": "watch_sync_pairing",
-      "value": "Pairing… confirm on the watch if prompted"
-    },
-    {
-      "name": "watch_sync_pair_failed",
-      "value": "Pairing failed, try again"
     },
     {
       "name": "watch_sync_token_list",
@@ -1207,10 +1187,6 @@
     {
       "name": "app_wearable_ble_settings_done",
       "value": "Settings synced"
-    },
-    {
-      "name": "app_wearable_ble_server_failed",
-      "value": "BLE receive service failed"
     },
     {
       "name": "ble_access_permission_reason",

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -1110,7 +1110,11 @@
     },
     {
       "name": "watch_sync_title",
-      "value": "Watch Sync"
+      "value": "Watch Sync (P2P)"
+    },
+    {
+      "name": "watch_sync_title_ble",
+      "value": "Watch Sync (BLE)"
     },
     {
       "name": "watch_sync_connect_section",
@@ -1129,16 +1133,36 @@
       "value": "Scan"
     },
     {
+      "name": "watch_sync_scan_hint",
+      "value": "Tap scan to find nearby watch"
+    },
+    {
       "name": "watch_sync_scanning",
       "value": "Scanning…"
+    },
+    {
+      "name": "watch_sync_connecting",
+      "value": "Connecting…"
     },
     {
       "name": "watch_sync_connect",
       "value": "Connect"
     },
     {
+      "name": "watch_sync_pairing",
+      "value": "Pairing… confirm on the watch if prompted"
+    },
+    {
+      "name": "watch_sync_pair_failed",
+      "value": "Pairing failed, try again"
+    },
+    {
       "name": "watch_sync_not_connected_warn",
       "value": "Connect a watch first"
+    },
+    {
+      "name": "watch_sync_watch_not_ready",
+      "value": "Watch app not ready, try again"
     },
     {
       "name": "watch_sync_token_list",
@@ -1182,15 +1206,27 @@
     },
     {
       "name": "setting_watch_sync",
-      "value": "Watch Sync"
+      "value": "Watch Sync (P2P)"
+    },
+    {
+      "name": "setting_watch_sync_ble",
+      "value": "Watch Sync (BLE)"
     },
     {
       "name": "app_wearable_ble_waiting",
       "value": "Waiting for phone sync"
     },
     {
+      "name": "app_wearable_ble_receiving",
+      "value": "Receiving tokens…"
+    },
+    {
       "name": "app_wearable_ble_received",
       "value": "Tokens received, refreshing"
+    },
+    {
+      "name": "app_wearable_ble_failed",
+      "value": "Receive failed, resend from phone"
     },
     {
       "name": "app_wearable_ble_settings_done",

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -1133,32 +1133,12 @@
       "value": "Scanning…"
     },
     {
-      "name": "watch_sync_scan_hint",
-      "value": "Tap scan to find nearby watch"
-    },
-    {
       "name": "watch_sync_connect",
       "value": "Connect"
     },
     {
-      "name": "watch_sync_reconnect",
-      "value": "Reconnect"
-    },
-    {
-      "name": "watch_sync_connecting",
-      "value": "Connecting…"
-    },
-    {
       "name": "watch_sync_not_connected_warn",
       "value": "Connect a watch first"
-    },
-    {
-      "name": "watch_sync_pairing",
-      "value": "Pairing… confirm on the watch if prompted"
-    },
-    {
-      "name": "watch_sync_pair_failed",
-      "value": "Pairing failed, try again"
     },
     {
       "name": "watch_sync_token_list",
@@ -1215,10 +1195,6 @@
     {
       "name": "app_wearable_ble_settings_done",
       "value": "Settings synced"
-    },
-    {
-      "name": "app_wearable_ble_server_failed",
-      "value": "BLE receive service failed"
     },
     {
       "name": "ble_access_permission_reason",

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -1110,7 +1110,11 @@
     },
     {
       "name": "watch_sync_title",
-      "value": "手表同步"
+      "value": "手表同步（P2P）"
+    },
+    {
+      "name": "watch_sync_title_ble",
+      "value": "手表同步（BLE）"
     },
     {
       "name": "watch_sync_connect_section",
@@ -1129,16 +1133,36 @@
       "value": "扫描"
     },
     {
+      "name": "watch_sync_scan_hint",
+      "value": "点击扫描查找附近手表"
+    },
+    {
       "name": "watch_sync_scanning",
       "value": "扫描中…"
+    },
+    {
+      "name": "watch_sync_connecting",
+      "value": "连接中…"
     },
     {
       "name": "watch_sync_connect",
       "value": "连接"
     },
     {
+      "name": "watch_sync_pairing",
+      "value": "配对中…若手表弹出确认请在手表上确认"
+    },
+    {
+      "name": "watch_sync_pair_failed",
+      "value": "配对失败，请重试"
+    },
+    {
       "name": "watch_sync_not_connected_warn",
       "value": "请先连接手表"
+    },
+    {
+      "name": "watch_sync_watch_not_ready",
+      "value": "手表端未就绪，请重试"
     },
     {
       "name": "watch_sync_token_list",
@@ -1182,15 +1206,27 @@
     },
     {
       "name": "setting_watch_sync",
-      "value": "手表同步"
+      "value": "手表同步（P2P）"
+    },
+    {
+      "name": "setting_watch_sync_ble",
+      "value": "手表同步（BLE）"
     },
     {
       "name": "app_wearable_ble_waiting",
       "value": "等待手机端同步"
     },
     {
+      "name": "app_wearable_ble_receiving",
+      "value": "正在接收令牌…"
+    },
+    {
       "name": "app_wearable_ble_received",
       "value": "已接收令牌，正在刷新"
+    },
+    {
+      "name": "app_wearable_ble_failed",
+      "value": "接收失败，请在手机端重发"
     },
     {
       "name": "app_wearable_ble_settings_done",

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -1133,32 +1133,12 @@
       "value": "扫描中…"
     },
     {
-      "name": "watch_sync_scan_hint",
-      "value": "点击扫描查找附近手表"
-    },
-    {
       "name": "watch_sync_connect",
       "value": "连接"
     },
     {
-      "name": "watch_sync_reconnect",
-      "value": "重连"
-    },
-    {
-      "name": "watch_sync_connecting",
-      "value": "连接中…"
-    },
-    {
       "name": "watch_sync_not_connected_warn",
       "value": "请先连接手表"
-    },
-    {
-      "name": "watch_sync_pairing",
-      "value": "配对中…若手表弹出确认请在手表上确认"
-    },
-    {
-      "name": "watch_sync_pair_failed",
-      "value": "配对失败，请重试"
     },
     {
       "name": "watch_sync_token_list",
@@ -1215,10 +1195,6 @@
     {
       "name": "app_wearable_ble_settings_done",
       "value": "设置已同步"
-    },
-    {
-      "name": "app_wearable_ble_server_failed",
-      "value": "蓝牙接收服务启动失败"
     },
     {
       "name": "ble_access_permission_reason",

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -1133,32 +1133,12 @@
       "value": "掃描中…"
     },
     {
-      "name": "watch_sync_scan_hint",
-      "value": "點擊掃描查找附近手錶"
-    },
-    {
       "name": "watch_sync_connect",
       "value": "連接"
     },
     {
-      "name": "watch_sync_reconnect",
-      "value": "重新連接"
-    },
-    {
-      "name": "watch_sync_connecting",
-      "value": "連接中…"
-    },
-    {
       "name": "watch_sync_not_connected_warn",
       "value": "請先連接手錶"
-    },
-    {
-      "name": "watch_sync_pairing",
-      "value": "配對中…若手錶彈出確認請在手錶上確認"
-    },
-    {
-      "name": "watch_sync_pair_failed",
-      "value": "配對失敗，請重試"
     },
     {
       "name": "watch_sync_token_list",
@@ -1215,10 +1195,6 @@
     {
       "name": "app_wearable_ble_settings_done",
       "value": "設定已同步"
-    },
-    {
-      "name": "app_wearable_ble_server_failed",
-      "value": "藍牙接收服務啟動失敗"
     },
     {
       "name": "ble_access_permission_reason",

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -1110,7 +1110,11 @@
     },
     {
       "name": "watch_sync_title",
-      "value": "手錶同步"
+      "value": "手錶同步（P2P）"
+    },
+    {
+      "name": "watch_sync_title_ble",
+      "value": "手錶同步（BLE）"
     },
     {
       "name": "watch_sync_connect_section",
@@ -1129,16 +1133,36 @@
       "value": "掃描"
     },
     {
+      "name": "watch_sync_scan_hint",
+      "value": "點擊掃描查找附近手錶"
+    },
+    {
       "name": "watch_sync_scanning",
       "value": "掃描中…"
+    },
+    {
+      "name": "watch_sync_connecting",
+      "value": "連線中…"
     },
     {
       "name": "watch_sync_connect",
       "value": "連接"
     },
     {
+      "name": "watch_sync_pairing",
+      "value": "配對中…若手錶彈出確認請在手錶上確認"
+    },
+    {
+      "name": "watch_sync_pair_failed",
+      "value": "配對失敗，請重試"
+    },
+    {
       "name": "watch_sync_not_connected_warn",
       "value": "請先連接手錶"
+    },
+    {
+      "name": "watch_sync_watch_not_ready",
+      "value": "手錶端未就緒，請重試"
     },
     {
       "name": "watch_sync_token_list",
@@ -1182,15 +1206,27 @@
     },
     {
       "name": "setting_watch_sync",
-      "value": "手錶同步"
+      "value": "手錶同步（P2P）"
+    },
+    {
+      "name": "setting_watch_sync_ble",
+      "value": "手錶同步（BLE）"
     },
     {
       "name": "app_wearable_ble_waiting",
       "value": "等待手機端同步"
     },
     {
+      "name": "app_wearable_ble_receiving",
+      "value": "正在接收令牌…"
+    },
+    {
       "name": "app_wearable_ble_received",
       "value": "已接收令牌，正在刷新"
+    },
+    {
+      "name": "app_wearable_ble_failed",
+      "value": "接收失敗，請在手機端重發"
     },
     {
       "name": "app_wearable_ble_settings_done",

--- a/entry/src/main/ets/components/TokenItem.ets
+++ b/entry/src/main/ets/components/TokenItem.ets
@@ -445,6 +445,12 @@ export struct TokenItem {
                 .color(this.TokenLeftPeriod <= this.token_color_change_threshold ?
                   this.token_progress_color_near_next :
                   this.token_progress_color_normal)
+              // 线性进度没有右侧进度环, 剩余秒数补在进度条下方(与环内数字等价, 避免倒计时不可见)
+              Text(this.TokenLeftPeriod.toString())
+                .textAlign(TextAlign.End)
+                .width(this.tokenNumberWidth)
+                .fontColor($r('app.color.str_gray'))
+                .fontSize(10)
             }
             if (this.Config.TokenType == otpType.HOTP) {
               Text(this.TokenCounter + (this.token_preference.app_appearance_show_next_token_enable ? ":" + this.TokenNumberNext : ""))

--- a/entry/src/main/ets/pages/BleWatchSyncPage.ets
+++ b/entry/src/main/ets/pages/BleWatchSyncPage.ets
@@ -63,6 +63,8 @@ export struct BleWatchSyncPage {
   private scroller: Scroller = new Scroller();
   /** 建连超时定时器 ID(建连完成/失败与 aboutToDisappear 清理) */
   private connectTimeoutId: number = -1;
+  /** 配对状态轮询定时器 ID(配对成功/失败/断开与 aboutToDisappear 清理) */
+  private pairSyncTimerId: number = -1;
 
   aboutToAppear(): void {
     TokenStore.getInstance().initTokenStore().then(() => {
@@ -85,6 +87,10 @@ export struct BleWatchSyncPage {
       if (connected) {
         this.connectedDeviceId = deviceId;
         this.connectingDeviceId = '';
+        // 配对态以系统查询为准、不依赖回调时序: 连接建立即核对一次,
+        // 仍未 bonded 则启动轮询兜底(见 ensurePairStateSynced)
+        this.bonded = BleTokenClient.getInstance().isCurrentDeviceBonded();
+        this.ensurePairStateSynced(deviceId);
       } else if (this.connectingDeviceId === deviceId) {
         // 建连尝试中收到断开(含对端无响应被协议层拒绝): 立即失败, 不等超时
         this.connectingDeviceId = '';
@@ -94,24 +100,28 @@ export struct BleWatchSyncPage {
         this.connectedDeviceId = '';
         this.bonded = false;
         this.pairFailed = false;
+        this.clearPairSyncTimer();
       }
     });
-    // 配对状态: 连接后系统拉起配对流程, bonded 后才能传输 secret 载荷
-    BleTokenClient.getInstance().setOnPairChanged((deviceId: string, isBonded: boolean) => {
-      if (deviceId === this.connectedDeviceId || deviceId === this.connectingDeviceId) {
-        this.bonded = isBonded;
-        if (isBonded) {
-          this.pairFailed = false;
-        }
+    // 配对状态: 连接后系统拉起配对流程, bonded 后才能传输 secret 载荷.
+    // 客户端已只转发当前连接设备的事件, 此处不再按 deviceId 严格过滤:
+    // 回调参数与扫描结果的地址表示可能不同(随机/真实地址), 过滤会导致
+    // bonded 更新丢失、页面停留在"配对中"
+    BleTokenClient.getInstance().setOnPairChanged((_deviceId: string, isBonded: boolean) => {
+      this.bonded = isBonded;
+      if (isBonded) {
+        this.pairFailed = false;
+        this.clearPairSyncTimer();
       }
     });
-    // 配对流程失败(用户取消/系统拒绝): 提示并进入"可重试"状态
-    BleTokenClient.getInstance().setOnPairFailed((deviceId: string) => {
-      if (deviceId === this.connectedDeviceId || deviceId === this.connectingDeviceId) {
-        this.bonded = false;
-        this.pairFailed = true;
-        showSnackBar($r('app.string.watch_sync_pair_failed'), SnackBarNotifyType.WARNING);
-      }
+    // 配对流程失败(用户取消/系统拒绝): 提示并进入"可重试"状态.
+    // 该回调仅来自当前建连流程(客户端单连接设计), 与配对态回调同理不做
+    // deviceId 严格过滤, 避免地址表示差异导致"配对失败"提示丢失
+    BleTokenClient.getInstance().setOnPairFailed((_deviceId: string) => {
+      this.bonded = false;
+      this.pairFailed = true;
+      this.clearPairSyncTimer();
+      showSnackBar($r('app.string.watch_sync_pair_failed'), SnackBarNotifyType.WARNING);
     });
   }
 
@@ -155,6 +165,7 @@ export struct BleWatchSyncPage {
 
   aboutToDisappear(): void {
     this.clearConnectTimeout();
+    this.clearPairSyncTimer();
     this.stopScan();
     BleTokenClient.getInstance().disconnect();
     // 注销单例回调, 避免页面销毁后仍被触达
@@ -169,6 +180,44 @@ export struct BleWatchSyncPage {
       clearTimeout(this.connectTimeoutId);
       this.connectTimeoutId = -1;
     }
+  }
+
+  private clearPairSyncTimer(): void {
+    if (this.pairSyncTimerId !== -1) {
+      clearInterval(this.pairSyncTimerId);
+      this.pairSyncTimerId = -1;
+    }
+  }
+
+  /**
+   * 已连接未完成配对期间轮询系统配对状态(兜底): BLE 配对事件偶发缺失时,
+   * 页面会停留在"配对中"且传输被 bonded 门禁拦截. 每 1.5s 查询一次权威
+   * 状态(getPairState), 收敛即停; 20 次(约 30s)后仍无结果则退回事件驱动,
+   * 用户可断开重连触发新一轮核对.
+   */
+  private ensurePairStateSynced(deviceId: string): void {
+    this.clearPairSyncTimer();
+    if (this.bonded) {
+      return;
+    }
+    let tries: number = 0;
+    this.pairSyncTimerId = setInterval(() => {
+      if (this.connectedDeviceId !== deviceId) {
+        // 已断开/切换设备: 停止轮询
+        this.clearPairSyncTimer();
+        return;
+      }
+      if (BleTokenClient.getInstance().isCurrentDeviceBonded()) {
+        this.bonded = true;
+        this.pairFailed = false;
+        this.clearPairSyncTimer();
+        return;
+      }
+      tries++;
+      if (tries >= 20) {
+        this.clearPairSyncTimer();
+      }
+    }, 1500);
   }
 
   /** 设备显示名(广播名 → 响应包自定义名 → 系统已知名 → deviceId 兜底) */

--- a/entry/src/main/ets/pages/BleWatchSyncPage.ets
+++ b/entry/src/main/ets/pages/BleWatchSyncPage.ets
@@ -1,0 +1,582 @@
+import { ble } from '@kit.ConnectivityKit';
+import { hdsMaterial, HdsNavDestination, HdsNavDestinationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
+import { ConfigurationConstant } from '@kit.AbilityKit';
+import { PageScaffold } from '../components/PageScaffold';
+import { SettingItem } from '../components/SettingItem';
+import { SubItemDivider } from '../components/SubItemDivider';
+import { TokenStore, TokenConfig, BleTokenClient, getDeviceDisplayName, BluetoothPermissionResult, WearEngineClient } from 'common';
+import { TokenIcon } from 'uikit';
+import { showSnackBar, SnackBarNotifyType } from 'common';
+import { AppWindowInfo, CommonConstants } from 'common';
+import { AppStorageV2 } from '@kit.ArkUI';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { MaterialSurface } from '../components/MaterialSurface';
+import { MaterialTheme, MaterialThickness } from '../components/MaterialTheme';
+import { SETTING_PAGE_INSET } from '../components/SettingStyle';
+
+const TAG = 'BleWatchSyncPage';
+const DOMAIN = 0xFF02;
+/**
+ * GATT 建连超时保护(ms): 手表端应用未运行/广播未启动时连接事件可能长期不来,
+ * 超时后提示"手表端未就绪"并复位页面状态, 允许立即重试.
+ */
+const CONNECT_TIMEOUT_MS = 8000;
+
+/**
+ * 手表同步(BLE)验证页: 通过 BLE GATT 通道下发令牌与设置到手表.
+ * 与 P2P 页(WatchSyncPage)相互独立: 设备发现走页面可见期 BLE 扫描(按服务 UUID 过滤,
+ * 离开页面即停), 点击设备建连(系统 BLE 配对 + GATT), 传输经分帧写入 + 5 秒操作超时保护.
+ */
+@Entry
+@ComponentV2
+export struct BleWatchSyncPage {
+  pageInfos: NavPathStack | null = null;
+  @Require @Param scrollEffectType: ScrollEffectType = ScrollEffectType.IMMERSIVE_GRADIENT_BLUR;
+  /** 扫描发现的广播设备(按 deviceId 去重) */
+  @Local devices: Array<ble.ScanResult> = [];
+  /** 扫描进行中(由 start/stop 显式管理, 不随单条广播到达翻转) */
+  @Local scanning: boolean = false;
+  /** 当前连接中的设备 ID(建连尝试期间非空) */
+  @Local connectingDeviceId: string = '';
+  @Local connectedDeviceId: string = '';
+  /** 当前设备系统 BLE 配对状态(bonded 后才允许传输 secret 载荷) */
+  @Local bonded: boolean = false;
+  /** 配对流程已失败(区分"配对中"与"配对失败可重试"两种提示) */
+  @Local pairFailed: boolean = false;
+  @Local tokens: TokenConfig[] = [];
+  @Local selectedUuids: string[] = [];
+  @Local transferring: boolean = false;
+  @Local window: AppWindowInfo = AppStorageV2.connect(AppWindowInfo) as AppWindowInfo;
+
+  /** 亮暗模式判定: 浅灰按钮背景在亮色下用深色文字, 暗色下用白色文字 */
+  @Computed
+  get is_dark_mode() {
+    return this.window.ColorMode == ConfigurationConstant.ColorMode.COLOR_MODE_DARK;
+  }
+
+  /** 已建连目标设备(按钮可用态判定) */
+  @Computed
+  get has_connected_device(): boolean {
+    return this.connectedDeviceId !== '';
+  }
+
+  private scroller: Scroller = new Scroller();
+  /** 建连超时定时器 ID(建连完成/失败与 aboutToDisappear 清理) */
+  private connectTimeoutId: number = -1;
+
+  aboutToAppear(): void {
+    TokenStore.getInstance().initTokenStore().then(() => {
+      return TokenStore.getInstance().getTokens();
+    }).then((tokens: TokenConfig[]) => {
+      this.tokens = tokens;
+    }).catch((err: Error) => {
+      hilog.error(DOMAIN, TAG, `load tokens failed: ${err.message}`);
+    });
+    this.registerClientCallbacks();
+  }
+
+  /** 注册 BleTokenClient 单例回调(页面销毁时逐一传 undefined 注销) */
+  private registerClientCallbacks(): void {
+    BleTokenClient.getInstance().setOnDevicesChanged((devices: Array<ble.ScanResult>) => {
+      this.devices = devices;
+    });
+    BleTokenClient.getInstance().setOnConnectionChanged((deviceId: string, connected: boolean) => {
+      this.clearConnectTimeout();
+      if (connected) {
+        this.connectedDeviceId = deviceId;
+        this.connectingDeviceId = '';
+      } else if (this.connectingDeviceId === deviceId) {
+        // 建连尝试中收到断开(含对端无响应被协议层拒绝): 立即失败, 不等超时
+        this.connectingDeviceId = '';
+        showSnackBar($r('app.string.watch_sync_watch_not_ready'), SnackBarNotifyType.WARNING);
+      }
+      if (this.connectedDeviceId === deviceId && !connected) {
+        this.connectedDeviceId = '';
+        this.bonded = false;
+        this.pairFailed = false;
+      }
+    });
+    // 配对状态: 连接后系统拉起配对流程, bonded 后才能传输 secret 载荷
+    BleTokenClient.getInstance().setOnPairChanged((deviceId: string, isBonded: boolean) => {
+      if (deviceId === this.connectedDeviceId || deviceId === this.connectingDeviceId) {
+        this.bonded = isBonded;
+        if (isBonded) {
+          this.pairFailed = false;
+        }
+      }
+    });
+    // 配对流程失败(用户取消/系统拒绝): 提示并进入"可重试"状态
+    BleTokenClient.getInstance().setOnPairFailed((deviceId: string) => {
+      if (deviceId === this.connectedDeviceId || deviceId === this.connectingDeviceId) {
+        this.bonded = false;
+        this.pairFailed = true;
+        showSnackBar($r('app.string.watch_sync_pair_failed'), SnackBarNotifyType.WARNING);
+      }
+    });
+  }
+
+  /**
+   * 页面可见期入口: 先查后申请 ACCESS_BLUETOOTH(受限=系统蓝牙开关未开, 引导开蓝牙),
+   * 授权成功后开始扫描. 挂载在 HdsNavDestination 的 onShown 事件(权限弹窗需 UI 就绪后展示).
+   */
+  private requestPermissionAndStartScan(): void {
+    WearEngineClient.getInstance().requestBluetoothPermission().then((result: BluetoothPermissionResult) => {
+      if (result === BluetoothPermissionResult.GRANTED) {
+        this.startScan();
+      } else if (result === BluetoothPermissionResult.RESTRICTED) {
+        hilog.warn(DOMAIN, TAG, 'ACCESS_BLUETOOTH restricted, guide user to enable bluetooth');
+        showSnackBar($r('app.string.watch_sync_bluetooth_restricted'), SnackBarNotifyType.WARNING);
+      } else {
+        hilog.warn(DOMAIN, TAG, 'ACCESS_BLUETOOTH not granted, skip scan');
+        showSnackBar($r('app.string.watch_sync_bluetooth_permission_denied'), SnackBarNotifyType.WARNING);
+      }
+    });
+  }
+
+  /** 开始扫描(按服务 UUID 过滤; 重新扫描前清空陈旧广播结果; 启动失败复位扫描态) */
+  private startScan(): void {
+    BleTokenClient.getInstance().clearFoundDevices();
+    this.scanning = BleTokenClient.getInstance().startScan();
+  }
+
+  /** 手动刷新: 重启扫描(页面可见期扫描常开, 重启以发现新广播) */
+  private refreshScan(): void {
+    BleTokenClient.getInstance().stopScan();
+    this.startScan();
+  }
+
+  /** 停止扫描(页面不可见/销毁时调用, 控制扫描功耗) */
+  private stopScan(): void {
+    BleTokenClient.getInstance().stopScan();
+    this.scanning = false;
+  }
+
+  aboutToDisappear(): void {
+    this.clearConnectTimeout();
+    this.stopScan();
+    BleTokenClient.getInstance().disconnect();
+    // 注销单例回调, 避免页面销毁后仍被触达
+    BleTokenClient.getInstance().setOnDevicesChanged(undefined);
+    BleTokenClient.getInstance().setOnConnectionChanged(undefined);
+    BleTokenClient.getInstance().setOnPairChanged(undefined);
+    BleTokenClient.getInstance().setOnPairFailed(undefined);
+  }
+
+  private clearConnectTimeout(): void {
+    if (this.connectTimeoutId !== -1) {
+      clearTimeout(this.connectTimeoutId);
+      this.connectTimeoutId = -1;
+    }
+  }
+
+  /** 设备显示名(广播名 → 响应包自定义名 → 系统已知名 → deviceId 兜底) */
+  private deviceDisplayName(device: ble.ScanResult): string {
+    return getDeviceDisplayName(device);
+  }
+
+  /**
+   * 点击设备建连: 连接与配对结果经回调反馈; 手表端未就绪时由断开回调或
+   * 超时保护兜底提示, 两种路径均复位状态允许立即重试.
+   */
+  private connectDevice(device: ble.ScanResult): void {
+    if (this.connectingDeviceId !== '' || this.connectedDeviceId !== '') {
+      return;
+    }
+    this.connectingDeviceId = device.deviceId;
+    this.bonded = false;
+    this.pairFailed = false;
+    BleTokenClient.getInstance().connect(device.deviceId);
+    this.connectTimeoutId = setTimeout(() => {
+      this.connectTimeoutId = -1;
+      if (this.connectingDeviceId === device.deviceId && this.connectedDeviceId === '') {
+        this.connectingDeviceId = '';
+        BleTokenClient.getInstance().disconnect();
+        showSnackBar($r('app.string.watch_sync_watch_not_ready'), SnackBarNotifyType.WARNING);
+      }
+    }, CONNECT_TIMEOUT_MS);
+  }
+
+  /** 配对失败后重试配对(对已连接设备重新发起系统配对流程) */
+  private retryPairing(): void {
+    if (!this.has_connected_device) {
+      return;
+    }
+    BleTokenClient.getInstance().retryPairing(this.connectedDeviceId).catch((err: Error) => {
+      hilog.warn(DOMAIN, TAG, `retryPairing failed: ${err.message}`);
+      showSnackBar($r('app.string.watch_sync_pair_failed'), SnackBarNotifyType.WARNING);
+    });
+  }
+
+  /**
+   * 按目标选中态幂等设置(双重检查当前状态, 避免重复/反向设置).
+   */
+  private setTokenSelected(uuid: string, selected: boolean): void {
+    const has = this.selectedUuids.includes(uuid);
+    if (selected && !has) {
+      this.selectedUuids = [...this.selectedUuids, uuid];
+    } else if (!selected && has) {
+      this.selectedUuids = this.selectedUuids.filter((u: string) => u !== uuid);
+    }
+  }
+
+  /** 行点击切换: 目标态 = 当前选中态的翻转 */
+  private toggleToken(uuid: string): void {
+    this.setTokenSelected(uuid, !this.selectedUuids.includes(uuid));
+  }
+
+  /** 传输前置校验: 重入/未连接/未配对/未选令牌时给出对应提示 */
+  private checkTransferReady(): boolean {
+    if (this.transferring) {
+      // 进行中守卫: 同帧双击/事件重入会并发两路 GATT 分帧交叉写入, 导致接收端解密失败
+      return false;
+    }
+    if (!this.has_connected_device) {
+      showSnackBar($r('app.string.watch_sync_not_connected_warn'), SnackBarNotifyType.WARNING);
+      return false;
+    }
+    if (!this.bonded) {
+      // 未完成系统 BLE 配对: 提示配对中, 等待系统配对流程
+      showSnackBar($r('app.string.watch_sync_pairing'), SnackBarNotifyType.WARNING);
+      return false;
+    }
+    if (this.selectedUuids.length === 0) {
+      showSnackBar($r('app.string.watch_sync_no_tokens'), SnackBarNotifyType.WARNING);
+      return false;
+    }
+    return true;
+  }
+
+  /** 传输选中令牌: GATT 分帧写入, 结果为真实入库反馈(手表端处理失败即失败, 可立即重试) */
+  private transfer(): void {
+    if (!this.checkTransferReady()) {
+      return;
+    }
+    this.transferring = true;
+    const selected: TokenConfig[] = this.tokens.filter((t: TokenConfig) => this.selectedUuids.includes(t.TokenUUID));
+    BleTokenClient.getInstance().sendTokens(selected).then(() => {
+      this.transferring = false;
+      showSnackBar($r('app.string.watch_sync_transfer_done'), SnackBarNotifyType.SUCCESS);
+    }).catch((err: Error) => {
+      this.transferring = false;
+      hilog.error(DOMAIN, TAG, `transfer failed: ${err.message}`);
+      showSnackBar($r('app.string.watch_sync_transfer_failed'), SnackBarNotifyType.WARNING);
+    });
+  }
+
+  /** 同步手机端外观/安全设置到手表(WEAR_SYNC_PREF_KEYS 白名单) */
+  private syncSettings(): void {
+    if (this.transferring) {
+      return;
+    }
+    if (!this.has_connected_device) {
+      showSnackBar($r('app.string.watch_sync_not_connected_warn'), SnackBarNotifyType.WARNING);
+      return;
+    }
+    if (!this.bonded) {
+      showSnackBar($r('app.string.watch_sync_pairing'), SnackBarNotifyType.WARNING);
+      return;
+    }
+    this.transferring = true;
+    BleTokenClient.getInstance().sendSettings().then(() => {
+      this.transferring = false;
+      showSnackBar($r('app.string.watch_sync_settings_done'), SnackBarNotifyType.SUCCESS);
+    }).catch((err: Error) => {
+      this.transferring = false;
+      hilog.error(DOMAIN, TAG, `sync settings failed: ${err.message}`);
+      showSnackBar($r('app.string.watch_sync_transfer_failed'), SnackBarNotifyType.WARNING);
+    });
+  }
+
+  build() {
+    HdsNavDestination() {
+      PageScaffold() {
+        RelativeContainer() {
+          Stack() {
+            List({ space: 10, scroller: this.scroller }) {
+              // 顶部避让
+              ListItem()
+                .height(CommonConstants.AVOID_TOP_BASE_HEIGHT)
+
+              // 目标设备区: 页面可见期扫描发现广播设备, 点击建连
+              ListItem() {
+                SettingItem({ title: $r('app.string.watch_sync_connect_section') }) {
+                  Row() {
+                    Text(this.has_connected_device
+                      ? $r('app.string.watch_sync_connected')
+                      : $r('app.string.watch_sync_not_connected'))
+                      .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                      .fontColor($r('sys.color.font_primary'))
+                      .layoutWeight(1)
+                      .maxLines(1)
+                      .textOverflow({ overflow: TextOverflow.Ellipsis })
+                    // 刷新扫描按钮: MaterialSurface 光感材质(重启扫描以发现新广播)
+                    MaterialSurface({
+                      thickness: MaterialThickness.THIN,
+                      lightEffect: true,
+                      interactive: true,
+                      materialColor: $r('app.color.button_light_gray'),
+                      radius: 8,
+                      solidColor: Color.Transparent,
+                      fillWidth: false
+                    }) {
+                      Button($r('app.string.watch_sync_scan'))
+                        .fontSize(14)
+                        .height(32)
+                        .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
+                        .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                        .stateEffect(false)
+                        .onClick(() => {
+                          this.refreshScan();
+                        })
+                    }
+                  }
+                  .padding(10)
+
+                  SubItemDivider()
+
+                  if (this.devices.length === 0) {
+                    Row() {
+                      Text(this.scanning
+                        ? $r('app.string.watch_sync_scanning')
+                        : $r('app.string.watch_sync_scan_hint'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.font_secondary'))
+                        .layoutWeight(1)
+                    }
+                    .padding(10)
+                  }
+                  // 已连接但未完成配对: 提示等待配对确认; 配对失败时点击可重试
+                  if (this.has_connected_device && !this.bonded) {
+                    Row() {
+                      Text(this.pairFailed
+                        ? $r('app.string.watch_sync_pair_failed')
+                        : $r('app.string.watch_sync_pairing'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor(this.pairFailed ? $r('sys.color.font_primary') : $r('sys.color.font_secondary'))
+                        .layoutWeight(1)
+                    }
+                    .padding(10)
+                    .onClick(() => {
+                      if (this.pairFailed) {
+                        this.retryPairing();
+                      }
+                    })
+
+                    SubItemDivider()
+                  }
+                  // 扫描到的手表设备: 点击建连, 建连中禁用避免重复点击
+                  ForEach(this.devices, (device: ble.ScanResult, index: number) => {
+                    Row() {
+                      Text(this.deviceDisplayName(device))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.font_primary'))
+                        .layoutWeight(1)
+                        .maxLines(1)
+                        .textOverflow({ overflow: TextOverflow.Ellipsis })
+                      if (this.connectedDeviceId === device.deviceId) {
+                        Text($r('app.string.watch_sync_connected'))
+                          .fontSize(14)
+                          .fontColor($r('sys.color.font_secondary'))
+                      } else if (this.connectingDeviceId === device.deviceId) {
+                        Text($r('app.string.watch_sync_connecting'))
+                          .fontSize(14)
+                          .fontColor($r('sys.color.font_secondary'))
+                      } else {
+                        // 连接按钮: MaterialSurface 光感材质
+                        MaterialSurface({
+                          thickness: MaterialThickness.THIN,
+                          lightEffect: true,
+                          interactive: true,
+                          materialColor: $r('app.color.button_light_gray'),
+                          radius: 8,
+                          solidColor: Color.Transparent,
+                          fillWidth: false
+                        }) {
+                          Button($r('app.string.watch_sync_connect'))
+                            .fontSize(14)
+                            .height(32)
+                            .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
+                            .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                            .stateEffect(false)
+                            .enabled(this.connectingDeviceId === '' && !this.has_connected_device)
+                            .onClick(() => {
+                              this.connectDevice(device);
+                            })
+                        }
+                      }
+                    }
+                    .padding(10)
+                    .onClick(() => {
+                      this.connectDevice(device);
+                    })
+
+                    // 行间分隔线: 最后一个 item 之后不加
+                    if (index < this.devices.length - 1) {
+                      SubItemDivider()
+                    }
+                  }, (device: ble.ScanResult) => device.deviceId)
+                }
+              }
+              .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
+
+              // 令牌选择区
+              ListItem() {
+                SettingItem({ title: $r('app.string.watch_sync_token_list') }) {
+                  if (this.tokens.length === 0) {
+                    Row() {
+                      Text($r('app.string.watch_sync_no_token_hint'))
+                        .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                        .fontColor($r('sys.color.font_secondary'))
+                    }
+                    .padding(10)
+                  }
+                  ForEach(this.tokens, (token: TokenConfig, index: number) => {
+                    Row({ space: 10 }) {
+                      // 令牌图标 + host name, 便于识别
+                      TokenIcon({ issuer: token.TokenIssuer, icon_path: token.TokenIconPath })
+                        .width(32)
+                        .height(32)
+                      Column() {
+                        Text(token.TokenName)
+                          .fontSize($r('sys.float.ohos_id_text_size_body2'))
+                          .fontColor($r('sys.color.font_primary'))
+                          .fontWeight(FontWeight.Medium)
+                          .maxLines(1)
+                          .textOverflow({ overflow: TextOverflow.Ellipsis })
+                        Text(token.TokenIssuer)
+                          .fontSize(12)
+                          .fontColor($r('sys.color.font_secondary'))
+                          .maxLines(1)
+                          .textOverflow({ overflow: TextOverflow.Ellipsis })
+                      }
+                      .layoutWeight(1)
+                      .alignItems(HorizontalAlign.Start)
+                      // 受控选中 + 幂等同步: select 绑定驱动选中态, onChange 按回调值
+                      // 幂等设置(双重检查当前状态)——即使 select 重绑触发 onChange 反馈,
+                      // 回调值不变则状态不变, 渲染收敛不卡死(翻转语义会无限循环)
+                      Checkbox()
+                        .select(this.selectedUuids.includes(token.TokenUUID))
+                        .shape(CheckBoxShape.ROUNDED_SQUARE)
+                        .onChange((checked: boolean) => {
+                          this.setTokenSelected(token.TokenUUID, checked);
+                        })
+                    }
+                    // 加大左右内边距: 图标背景与列表边缘保持间距(对齐手机端列表项 16vp 标准)
+                    .padding({ left: 16, right: 16, top: 10, bottom: 10 })
+                    .onClick(() => {
+                      this.toggleToken(token.TokenUUID);
+                    })
+
+                    // 行间分隔线: 最后一个 item 之后不加
+                    if (index < this.tokens.length - 1) {
+                      SubItemDivider()
+                    }
+                  }, (token: TokenConfig) => token.TokenUUID)
+                }
+              }
+              .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
+
+              // 传输按钮: 未连接设备时禁用
+              ListItem() {
+                MaterialSurface({
+                  thickness: MaterialThickness.THIN,
+                  lightEffect: true,
+                  interactive: true,
+                  materialColor: $r('app.color.button_light_gray'),
+                  radius: 10,
+                  solidColor: Color.Transparent,
+                  fillWidth: true
+                }) {
+                  Button($r('app.string.watch_sync_transfer'))
+                    .width('100%')
+                    .height(44)
+                    .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
+                    .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                    .stateEffect(false)
+                    .enabled(!this.transferring && this.has_connected_device)
+                    .onClick(() => {
+                      this.transfer();
+                    })
+                }
+              }
+              .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
+
+              // 同步设置按钮: 将手机端外观/安全设置(白名单)经 BLE 下发到手表
+              ListItem() {
+                MaterialSurface({
+                  thickness: MaterialThickness.THIN,
+                  lightEffect: true,
+                  interactive: true,
+                  materialColor: $r('app.color.button_light_gray'),
+                  radius: 10,
+                  solidColor: Color.Transparent,
+                  fillWidth: true
+                }) {
+                  Button($r('app.string.watch_sync_settings'))
+                    .width('100%')
+                    .height(44)
+                    .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
+                    .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                    .stateEffect(false)
+                    .enabled(!this.transferring && this.has_connected_device)
+                    .onClick(() => {
+                      this.syncSettings();
+                    })
+                }
+              }
+              .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
+
+            }
+            .edgeEffect(EdgeEffect.Spring, { alwaysEnabled: true })
+            .scrollBar(BarState.Off)
+            .backgroundColor($r('app.color.window_background'))
+            // 沉浸式底部避让: 内容可滚动进入安全区, 滚动到底时最后一项抬升至导航条之上
+            .contentEndOffset(this.window.AvoidBottomHeight)
+            .width('100%')
+            .height('100%')
+          }
+        }
+      }
+    }
+    .bindToScrollable([this.scroller])
+    .titleMode(HdsNavDestinationTitleMode.MODAL)
+    .titleBar({
+      style: {
+        originalStyle: {
+          contentStyle: {
+            titleStyle: {
+              mainTitleColor: $r('sys.color.font_primary'),
+              subTitleColor: $r('sys.color.font_secondary')
+            },
+            backIconStyle: {
+              iconColor: $r('sys.color.icon_primary')
+            }
+          },
+        },
+        scrollEffectOpts: {
+          enableScrollEffect: true,
+          scrollEffectType: this.scrollEffectType
+        },
+        systemMaterialEffect: {
+          materialType: hdsMaterial.MaterialType.ADAPTIVE,
+          materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
+        }
+      },
+      content: {
+        title: {
+          mainTitle: $r('app.string.watch_sync_title_ble'),
+        },
+      }
+    })
+    .onReady((context: NavDestinationContext) => {
+      this.pageInfos = context.pathStack;
+    })
+    .onShown(() => {
+      this.requestPermissionAndStartScan();
+    })
+    .onHidden(() => {
+      // 页面不可见即停扫描(功耗控制); 连接保留, 返回页面后扫描自动恢复
+      this.stopScan();
+    })
+  }
+}

--- a/entry/src/main/ets/pages/BleWatchSyncPage.ets
+++ b/entry/src/main/ets/pages/BleWatchSyncPage.ets
@@ -130,6 +130,8 @@ export struct BleWatchSyncPage {
         hilog.warn(DOMAIN, TAG, 'ACCESS_BLUETOOTH not granted, skip scan');
         showSnackBar($r('app.string.watch_sync_bluetooth_permission_denied'), SnackBarNotifyType.WARNING);
       }
+    }).catch((err: Error) => {
+      hilog.error(DOMAIN, TAG, `requestBluetoothPermission failed: ${err.message}`);
     });
   }
 

--- a/entry/src/main/ets/pages/setting/DataSyncSheet.ets
+++ b/entry/src/main/ets/pages/setting/DataSyncSheet.ets
@@ -12,6 +12,7 @@ import { PermissionManager } from 'common';
 import { throttle } from 'common';
 import { ShowDataSyncDetailsPage } from '../ShowDataSyncDetailsPage';
 import lazy { WatchSyncPage } from '../WatchSyncPage';
+import lazy { BleWatchSyncPage } from '../BleWatchSyncPage';
 import { hdsMaterial, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
 import { SETTING_PAGE_INSET } from '../../components/SettingStyle';
 import { MaterialTheme } from '../../components/MaterialTheme';
@@ -49,6 +50,8 @@ export struct DataSyncSheet {
       ShowDataSyncDetailsPage({ scrollEffectType: this.scrollEffectType })
     } else if (name === ROUTE_NAMES.WatchSyncPage) {
       WatchSyncPage({ scrollEffectType: this.scrollEffectType })
+    } else if (name === ROUTE_NAMES.BleWatchSyncPage) {
+      BleWatchSyncPage({ scrollEffectType: this.scrollEffectType })
     }
   }
 
@@ -85,13 +88,24 @@ export struct DataSyncSheet {
 
                 SubItemDivider()
 
-                // 手表同步: 经 Wear Engine P2P 下发令牌到手表(独立子页面, 经本 Sheet 内嵌导航栈 push)
+                // 手表同步(P2P): 经 Wear Engine 应用间消息下发令牌(独立子页面, 经本 Sheet 内嵌导航栈 push)
                 SubItemButton({
                   symbol: $r('sys.symbol.transfer'),
                   text: $r('app.string.setting_watch_sync')
                 })
                   .onClick(throttle((event) => {
                     this.pageInfos.pushPathByName(ROUTE_NAMES.WatchSyncPage, null);
+                  }, 1000))
+
+                SubItemDivider()
+
+                // 手表同步(BLE): 经 BLE GATT 通道下发令牌(独立子页面, 与 P2P 页互不依赖)
+                SubItemButton({
+                  symbol: $r('sys.symbol.transfer'),
+                  text: $r('app.string.setting_watch_sync_ble')
+                })
+                  .onClick(throttle((event) => {
+                    this.pageInfos.pushPathByName(ROUTE_NAMES.BleWatchSyncPage, null);
                   }, 1000))
               }
             }

--- a/entry/src/main/ets/shell/AppShell.ets
+++ b/entry/src/main/ets/shell/AppShell.ets
@@ -5,6 +5,7 @@ import { MaterialPolicy } from '../utils/MaterialPolicy';
 // [冷启动优化] 以下 NavDestination 页面仅在用户导航时触发评估
 import lazy { TokenCardConfigPage } from '../pages/TokenCardConfigPage'
 import lazy { WatchSyncPage } from '../pages/WatchSyncPage'
+import lazy { BleWatchSyncPage } from '../pages/BleWatchSyncPage'
 import lazy { TokenSortPage } from '../pages/TokenSortPage'
 import lazy { TokenSearchPage } from '../pages/TokenSearchPage'
 import lazy { ShowDataSyncDetailsPage } from '../pages/ShowDataSyncDetailsPage';
@@ -162,6 +163,8 @@ export struct AppShell {
       })
     } else if (name === ROUTE_NAMES.WatchSyncPage) {
       WatchSyncPage({ scrollEffectType: this.scrollEffectType })
+    } else if (name === ROUTE_NAMES.BleWatchSyncPage) {
+      BleWatchSyncPage({ scrollEffectType: this.scrollEffectType })
     } else if (name.startsWith('setting/')) {
       HdsNavDestination() {
         SheetCoordinator({

--- a/entry/src/main/resources/base/profile/main_pages.json
+++ b/entry/src/main/resources/base/profile/main_pages.json
@@ -8,6 +8,7 @@
     "pages/ShowCloudBackupHistoryPage",
     "pages/WebPage",
     "pages/TokenCardConfigPage",
-    "pages/WatchSyncPage"
+    "pages/WatchSyncPage",
+    "pages/BleWatchSyncPage"
   ]
 }

--- a/wearable/src/main/ets/entryability/EntryAbility.ets
+++ b/wearable/src/main/ets/entryability/EntryAbility.ets
@@ -6,7 +6,7 @@ import {
 } from '@kit.AbilityKit';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { AppStorageV2, window } from '@kit.ArkUI';
-import { AppPreference, AppWindowInfo, TokenStore, WearEngineServer } from 'common';
+import { AppPreference, AppWindowInfo, TokenStore, WearEngineServer, BleTokenServer } from 'common';
 import { wearEngine } from '@kit.WearEngine';
 
 const TAG: string = 'WearableEntry';
@@ -38,7 +38,7 @@ export default class EntryAbility extends UIAbility {
 
       await AppPreference.loadSettings();
 
-      // 后台初始化: TokenStore(ASSET 回填) → Wear Engine P2P 接收注册
+      // 后台初始化: TokenStore(ASSET 回填) → P2P 接收注册与 BLE GATT Server 并行就绪
       // 不阻塞首帧渲染; 失败仅记日志(initDataSync 内部 catch)
       this.initDataSync();
 
@@ -87,22 +87,43 @@ export default class EntryAbility extends UIAbility {
   }
 
   /**
-   * 手表端初始化链路: TokenStore 初始化 → Wear Engine P2P 消息接收注册.
+   * 手表端初始化链路: TokenStore 初始化 → P2P 接收注册与 BLE GATT Server 并行就绪.
    *
    * 分布式 KV 同步方案已废弃(数据库安全等级 S4 无法同步到 SL1 手表),
-   * 令牌改由 Wear Engine 应用间消息通信下发(手机 WatchSyncPage → P2P → TokenStore → ASSET).
+   * 令牌改由手机端手动下发: Wear Engine P2P(WatchSyncPage)与 BLE GATT(BleWatchSyncPage)
+   * 两条通道并行常驻、互不阻塞, 入库均走 WearEngineTransfer 共享实现.
    */
   private async initDataSync(): Promise<void> {
+    // 两通道入库均依赖 TokenStore 就绪(kvMgr/ASSET 回填), 必须先行初始化
     try {
-      // 必须先初始化 TokenStore(kvMgr/ASSET 回填), 消息入库依赖其就绪
       await TokenStore.getInstance().initTokenStore();
-      // 获取已连接对端(手机)设备并注册消息接收
+    } catch (err) {
+      hilog.error(0x0000, TAG, `initTokenStore failed: ${JSON.stringify(err)}`);
+      return;
+    }
+    // P2P 与 BLE 并行启动, 各自独立 try/catch: 任一通道失败(权限/蓝牙未就绪)不阻塞另一通道
+    this.startP2pReceive();
+    this.startBleReceive();
+  }
+
+  /** P2P 通道: 获取已连接对端(手机)并注册消息接收, 失败仅记日志 */
+  private async startP2pReceive(): Promise<void> {
+    try {
       const deviceClient: wearEngine.DeviceClient = wearEngine.getDeviceClient(this.context);
       const connected = await deviceClient.getConnectedDevices();
       const randomIds: Array<string> = connected.map((device: wearEngine.Device) => device.randomId);
       await WearEngineServer.getInstance().registerReceiver(randomIds);
     } catch (err) {
-      hilog.error(0x0000, TAG, `initDataSync failed: ${JSON.stringify(err)}`);
+      hilog.error(0x0000, TAG, `startP2pReceive failed: ${JSON.stringify(err)}`);
+    }
+  }
+
+  /** BLE 通道: 启动 GATT Server 与广播(内部含 5 次 × 1s 延时重试), 失败仅记日志 */
+  private async startBleReceive(): Promise<void> {
+    try {
+      await BleTokenServer.getInstance().start();
+    } catch (err) {
+      hilog.error(0x0000, TAG, `startBleReceive failed: ${JSON.stringify(err)}`);
     }
   }
 }

--- a/wearable/src/main/ets/pages/ArcTokenListPage.ets
+++ b/wearable/src/main/ets/pages/ArcTokenListPage.ets
@@ -66,13 +66,15 @@ export struct ArcTokenListPage {
       }
     });
     // BLE GATT Server 依赖 ACCESS_BLUETOOTH(user_grant): 先查后申请,
-    // 授权成功后启动(幂等, 已启动则直接返回); 失败仅记日志, 不影响 P2P 通道
+    // 授权成功后启动(幂等, 已启动/启动中则收敛); 失败仅记日志, 不影响 P2P 通道
     WearEngineClient.getInstance().requestBluetoothPermission().then((result: BluetoothPermissionResult) => {
       if (result === BluetoothPermissionResult.GRANTED) {
         BleTokenServer.getInstance().start();
       } else {
         hilog.warn(0x0000, 'ArcTokenListPage', `ACCESS_BLUETOOTH result ${result}, BLE receive unavailable`);
       }
+    }).catch((err: BusinessError) => {
+      hilog.error(err.code, 'ArcTokenListPage', `requestBluetoothPermission failed: ${err.message}`);
     });
     this.onTokenChanged();
 

--- a/wearable/src/main/ets/pages/ArcTokenListPage.ets
+++ b/wearable/src/main/ets/pages/ArcTokenListPage.ets
@@ -28,26 +28,25 @@ export struct ArcTokenListPage {
   private timestampIntervalId: number = -1;
   /** 页面可见性: 不可见时暂停广播以省电, 回前台时 force 刷新一次 */
   private appIsShow: boolean = true;
+  /** TOKEN_CHANGED 事件处理器引用(aboutToDisappear 注销) */
+  private onTokenChangedHandler: () => void = () => {};
+  /** bleStatus 3 秒复位定时器 ID(aboutToDisappear 清理) */
+  private bleStatusTimerId: number = -1;
 
   aboutToAppear(): void {
     // token 数据变更(增删改/同步完成)时全量刷新列表
     if (this.appCtx.eventHub != undefined) {
-      this.appCtx.eventHub.on(EVENT_NAMES.TOKEN_CHANGED, () => this.onTokenChanged());
+      this.onTokenChangedHandler = () => this.onTokenChanged();
+      this.appCtx.eventHub.on(EVENT_NAMES.TOKEN_CHANGED, this.onTokenChangedHandler);
     }
     // BLE 接收完成回调: 刷新列表 + 显示接收提示 3 秒后复位
     WearEngineServer.getInstance().setOnTokensSaved(async (count: number) => {
       await this.onTokenChanged();
-      this.bleStatus = $r('app.string.app_wearable_ble_received');
-      setTimeout(() => {
-        this.bleStatus = undefined;
-      }, 3000);
+      this.showBleStatus($r('app.string.app_wearable_ble_received'));
     });
     // 设置应用完成回调: 显示设置已同步提示 3 秒后复位
     WearEngineServer.getInstance().setOnSettingsApplied(() => {
-      this.bleStatus = $r('app.string.app_wearable_ble_settings_done');
-      setTimeout(() => {
-        this.bleStatus = undefined;
-      }, 3000);
+      this.showBleStatus($r('app.string.app_wearable_ble_settings_done'));
     });
     this.onTokenChanged();
 
@@ -65,6 +64,28 @@ export struct ArcTokenListPage {
       clearInterval(this.timestampIntervalId);
       this.timestampIntervalId = -1;
     }
+    if (this.bleStatusTimerId !== -1) {
+      clearTimeout(this.bleStatusTimerId);
+      this.bleStatusTimerId = -1;
+    }
+    if (this.appCtx.eventHub != undefined) {
+      this.appCtx.eventHub.off(EVENT_NAMES.TOKEN_CHANGED, this.onTokenChangedHandler);
+    }
+    // 注销 WearEngineServer 单例回调, 避免页面销毁后仍被触达
+    WearEngineServer.getInstance().setOnTokensSaved(undefined);
+    WearEngineServer.getInstance().setOnSettingsApplied(undefined);
+  }
+
+  /** 显示同步状态提示, 3 秒后复位(重复触发时重置计时) */
+  showBleStatus(status: Resource): void {
+    this.bleStatus = status;
+    if (this.bleStatusTimerId !== -1) {
+      clearTimeout(this.bleStatusTimerId);
+    }
+    this.bleStatusTimerId = setTimeout(() => {
+      this.bleStatus = undefined;
+      this.bleStatusTimerId = -1;
+    }, 3000);
   }
 
   onPageShow(): void {

--- a/wearable/src/main/ets/pages/ArcTokenListPage.ets
+++ b/wearable/src/main/ets/pages/ArcTokenListPage.ets
@@ -1,7 +1,7 @@
 import { QRCodeDialog } from 'uikit';
 import { TokenPreference, EVENT_NAMES } from 'common';
 import { TokenConfig, TokenIconPacks } from 'common';
-import { TokenStore, WearEngineServer, convertToken2URI } from 'common';
+import { TokenStore, WearEngineServer, BleTokenServer, BleSyncStatus, WearEngineClient, BluetoothPermissionResult, convertToken2URI } from 'common';
 import { systemDateTime } from '@kit.BasicServicesKit';
 import { AppStorageV2, ArcList, ArcListItem, LengthMetrics } from "@kit.ArkUI";
 import { common } from '@kit.AbilityKit';
@@ -48,6 +48,32 @@ export struct ArcTokenListPage {
     WearEngineServer.getInstance().setOnSettingsApplied(() => {
       this.showBleStatus($r('app.string.app_wearable_ble_settings_done'));
     });
+    // BLE 通道接收状态(接收中/成功/失败): 与 P2P 回调共用 bleStatus 状态区,
+    // 语义为最后事件胜出(showBleStatus 重置 3 秒复位计时); 列表刷新由 onTokensSaved 驱动
+    BleTokenServer.getInstance().setOnTokensSaved(async (count: number) => {
+      await this.onTokenChanged();
+    });
+    BleTokenServer.getInstance().setOnSettingsApplied(() => {
+      this.showBleStatus($r('app.string.app_wearable_ble_settings_done'));
+    });
+    BleTokenServer.getInstance().setOnSyncStatus((status: BleSyncStatus) => {
+      if (status === BleSyncStatus.RECEIVING) {
+        this.showBleStatus($r('app.string.app_wearable_ble_receiving'));
+      } else if (status === BleSyncStatus.SUCCESS) {
+        this.showBleStatus($r('app.string.app_wearable_ble_received'));
+      } else {
+        this.showBleStatus($r('app.string.app_wearable_ble_failed'));
+      }
+    });
+    // BLE GATT Server 依赖 ACCESS_BLUETOOTH(user_grant): 先查后申请,
+    // 授权成功后启动(幂等, 已启动则直接返回); 失败仅记日志, 不影响 P2P 通道
+    WearEngineClient.getInstance().requestBluetoothPermission().then((result: BluetoothPermissionResult) => {
+      if (result === BluetoothPermissionResult.GRANTED) {
+        BleTokenServer.getInstance().start();
+      } else {
+        hilog.warn(0x0000, 'ArcTokenListPage', `ACCESS_BLUETOOTH result ${result}, BLE receive unavailable`);
+      }
+    });
     this.onTokenChanged();
 
     // 每秒广播时间戳事件, 驱动各 TOTP 令牌按周期刷新(参考手机端 Index 实现:
@@ -71,9 +97,12 @@ export struct ArcTokenListPage {
     if (this.appCtx.eventHub != undefined) {
       this.appCtx.eventHub.off(EVENT_NAMES.TOKEN_CHANGED, this.onTokenChangedHandler);
     }
-    // 注销 WearEngineServer 单例回调, 避免页面销毁后仍被触达
+    // 注销 WearEngineServer/BleTokenServer 单例回调, 避免页面销毁后仍被触达
     WearEngineServer.getInstance().setOnTokensSaved(undefined);
     WearEngineServer.getInstance().setOnSettingsApplied(undefined);
+    BleTokenServer.getInstance().setOnTokensSaved(undefined);
+    BleTokenServer.getInstance().setOnSettingsApplied(undefined);
+    BleTokenServer.getInstance().setOnSyncStatus(undefined);
   }
 
   /** 显示同步状态提示, 3 秒后复位(重复触发时重置计时) */

--- a/wearable/src/main/module.json5
+++ b/wearable/src/main/module.json5
@@ -39,16 +39,6 @@
           "when": "inuse"
         },
         "reason": "$string:ble_access_permission_reason"
-      },
-      {
-        "name": "ohos.permission.DISTRIBUTED_DATASYNC",
-        "reason": "$string:distributed_data_sync",
-        "usedScene": {
-          "abilities": [
-            "EntryAbility"
-          ],
-          "when": "always"
-        }
       }
     ],
     "deliveryWithInstall": true,


### PR DESCRIPTION
## 概述

实施 OpenSpec 变更 `watch-sync-channel-split`:将手表同步按传输通道拆分为两个独立验证页(BLE / P2P 各一页),两页互不依赖,任一通道被阻塞(ACL 审批未过、蓝牙关闭)都不影响另一通道的真机验证。

## 变更内容

- 新增 `BleWatchSyncPage`(BLE 验证页):页面可见期 BLE 扫描(服务 UUID 过滤、离开页面即停、支持手动刷新)、点击建连(8s 超时提示"手表端未就绪")、系统 BLE 配对(失败可重试)、令牌多选幂等选择、GATT 分帧传输与设置同步,真实结果反馈(失败可立即重试)
- 恢复 BLE 传输层(源自 5336baf)并适配当前 dev:设置白名单统一 `WEAR_SYNC_PREF_KEYS` 单一来源、`withTimeout` 定时器悬挂清理、GATT 监听/回调注册注销成对、结果回调 setter 支持"传 undefined 注销"、启动重试 5 次 × 1s 保留
- 共享化:`WearEngineServer` 抽出 `saveTokensBatch` / `applyWearSettings` 共享函数,P2P / BLE 两通道入库语义完全一致(issuer+name 覆盖、复用 UUID、ASSET 双写、排序)
- 防假成功/半截数据:接收端在连接建立与每个批次开始时重置状态机,分片越界、解密失败、处理异常的批次全部丢弃不入库;收尾帧写应答延后到重组/解密/入库完成后按结果回发,手机端反馈与手表实际入库结果一致
- 手表端 `initDataSync`:`TokenStore.initTokenStore()` 先行,P2P 注册与 BLE GATT Server 并行就绪、各自独立 try/catch 互不阻塞;列表页同步状态文本接入 BLE 三态(接收中/成功/失败,与 P2P 共用状态区、最后事件胜出)
- 路由四件套与 i18n:`ROUTE_NAMES` / `main_pages.json` / `AppShell` / `DataSyncSheet` 双入口并列标注通道,P2P 页仅标题文案标注"(P2P)"行为零改动,四语言文案补齐(含恢复 BLE 页所需既有 key)
- 附带 7767aea:联合评审跟进项(#186/#193 生命周期清理、wearable 最小授权收敛、无引用字符串 key 清理)

## 验证

- 全模块构建(common / uikit / entry / wearable)通过
- i18n 校验:四语言 key 集合一致(472 key)、无缺失/重复/未引用
- 三轮联合评审迭代:终态 0 阻塞 / 0 重要

## 待真机验证(后续补充结论)

- BLE 正向:扫描发现连接、令牌传输入库(含覆盖重传)、设置同步即时重绘
- BLE 负向:手表端未就绪连接失败、传输中断连/超时(不得半截入库)、中断后立即重试(无假成功)、蓝牙关闭时引导
- P2P 页回归:标题标注后原传输/设置流程不受影响
