### PR TITLE
ci: PR/dev 门禁增加全模块构建任务

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - main
+      # dev push = PR merge commits. PR-tip checks cannot see semantic merge
+      # conflicts between separately-green PRs (e.g. ed5e53e: #196 still
+      # referenced MaterialSurface that #197 had deleted), so the trunk
+      # itself must be gated too.
+      - dev
   workflow_call:
 
 permissions:
@@ -68,3 +73,57 @@ jobs:
             exit 1
           fi
           echo "All LocalUnit tests passed - $SUMMARY"
+
+  build:
+    name: Build HAP (all modules)
+    # LocalUnit only compiles entry for test purposes; the wearable HAP and
+    # the release build path (obfuscation, resource packaging) are otherwise
+    # never verified before main. Plain assembleHap runs fine on Linux - only
+    # `hvigorw test` needs the previewer runtime (see localunit job).
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Setup HarmonyOS CLI tools
+        uses: ErBWs/setup-ohos@v2
+        with:
+          # Keep the SDK version in sync with the localunit job.
+          version: 26.0.0.821
+          cache: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl libgl1-mesa-dev
+        shell: bash
+
+      - name: Install project dependencies
+        run: ohpm install --all --rt 5 --ri 5000
+        shell: bash
+
+      # Same release-mode unsigned path as the shipping build.yaml, so a
+      # PR that only breaks release packaging (not debug/LocalUnit) is
+      # still caught before merge.
+      - name: Build HAPs (default product, release, unsigned)
+        run: hvigorw assembleHap -p buildMode=release --config properties.ignoreSignHap=true --no-daemon
+        shell: bash
+
+      - name: Verify build artifacts
+        shell: bash
+        run: |
+          FAIL=0
+          for MODULE in entry wearable; do
+            HAP=$(find "${MODULE}/build" -name "*.hap" -type f 2>/dev/null | head -n 1)
+            if [ -z "$HAP" ]; then
+              echo "::error::No hap found for module ${MODULE}"
+              FAIL=1
+            else
+              echo "Module ${MODULE}: $(basename "$HAP")"
+            fi
+          done
+          exit $FAIL

--- a/entry/src/main/ets/pages/BleWatchSyncPage.ets
+++ b/entry/src/main/ets/pages/BleWatchSyncPage.ets
@@ -10,8 +10,6 @@ import { showSnackBar, SnackBarNotifyType } from 'common';
 import { AppWindowInfo, CommonConstants } from 'common';
 import { AppStorageV2 } from '@kit.ArkUI';
 import { hilog } from '@kit.PerformanceAnalysisKit';
-import { MaterialSurface } from '../components/MaterialSurface';
-import { MaterialTheme, MaterialThickness } from '../components/MaterialTheme';
 import { SETTING_PAGE_INSET } from '../components/SettingStyle';
 
 const TAG = 'BleWatchSyncPage';
@@ -360,26 +358,16 @@ export struct BleWatchSyncPage {
                       .layoutWeight(1)
                       .maxLines(1)
                       .textOverflow({ overflow: TextOverflow.Ellipsis })
-                    // 刷新扫描按钮: MaterialSurface 光感材质(重启扫描以发现新广播)
-                    MaterialSurface({
-                      thickness: MaterialThickness.THIN,
-                      lightEffect: true,
-                      interactive: true,
-                      materialColor: $r('app.color.button_light_gray'),
-                      radius: 8,
-                      solidColor: Color.Transparent,
-                      fillWidth: false
-                    }) {
-                      Button($r('app.string.watch_sync_scan'))
-                        .fontSize(14)
-                        .height(32)
-                        .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
-                        .fontColor(this.is_dark_mode ? Color.White : Color.Black)
-                        .stateEffect(false)
-                        .onClick(() => {
-                          this.refreshScan();
-                        })
-                    }
+                    // 刷新扫描按钮: 内容区实体背景(重启扫描以发现新广播)
+                    Button($r('app.string.watch_sync_scan'))
+                      .fontSize(14)
+                      .height(32)
+                      .backgroundColor($r('app.color.button_light_gray'))
+                      .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                      .stateEffect(false)
+                      .onClick(() => {
+                        this.refreshScan();
+                      })
                   }
                   .padding(10)
 
@@ -433,27 +421,17 @@ export struct BleWatchSyncPage {
                           .fontSize(14)
                           .fontColor($r('sys.color.font_secondary'))
                       } else {
-                        // 连接按钮: MaterialSurface 光感材质
-                        MaterialSurface({
-                          thickness: MaterialThickness.THIN,
-                          lightEffect: true,
-                          interactive: true,
-                          materialColor: $r('app.color.button_light_gray'),
-                          radius: 8,
-                          solidColor: Color.Transparent,
-                          fillWidth: false
-                        }) {
-                          Button($r('app.string.watch_sync_connect'))
-                            .fontSize(14)
-                            .height(32)
-                            .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
-                            .fontColor(this.is_dark_mode ? Color.White : Color.Black)
-                            .stateEffect(false)
-                            .enabled(this.connectingDeviceId === '' && !this.has_connected_device)
-                            .onClick(() => {
-                              this.connectDevice(device);
-                            })
-                        }
+                        // 连接按钮: 内容区实体背景
+                        Button($r('app.string.watch_sync_connect'))
+                          .fontSize(14)
+                          .height(32)
+                          .backgroundColor($r('app.color.button_light_gray'))
+                          .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                          .stateEffect(false)
+                          .enabled(this.connectingDeviceId === '' && !this.has_connected_device)
+                          .onClick(() => {
+                            this.connectDevice(device);
+                          })
                       }
                     }
                     .padding(10)
