### PR TITLE
fix(watch-sync): BLE 页去除已删除的 MaterialSurface 包装，修复 dev 编译失败

### DIFF
--- a/entry/src/main/ets/pages/BleWatchSyncPage.ets
+++ b/entry/src/main/ets/pages/BleWatchSyncPage.ets
@@ -10,8 +10,6 @@ import { showSnackBar, SnackBarNotifyType } from 'common';
 import { AppWindowInfo, CommonConstants } from 'common';
 import { AppStorageV2 } from '@kit.ArkUI';
 import { hilog } from '@kit.PerformanceAnalysisKit';
-import { MaterialSurface } from '../components/MaterialSurface';
-import { MaterialTheme, MaterialThickness } from '../components/MaterialTheme';
 import { SETTING_PAGE_INSET } from '../components/SettingStyle';
 
 const TAG = 'BleWatchSyncPage';
@@ -360,26 +358,16 @@ export struct BleWatchSyncPage {
                       .layoutWeight(1)
                       .maxLines(1)
                       .textOverflow({ overflow: TextOverflow.Ellipsis })
-                    // 刷新扫描按钮: MaterialSurface 光感材质(重启扫描以发现新广播)
-                    MaterialSurface({
-                      thickness: MaterialThickness.THIN,
-                      lightEffect: true,
-                      interactive: true,
-                      materialColor: $r('app.color.button_light_gray'),
-                      radius: 8,
-                      solidColor: Color.Transparent,
-                      fillWidth: false
-                    }) {
-                      Button($r('app.string.watch_sync_scan'))
-                        .fontSize(14)
-                        .height(32)
-                        .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
-                        .fontColor(this.is_dark_mode ? Color.White : Color.Black)
-                        .stateEffect(false)
-                        .onClick(() => {
-                          this.refreshScan();
-                        })
-                    }
+                    // 刷新扫描按钮: 内容区实体背景(重启扫描以发现新广播)
+                    Button($r('app.string.watch_sync_scan'))
+                      .fontSize(14)
+                      .height(32)
+                      .backgroundColor($r('app.color.button_light_gray'))
+                      .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                      .stateEffect(false)
+                      .onClick(() => {
+                        this.refreshScan();
+                      })
                   }
                   .padding(10)
 
@@ -433,27 +421,17 @@ export struct BleWatchSyncPage {
                           .fontSize(14)
                           .fontColor($r('sys.color.font_secondary'))
                       } else {
-                        // 连接按钮: MaterialSurface 光感材质
-                        MaterialSurface({
-                          thickness: MaterialThickness.THIN,
-                          lightEffect: true,
-                          interactive: true,
-                          materialColor: $r('app.color.button_light_gray'),
-                          radius: 8,
-                          solidColor: Color.Transparent,
-                          fillWidth: false
-                        }) {
-                          Button($r('app.string.watch_sync_connect'))
-                            .fontSize(14)
-                            .height(32)
-                            .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
-                            .fontColor(this.is_dark_mode ? Color.White : Color.Black)
-                            .stateEffect(false)
-                            .enabled(this.connectingDeviceId === '' && !this.has_connected_device)
-                            .onClick(() => {
-                              this.connectDevice(device);
-                            })
-                        }
+                        // 连接按钮: 内容区实体背景
+                        Button($r('app.string.watch_sync_connect'))
+                          .fontSize(14)
+                          .height(32)
+                          .backgroundColor($r('app.color.button_light_gray'))
+                          .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                          .stateEffect(false)
+                          .enabled(this.connectingDeviceId === '' && !this.has_connected_device)
+                          .onClick(() => {
+                            this.connectDevice(device);
+                          })
                       }
                     }
                     .padding(10)
@@ -527,53 +505,33 @@ export struct BleWatchSyncPage {
               }
               .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
 
