### PR TITLE
chore: 新增 ACCESS_NEARLINK 权限并升版 1.3.0（AppTest 内测）

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -78,9 +78,10 @@ jobs:
     name: Build HAP (all modules)
     # LocalUnit only compiles entry for test purposes; the wearable HAP and
     # the release build path (obfuscation, resource packaging) are otherwise
-    # never verified before main. Plain assembleHap runs fine on Linux - only
-    # `hvigorw test` needs the previewer runtime (see localunit job).
-    runs-on: ubuntu-latest
+    # never verified before main. Runs on the same macOS image as localunit
+    # so both jobs share one setup-ohos SDK cache (actions/cache is keyed
+    # per runner OS); the macOS runner needs no extra system packages.
+    runs-on: macos-latest
     timeout-minutes: 40
 
     steps:
@@ -95,12 +96,6 @@ jobs:
           # Keep the SDK version in sync with the localunit job.
           version: 26.0.0.821
           cache: true
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl libgl1-mesa-dev
-        shell: bash
 
       - name: Install project dependencies
         run: ohpm install --all --rt 5 --ri 5000

--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "smartcityshenzhen.yylx.totptoken",
     "vendor": "opensource",
-    "versionCode": 1002060,
-    "versionName": "1.2.6",
+    "versionCode": 1003000,
+    "versionName": "1.3.0",
     "icon": "$media:app_icon",
     "label": "$string:app_name",
     "cloudFileSyncEnabled": true

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -1318,6 +1318,10 @@
       "value": "Used to pair with wearable devices and securely sync tokens"
     },
     {
+      "name": "nearlink_access_permission_reason",
+      "value": "Used to pair with wearable devices via NearLink and securely sync tokens"
+    },
+    {
       "name": "feedback_survey",
       "value": "Survey Feedback"
     },

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -1301,6 +1301,10 @@
       "value": "Used to pair with wearable devices and securely sync tokens"
     },
     {
+      "name": "nearlink_access_permission_reason",
+      "value": "Used to pair with wearable devices via NearLink and securely sync tokens"
+    },
+    {
       "name": "setting_top_effect_type",
       "value": "Title Bar Blur Type"
     },

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -1326,6 +1326,10 @@
       "value": "用于通过蓝牙与手表配对并安全同步令牌"
     },
     {
+      "name": "nearlink_access_permission_reason",
+      "value": "用于通过星闪与手表配对并安全同步令牌"
+    },
+    {
       "name": "setting_top_effect_type",
       "value": "顶部模糊类型"
     },

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -1326,6 +1326,10 @@
       "value": "用於透過藍牙與手錶配對並安全同步令牌"
     },
     {
+      "name": "nearlink_access_permission_reason",
+      "value": "用於透過星閃與手錶配對並安全同步令牌"
+    },
+    {
       "name": "setting_top_effect_type",
       "value": "頂部模糊類型"
     },

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -86,6 +86,16 @@
           "when": "inuse"
         }
       },
+      {
+        "name": "ohos.permission.ACCESS_NEARLINK",
+        "reason": "$string:nearlink_access_permission_reason",
+        "usedScene": {
+          "abilities": [
+            "EntryAbility"
+          ],
+          "when": "inuse"
+        }
+      },
 
     {
         "name": "ohos.permission.DLP_GET_HIDE_STATUS",


### PR DESCRIPTION
## 改动说明

本 PR 主要用于**推送应用市场 AppTest 内测渠道**：升版本号 1.3.0，并预先申明星闪（NearLink）权限；顺带统一 CI 两个 job 的 runner 以共享 SDK 缓存。

- `entry/src/main/module.json5` 新增 `ohos.permission.ACCESS_NEARLINK`（user_grant 级，API 12+，HMS NearLink Kit 所需），按规范携带 `reason` + `usedScene`；为手表同步后续接入星闪通道做准备，**本版本仅声明、未调用任何 NearLink API**。
- `common` 四语言新增 `nearlink_access_permission_reason` 权限说明文案（base/en_US/zh_CN/zh_TW 齐平，紧随蓝牙权限条目）。
- `AppScope/app.json5`：`versionName` 1.2.6 → **1.3.0**，`versionCode` 1002060 → **1003000**（沿用既有 major×10⁶ + minor×10³ + patch×10 编码）。
- `quality.yml`：`Build HAP` job 从 `ubuntu-latest` 改为 `macos-latest`，与 LocalUnit 同镜像 — actions/cache 按 runner OS 分键，统一后**两个 job 共享同一份 setup-ohos SDK 缓存**，省去 ubuntu 侧第二份 ~5GB 缓存的下载与存储；macOS 上无需 apt 安装系统依赖，该步骤移除。

不涉及任何运行时逻辑改动；wearable 模块未动（手表端星闪接入时再按需申明）。

## 改动类型

- [ ] 新功能（feat）
- [ ] Bug 修复（fix）
- [ ] 重构（refactor）
- [ ] 样式调整（style）
- [ ] 文档（docs）
- [x] 构建 / 依赖 / 配置（chore）

## 检查清单

- [x] **目标分支已选择 `dev`**（不是 `main`）
- [x] 已基于最新 `dev` 创建分支并 rebase，无冲突（基于 82a579d）
- [x] 本地构建通过（`devecocli build --modules entry wearable common uikit`；权限缺 reason/usedScene 的报错已在本地复现并修复，PackingCheck 通过）
- [ ] 已在真机 / 模拟器上测试，行为符合预期（纯清单/资源改动，无运行时行为变化；AppTest 包出包后以内测渠道分发验证）
- [x] commit message 遵循 Conventional Commits 规范
- [x] 未提交本地的 `build-profile.json5` 签名配置、IDE 缓存等产物

## 测试说明

- 全模块构建通过（entry/wearable/common/uikit）。
- 首次构建曾触发 hvigor 00303218（user_grant 权限必须带 reason/usedScene），补齐后通过——权限级别与声明要求已按编译器校验确认。
- i18n 四语言脚本校验：新增 key 在 base/en_US/zh_CN/zh_TW 全部齐平（en_US 既有的 25 个分组 key 缺口为 #198 遗留，与本 PR 无关）。
- CI runner 统一：本 PR 的 CI 即为 macOS 构建的首跑验证（`Build HAP` job 在 macOS 上执行同一 release 无签名路径）。

## 截图 / 录屏（如涉及 UI 改动）

无 UI 改动。