@@ -527,53 +505,33 @@ export struct BleWatchSyncPage {
               }
               .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
 
-              // 传输按钮: 未连接设备时禁用
+              // 传输按钮: 内容区实体背景, 未连接设备时禁用
               ListItem() {
-                MaterialSurface({
-                  thickness: MaterialThickness.THIN,
-                  lightEffect: true,
-                  interactive: true,
-                  materialColor: $r('app.color.button_light_gray'),
-                  radius: 10,
-                  solidColor: Color.Transparent,
-                  fillWidth: true
-                }) {
-                  Button($r('app.string.watch_sync_transfer'))
-                    .width('100%')
-                    .height(44)
-                    .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
-                    .fontColor(this.is_dark_mode ? Color.White : Color.Black)
-                    .stateEffect(false)
-                    .enabled(!this.transferring && this.has_connected_device)
-                    .onClick(() => {
-                      this.transfer();
-                    })
-                }
+                Button($r('app.string.watch_sync_transfer'))
+                  .width('100%')
+                  .height(44)
+                  .backgroundColor($r('app.color.button_light_gray'))
+                  .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                  .stateEffect(false)
+                  .enabled(!this.transferring && this.has_connected_device)
+                  .onClick(() => {
+                    this.transfer();
+                  })
               }
               .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
 
               // 同步设置按钮: 将手机端外观/安全设置(白名单)经 BLE 下发到手表
               ListItem() {
-                MaterialSurface({
-                  thickness: MaterialThickness.THIN,
-                  lightEffect: true,
-                  interactive: true,
-                  materialColor: $r('app.color.button_light_gray'),
-                  radius: 10,
-                  solidColor: Color.Transparent,
-                  fillWidth: true
-                }) {
-                  Button($r('app.string.watch_sync_settings'))
-                    .width('100%')
-                    .height(44)
-                    .backgroundColor(MaterialTheme.surfaceBackground($r('app.color.button_light_gray')))
-                    .fontColor(this.is_dark_mode ? Color.White : Color.Black)
-                    .stateEffect(false)
-                    .enabled(!this.transferring && this.has_connected_device)
-                    .onClick(() => {
-                      this.syncSettings();
-                    })
-                }
+                Button($r('app.string.watch_sync_settings'))
+                  .width('100%')
+                  .height(44)
+                  .backgroundColor($r('app.color.button_light_gray'))
+                  .fontColor(this.is_dark_mode ? Color.White : Color.Black)
+                  .stateEffect(false)
+                  .enabled(!this.transferring && this.has_connected_device)
+                  .onClick(() => {
+                    this.syncSettings();
+                  })
               }
               .padding({ left: SETTING_PAGE_INSET, right: SETTING_PAGE_INSET })
 


### PR DESCRIPTION
## 改动说明

为 PR 门禁补充构建检查。现状缺口：

- `quality.yml` 只有 LocalUnit 一个 job（`hvigorw test` 仅编译 entry 的测试目标），**wearable 模块与 release 构建路径（混淆、资源打包）在合入 main 前从未被 CI 验证**；
- CI 只在 PR 分支尖端运行，dev 的合并提交（push）不触发任何检查 — 两个各自绿的 PR 在合并提交上产生语义冲突时无人拦截（正是 ed5e53e：#196 仍引用 #197 已删除的 `MaterialSurface`，带病合入 dev）；
- `build.yaml` 仅在 PR 合入 **main** 后触发（发版用），补不上这个洞。

本 PR 改动（`quality.yml`）：

1. **新增 `Build HAP (all modules)` job**：ubuntu-latest 上执行 `hvigorw assembleHap -p buildMode=release --config properties.ignoreSignHap=true`（与发版 build.yaml 完全同路径），并校验 entry 与 wearable 均产出 HAP 产物。纯构建不需要 Previewer 运行时，Linux 可跑（LocalUnit 才需要 mac/win，见既有注释）。
2. **push 触发范围扩展到 `dev`**：PR 合并产生 merge commit 时同样跑 LocalUnit + 构建，拦截"各自绿、合并坏"的交叉破坏。

SDK 版本与 localunit job 保持一致（`26.0.0.821` 钉版，共享缓存策略）。

> 分支基于 #200（dev 编译修复）叠加：#200 未合入前 dev 基线本身编译失败。建议先合 #200 再合本 PR。

Refs #200

## 改动类型

- [ ] 新功能（feat）
- [ ] Bug 修复（fix）
- [ ] 重构（refactor）
- [ ] 样式调整（style）
- [ ] 文档（docs）
- [x] 构建 / 依赖 / 配置（chore）

## 检查清单

- [x] **目标分支已选择 `dev`**（不是 `main`）
- [x] 已基于最新 `dev` 创建分支并 rebase，无冲突（叠加在 #200 之上）
- [x] 本地构建通过（workflow 改动，已用 js-yaml 校验语法；实际构建由本 PR 的 CI 自验证）
- [ ] 已在真机 / 模拟器上测试，行为符合预期（纯 CI 配置，无运行时改动）
- [x] commit message 遵循 Conventional Commits 规范
- [x] 未提交本地的 `build-profile.json5` 签名配置、IDE 缓存等产物

## 测试说明

- `npx js-yaml` 校验 workflow 语法通过。
- 本 PR 自身即验证载体：CI 应出现 **两个** 检查（LocalUnit + Build HAP），且 Build HAP 首跑在 ubuntu 冷缓存下应在 timeout（40 min）内完成并产出双模块 HAP。
- 构建命令与 build.yaml 在 main 上长期运行的发版路径一致（`assembleHap` + release + ignoreSignHap）。

## 截图 / 录屏（如涉及 UI 改动）

无 UI 改动。
