### PR TITLE
build: 最低兼容版本降至 HarmonyOS 6.0（6.0.0(20)），编译/目标 26.0.0

### DIFF
--- a/build-profile.json5
+++ b/build-profile.json5
@@ -19,8 +19,9 @@
       {
         "name": "default",
         "signingConfig": "default",
+        "compileSdkVersion": "26.0.0",
         "targetSdkVersion": "26.0.0",
-        "compatibleSdkVersion": "6.1.0(23)",
+        "compatibleSdkVersion": "6.0.0(20)",
         "runtimeOS": "HarmonyOS",
         "buildOption": {
           "strictMode": {


### PR DESCRIPTION
## 变更内容

仅改工程级 `build-profile.json5` 的 SDK 版本三字段（2 增 1 删），不动签名配置与任何代码：

| 字段 | 变更前 | 变更后 |
|---|---|---|
| compileSdkVersion | （未配置，缺省） | `26.0.0` |
| targetSdkVersion | `26.0.0` | `26.0.0`（不变） |
| compatibleSdkVersion | `6.1.0(23)` | `6.0.0(20)` |

## 说明

- 官方版本序列中无 "鸿蒙 7.0"：6.x 之后版本号改为语义化格式，当前最新大版本即 **26.0.0**（2026-08-29 Release，配套 DevEco Studio 26.0.0）。目标/编译版本取 26.0.0 即为最新。
- `compatibleSdkVersion` 降至 6.0.0(20) 后，HarmonyOS 6.0 及以上设备均可安装运行。
- 版本约束满足：compatible(6.0.0(20)) ≤ target(26.0.0) ≤ compile(26.0.0)；26 之前版本须写 `X.Y.Z(N)` 带底座 API 号格式。
- `compileSdkVersion` 显式补齐，与 DevEco Studio 26.0.0 内置 SDK 配套（该字段只允许配当前 IDE 配套 SDK）。

## 本地验证

- `devecocli build clean` + `devecocli build --modules entry wearable common uikit`：BUILD SUCCESSFUL。
- 全工程 **0 条** 11706011/11706012 API 兼容性告警，即 6.0 之后引入的 API 调用均已有 `deviceInfo.apiAvailable()` 守卫（如沉浸材质 `uiMaterial.isImmersiveMaterialSupported`）。

## 风险

- 构建期兼容检查已通过；建议后续在 HarmonyOS 6.0 真机跑一轮冒烟（BLE 手表同步、沉浸材质路径）。