-              // 传输按钮: 未连接设备时禁用
+              // 传输按钮: 内容区实体背景, 未连接设备时禁用
               ListItem() {
-                MaterialSurface({
-                  thickness: MaterialThickness.THIN,
-                  lightEffect: true,
-                  interactive: true,
-                  materialColor: $r('app.color.button_light_gray'),
-                  radius: 10,
-                  solidColor: Color.Transparent,
-                  fillWidth: true
-                }) {
-                  Button($r('app.string.watch_sync_transfer'))
-                    .width('100%')
-                    .height(44)
-                    .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
-                    .fontColor(this.is_dark_mode ? Color.White : Color.Black)
-                    .stateEffect(false)
-                    .enabled(!this.transferring && this.has_connected_device)
-                    .onClick(() => {
-                      this.transfer();
-                    })
-                }
+                Button($r('app.string.watch_sync_transfer'))
+                  .width('100%')
+                  .height(44)
+                  .backgroundColor($r('app.color.button_light_gray'))
+                  .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                  .stateEffect(false)
+                  .enabled(!this.transferring && this.has_connected_device)
+                  .onClick(() => {
+                    this.transfer();
+                  })
               }
               .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
 
               // 同步设置按钮: 将手机端外观/安全设置(白名单)经 BLE 下发到手表
               ListItem() {
-                MaterialSurface({
-                  thickness: MaterialThickness.THIN,
-                  lightEffect: true,
-                  interactive: true,
-                  materialColor: $r('app.color.button_light_gray'),
-                  radius: 10,
-                  solidColor: Color.Transparent,
-                  fillWidth: true
-                }) {
-                  Button($r('app.string.watch_sync_settings'))
-                    .width('100%')
-                    .height(44)
-                    .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
-                    .fontColor(this.is_dark_mode ? Color.White : Color.Black)
-                    .stateEffect(false)
-                    .enabled(!this.transferring && this.has_connected_device)
-                    .onClick(() => {
-                      this.syncSettings();
-                    })
-                }
+                Button($r('app.string.watch_sync_settings'))
+                  .width('100%')
+                  .height(44)
+                  .backgroundColor($r('app.color.button_light_gray'))
+                  .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                  .stateEffect(false)
+                  .enabled(!this.transferring && this.has_connected_device)
+                  .onClick(() => {
+                    this.syncSettings();
+                  })
               }
               .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
 


### PR DESCRIPTION
## 改动说明

修复 dev（ed5e53e）合入 PR #196 后的编译失败：`BleWatchSyncPage.ets` 仍引用 PR #197 已删除的 `MaterialSurface` / `MaterialThickness`，两个 PR 文本合并无冲突，但 ArkTS/Rollup 编译报错：

```
ERROR: 10505001 Cannot find module '../components/MaterialSurface'
ERROR: 10505001 Module '"../components/MaterialTheme"' has no exported member 'MaterialThickness'
```

处理方式：按 #197 的迁移范式（材质只作用于标题栏/弹窗/HDS 组件，内容区不套材质），删除 BLE 页 4 处 `MaterialSurface` 包装（刷新扫描 / 连接 / 传输 / 同步设置按钮）及相关 import，按钮改为普通实体背景 — 与同批合入、未被破坏的 P2P 页 `WatchSyncPage.ets` 的按钮属性链逐项一致。非沉浸模式下渲染零变化（旧包装 `solidColor: Color.Transparent`，可见背景本就是 Button 自身）。

已由子代理独立评审：可合入、零阻塞；与 `5e8ea1d` 迁移范式同构、与 P2P 页视觉一致、全仓无残留引用。

## 改动类型

- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 重构（refactor）
- [ ] 样式调整（style）
- [ ] 文档（docs）
- [ ] 构建 / 依赖 / 配置（chore）

## 检查清单

- [x] **目标分支已选择 `dev`**（不是 `main`）
- [x] 已基于最新 `dev` 创建分支并 rebase，无冲突（分支 = dev HEAD ed5e53e + 1 个修复提交）
- [x] 本地构建通过（`devecocli build --modules entry wearable common uikit`）
- [ ] 已在真机 / 模拟器上测试，行为符合预期（纯编译级修复，视觉与 P2P 页一致；真机回归随 #196 的用例 5.3-5.5 一并进行）
- [x] commit message 遵循 Conventional Commits 规范
- [x] 未提交本地的 `build-profile.json5` 签名配置、IDE 缓存等产物

## 测试说明

- `devecocli build --modules entry wearable common uikit`：构建成功（修复前 entry 模块编译失败）。
- 全仓 grep `MaterialSurface|MaterialThickness`（含 wearable/common/uikit）：零残留。
- 与 `WatchSyncPage.ets` 四个按钮的属性链逐项比对一致（差异仅 enabled 条件，属两页状态模型固有差异）。
- 未跑真机：改动仅删包装层，点击区域/尺寸/对齐不变（onClick 始终在 Button 上）。

## 截图 / 录屏（如涉及 UI 改动）

按钮视觉与 P2P 页现有实体按钮一致；沉浸模式下材质胶囊恢复为实体按钮，与 #197 对 P2P 页的处理相同（该范式变更已随 #197 合入被接受）。
