### PR TITLE
fix: unify navigation styling and refine group sidebar interactions

### DIFF
--- a/common/src/main/ets/utils/AppPreference.ets
+++ b/common/src/main/ets/utils/AppPreference.ets
@@ -413,7 +413,7 @@ export class MaterialPreference {
   /** 默认开启，仅在系统支持的区域应用 */
   @Trace app_appearance_immersive_enable: boolean = true;
   /** 沉浸材质厚度偏好（SettingImmersiveStyle 五档） */
-  @Trace app_appearance_immersive_style: number = SettingImmersiveStyle.REGULAR;
+  @Trace app_appearance_immersive_style: number = SettingImmersiveStyle.THICK;
   @Trace app_appearance_immersive_interactive: boolean = true;
   @Trace app_appearance_immersive_light_effect: boolean = true;
   @Trace app_appearance_material_shadow: boolean = true;
@@ -556,8 +556,8 @@ export class AppPreference {
     [PREF_KEYS.WANT_URI, ''],
     // 沉浸光感开关（默认开启）
     [PREF_KEYS.APPEARANCE_IMMERSIVE_ENABLE, true],
-    // 沉浸材质厚度偏好（默认常规）
-    [PREF_KEYS.APPEARANCE_IMMERSIVE_STYLE, SettingImmersiveStyle.REGULAR],
+    // 沉浸材质厚度偏好（默认厚）
+    [PREF_KEYS.APPEARANCE_IMMERSIVE_STYLE, SettingImmersiveStyle.THICK],
     [PREF_KEYS.APPEARANCE_IMMERSIVE_INTERACTIVE, true],
     [PREF_KEYS.APPEARANCE_IMMERSIVE_LIGHT_EFFECT, true],
     [PREF_KEYS.APPEARANCE_MATERIAL_SHADOW, true],

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -1684,7 +1684,7 @@
     },
     {
       "name": "setting_immersive_interactive_desc",
-      "value": "Animate supported native material controls when pressed. Does not affect HDS title bars."
+      "value": "Animate supported native material controls when pressed."
     },
     {
       "name": "setting_immersive_light_effect",
@@ -1692,7 +1692,7 @@
     },
     {
       "name": "setting_immersive_light_effect_desc",
-      "value": "Show touch lighting on supported native material controls, independently of deformation. Does not affect HDS title bars."
+      "value": "Show touch lighting on supported native material controls, independently of deformation."
     },
     {
       "name": "setting_material_reset_colors",
@@ -1704,7 +1704,7 @@
     },
     {
       "name": "setting_material_shadow_desc",
-      "value": "Control native material shadows, not separately configured shadows or HDS title bars."
+      "value": "Control native material shadows."
     },
     {
       "name": "setting_material_color",
@@ -1720,7 +1720,7 @@
     },
     {
       "name": "setting_light_color_desc",
-      "value": "White by default. Requires touch lighting and a supported API 26+ device. Does not affect HDS title bars."
+      "value": "White by default. Requires touch lighting and a supported API 26+ device."
     },
     {
       "name": "setting_immersive_enable",
@@ -1736,7 +1736,7 @@
     },
     {
       "name": "setting_immersive_style_desc",
-      "value": "Adjust translucency; excludes HDS bars."
+      "value": "Adjust translucency."
     },
     {
       "name": "setting_immersive_style_ultra_thin",

--- a/common/src/main/resources/base/element/string.json
+++ b/common/src/main/resources/base/element/string.json
@@ -24,6 +24,7 @@
     { "name": "token_multi_delete_title", "value": "Delete %d selected tokens?" },
     { "name": "token_multi_success", "value": "Processed %d tokens" },
     { "name": "token_multi_failed", "value": "%d tokens could not be processed. Try again. NFC session tokens cannot be favorited or grouped." },
+    { "name": "token_group_manage", "value": "Manage groups" },
     { "name": "token_group_open_sidebar", "value": "Open groups sidebar" },
     { "name": "token_group_close_sidebar", "value": "Close groups sidebar" },
     { "name": "token_group_all", "value": "All tokens" },

--- a/common/src/main/resources/en_US/element/string.json
+++ b/common/src/main/resources/en_US/element/string.json
@@ -1646,7 +1646,7 @@
     },
     {
       "name": "setting_immersive_interactive_desc",
-      "value": "Animate supported native material controls when pressed. Does not affect HDS title bars."
+      "value": "Animate supported native material controls when pressed."
     },
     {
       "name": "setting_immersive_light_effect",
@@ -1654,7 +1654,7 @@
     },
     {
       "name": "setting_immersive_light_effect_desc",
-      "value": "Show touch lighting on supported native material controls, independently of deformation. Does not affect HDS title bars."
+      "value": "Show touch lighting on supported native material controls, independently of deformation."
     },
     {
       "name": "setting_material_reset_colors",
@@ -1666,7 +1666,7 @@
     },
     {
       "name": "setting_material_shadow_desc",
-      "value": "Control native material shadows, not separately configured shadows or HDS title bars."
+      "value": "Control native material shadows."
     },
     {
       "name": "setting_material_color",
@@ -1682,7 +1682,7 @@
     },
     {
       "name": "setting_light_color_desc",
-      "value": "White by default. Requires touch lighting and a supported API 26+ device. Does not affect HDS title bars."
+      "value": "White by default. Requires touch lighting and a supported API 26+ device."
     },
     {
       "name": "setting_immersive_enable",
@@ -1698,7 +1698,7 @@
     },
     {
       "name": "setting_immersive_style_desc",
-      "value": "Adjust translucency; excludes HDS bars."
+      "value": "Adjust translucency."
     },
     {
       "name": "setting_immersive_style_ultra_thin",

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -1672,7 +1672,7 @@
     },
     {
       "name": "setting_immersive_interactive_desc",
-      "value": "按压支持的原生材质控件时产生弹性形变，不影响 HDS 标题栏。"
+      "value": "按压支持的原生材质控件时产生弹性形变。"
     },
     {
       "name": "setting_immersive_light_effect",
@@ -1680,7 +1680,7 @@
     },
     {
       "name": "setting_immersive_light_effect_desc",
-      "value": "为支持的原生材质控件显示触摸光感反馈，与形变独立，不影响 HDS 标题栏。"
+      "value": "为支持的原生材质控件显示触摸光感反馈，与形变独立。"
     },
     {
       "name": "setting_material_reset_colors",
@@ -1692,7 +1692,7 @@
     },
     {
       "name": "setting_material_shadow_desc",
-      "value": "控制原生材质自带阴影，不影响组件单独设置的阴影或 HDS 标题栏。"
+      "value": "控制原生材质自带阴影。"
     },
     {
       "name": "setting_material_color",
@@ -1708,7 +1708,7 @@
     },
     {
       "name": "setting_light_color_desc",
-      "value": "默认白色，开启触摸光效后生效。需 API 26+ 支持光效的设备，不影响 HDS 标题栏。"
+      "value": "默认白色，开启触摸光效后生效。需 API 26+ 支持光效的设备。"
     },
     {
       "name": "setting_immersive_enable",
@@ -1724,7 +1724,7 @@
     },
     {
       "name": "setting_immersive_style_desc",
-      "value": "调节通透程度，不影响 HDS 导航与页签。"
+      "value": "调节通透程度。"
     },
     {
       "name": "setting_immersive_style_ultra_thin",

--- a/common/src/main/resources/zh_CN/element/string.json
+++ b/common/src/main/resources/zh_CN/element/string.json
@@ -24,6 +24,7 @@
     { "name": "token_multi_delete_title", "value": "删除选中的 %d 个令牌？" },
     { "name": "token_multi_success", "value": "已处理 %d 个令牌" },
     { "name": "token_multi_failed", "value": "%d 个令牌未完成，请重试。NFC 会话令牌不支持收藏和分组。" },
+    { "name": "token_group_manage", "value": "管理分组" },
     { "name": "token_group_open_sidebar", "value": "展开分组侧栏" },
     { "name": "token_group_close_sidebar", "value": "收起分组侧栏" },
     { "name": "token_group_all", "value": "全部令牌" },

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -1672,7 +1672,7 @@
     },
     {
       "name": "setting_immersive_interactive_desc",
-      "value": "按壓支援的原生材質控制項時產生彈性形變，不影響 HDS 標題列。"
+      "value": "按壓支援的原生材質控制項時產生彈性形變。"
     },
     {
       "name": "setting_immersive_light_effect",
@@ -1680,7 +1680,7 @@
     },
     {
       "name": "setting_immersive_light_effect_desc",
-      "value": "為支援的原生材質控制項顯示觸控光感回饋，與形變獨立，不影響 HDS 標題列。"
+      "value": "為支援的原生材質控制項顯示觸控光感回饋，與形變獨立。"
     },
     {
       "name": "setting_material_reset_colors",
@@ -1692,7 +1692,7 @@
     },
     {
       "name": "setting_material_shadow_desc",
-      "value": "控制原生材質自帶陰影，不影響控制項單獨設定的陰影或 HDS 標題列。"
+      "value": "控制原生材質自帶陰影。"
     },
     {
       "name": "setting_material_color",
@@ -1708,7 +1708,7 @@
     },
     {
       "name": "setting_light_color_desc",
-      "value": "預設白色，開啟觸控光效後生效。需 API 26+ 支援光效的裝置，不影響 HDS 標題列。"
+      "value": "預設白色，開啟觸控光效後生效。需 API 26+ 支援光效的裝置。"
     },
     {
       "name": "setting_immersive_enable",
@@ -1724,7 +1724,7 @@
     },
     {
       "name": "setting_immersive_style_desc",
-      "value": "調整通透程度，不影響 HDS 導覽與分頁。"
+      "value": "調整通透程度。"
     },
     {
       "name": "setting_immersive_style_ultra_thin",

--- a/common/src/main/resources/zh_TW/element/string.json
+++ b/common/src/main/resources/zh_TW/element/string.json
@@ -24,6 +24,7 @@
     { "name": "token_multi_delete_title", "value": "刪除選中的 %d 個權杖？" },
     { "name": "token_multi_success", "value": "已處理 %d 個權杖" },
     { "name": "token_multi_failed", "value": "%d 個權杖未完成，請重試。NFC 工作階段權杖不支援收藏和分組。" },
+    { "name": "token_group_manage", "value": "管理分組" },
     { "name": "token_group_open_sidebar", "value": "展開分組側欄" },
     { "name": "token_group_close_sidebar", "value": "收起分組側欄" },
     { "name": "token_group_all", "value": "全部權杖" },

--- a/entry/src/main/ets/components/MaterialTheme.ets
+++ b/entry/src/main/ets/components/MaterialTheme.ets
@@ -1,7 +1,7 @@
 import { MaterialPreference, SettingImmersiveStyle } from 'common';
 import { AppStorageV2, uiMaterial } from '@kit.ArkUI';
 import { deviceInfo } from '@kit.BasicServicesKit';
-import { hdsMaterial } from '@kit.UIDesignKit';
+import { hdsMaterial, HdsNavigationIconItemStyle, HdsNavigationTitleBarStyle } from '@kit.UIDesignKit';
 import { MaterialPolicy } from '../utils/MaterialPolicy';
 
 /** 只提供材质实参，不包装组件；调用方必须处于官方允许的生效区域。 */
@@ -67,6 +67,28 @@ export class MaterialTheme {
     return MaterialTheme.materialPref().app_appearance_immersive_enable &&
       MaterialPolicy.getInstance().getTier() !== 'solid' ?
       hdsMaterial.MaterialType.IMMERSIVE : hdsMaterial.MaterialType.NONE;
+  }
+
+  /** 无光感时，标题栏图标在初始和滚动状态下使用相同的系统灰色背板。 */
+  static navigationIconStyle(): HdsNavigationIconItemStyle {
+    return {
+      iconColor: $r('sys.color.icon_primary'),
+      backgroundColor: MaterialTheme.hdsMaterialType() === hdsMaterial.MaterialType.NONE ?
+        $r('sys.color.comp_background_gray') : undefined
+    };
+  }
+
+  static navigationScrollStyle(): HdsNavigationTitleBarStyle {
+    return {
+      contentStyle: {
+        backIconStyle: {
+          backgroundColor: MaterialTheme.navigationIconStyle().backgroundColor
+        },
+        menuStyle: {
+          backgroundColor: MaterialTheme.navigationIconStyle().backgroundColor
+        }
+      }
+    };
   }
 
   /** HdsTabs 悬浮页签支持独立光效颜色；HDS 材质参数不支持 materialColor。 */

--- a/entry/src/main/ets/components/TokenGroupSidePanel.ets
+++ b/entry/src/main/ets/components/TokenGroupSidePanel.ets
@@ -14,6 +14,7 @@ export struct TokenGroupSidePanel {
   @Local busy: boolean = false;
   @Event onSelect: (id: string) => void = () => {};
   @Event onAdd: () => void = () => {};
+  @Event onClose: () => void = () => {};
   private scroller: Scroller = new Scroller();
   private groupDataSource: GenericDataSource<TokenGroup> = new GenericDataSource<TokenGroup>([]);
 
@@ -254,12 +255,18 @@ export struct TokenGroupSidePanel {
     .mode(NavigationMode.Stack)
     .bindToScrollable([this.scroller])
     .titleMode(HdsNavigationTitleMode.MINI)
-    .hideBackButton(true)
+    .hideBackButton(false)
     .backgroundColor(Color.Transparent)
     .titleBar({
       avoidLayoutSafeArea: true,
       enableComponentSafeArea: true,
       content: {
+        backIcon: {
+          icon: $r('sys.symbol.open_sidebar'),
+          label: $r('app.string.token_group_close_sidebar'),
+          componentId: 'token_group_sidebar_close',
+          action: () => this.onClose()
+        },
         menu: {
           value: [
             {

--- a/entry/src/main/ets/components/TokenGroupSidePanel.ets
+++ b/entry/src/main/ets/components/TokenGroupSidePanel.ets
@@ -1,4 +1,4 @@
-import { HdsNavigation, HdsNavigationTitleMode, ScrollEffectType, hdsMaterial } from '@kit.UIDesignKit';
+import { HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
 import { MaterialTheme } from './MaterialTheme';
 import { ALL_TOKEN_GROUPS, FAVORITE_TOKEN_GROUP, TokenConfig, otpType, TokenGroup, TokenGroupState,
   TokenGroupStore, TokenStore, GenericDataSource, dialogSystemMaterial, showSnackBar, SnackBarNotifyType } from 'common';
@@ -277,21 +277,11 @@ export struct TokenGroupSidePanel {
       style: {
         originalStyle: {
           contentStyle: {
-            menuStyle: {
-              iconColor: $r('sys.color.icon_primary'),
-              backgroundColor: MaterialTheme.hdsMaterialType() === hdsMaterial.MaterialType.NONE ?
-                $r('sys.color.comp_background_gray') : undefined
-            }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           }
         },
-        scrollEffectStyle: {
-          contentStyle: {
-            menuStyle: {
-              backgroundColor: MaterialTheme.hdsMaterialType() === hdsMaterial.MaterialType.NONE ?
-                $r('sys.color.comp_background_gray') : undefined
-            }
-          }
-        },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/AddFortiTokenPage.ets
+++ b/entry/src/main/ets/pages/AddFortiTokenPage.ets
@@ -352,10 +352,11 @@ export struct AddFortiTokenPage {
         originalStyle: {
           contentStyle: {
             titleStyle: { mainTitleColor: $r('sys.color.font_primary'), subTitleColor: $r('sys.color.font_secondary') },
-            backIconStyle: { iconColor: $r('sys.color.icon_primary') },
-            menuStyle: { iconColor: $r('sys.color.icon_primary') }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           }
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: { enableScrollEffect: true, scrollEffectType: this.scrollEffectType },
         systemMaterialEffect: {
           materialType: MaterialTheme.hdsMaterialType(),

--- a/entry/src/main/ets/pages/AddSteamTokenPage.ets
+++ b/entry/src/main/ets/pages/AddSteamTokenPage.ets
@@ -439,10 +439,11 @@ export struct AddSteamTokenPage {
         originalStyle: {
           contentStyle: {
             titleStyle: { mainTitleColor: $r('sys.color.font_primary'), subTitleColor: $r('sys.color.font_secondary') },
-            backIconStyle: { iconColor: $r('sys.color.icon_primary') },
-            menuStyle: { iconColor: $r('sys.color.icon_primary') }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           }
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: { enableScrollEffect: true, scrollEffectType: this.scrollEffectType },
         systemMaterialEffect: {
           materialType: MaterialTheme.hdsMaterialType(),

--- a/entry/src/main/ets/pages/AddTotpTokenPage.ets
+++ b/entry/src/main/ets/pages/AddTotpTokenPage.ets
@@ -371,10 +371,11 @@ export struct AddTotpTokenPage {
         originalStyle: {
           contentStyle: {
             titleStyle: { mainTitleColor: $r('sys.color.font_primary'), subTitleColor: $r('sys.color.font_secondary') },
-            backIconStyle: { iconColor: $r('sys.color.icon_primary') },
-            menuStyle: { iconColor: $r('sys.color.icon_primary') }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           }
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: { enableScrollEffect: true, scrollEffectType: this.scrollEffectType },
         systemMaterialEffect: {
           materialType: MaterialTheme.hdsMaterialType(),

--- a/entry/src/main/ets/pages/AppearancePage.ets
+++ b/entry/src/main/ets/pages/AppearancePage.ets
@@ -619,11 +619,11 @@ export struct AppearancePage {
               mainTitleColor: $r('sys.color.font_primary'),
               subTitleColor: $r('sys.color.font_secondary')
             },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           },
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/BleWatchSyncPage.ets
+++ b/entry/src/main/ets/pages/BleWatchSyncPage.ets
@@ -1,5 +1,6 @@
 import { ble } from '@kit.ConnectivityKit';
 import { hdsMaterial, HdsNavDestination, HdsNavDestinationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
+import { MaterialTheme } from '../components/MaterialTheme';
 import { ConfigurationConstant } from '@kit.AbilityKit';
 import { PageScaffold } from '../components/PageScaffold';
 import { SettingItem } from '../components/SettingItem';
@@ -557,17 +558,17 @@ export struct BleWatchSyncPage {
               mainTitleColor: $r('sys.color.font_primary'),
               subTitleColor: $r('sys.color.font_secondary')
             },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           },
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType
         },
         systemMaterialEffect: {
-          materialType: hdsMaterial.MaterialType.ADAPTIVE,
+          materialType: MaterialTheme.hdsMaterialType(),
           materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE
         }
       },

--- a/entry/src/main/ets/pages/IconPickerPage.ets
+++ b/entry/src/main/ets/pages/IconPickerPage.ets
@@ -149,10 +149,11 @@ export struct IconPickerPage {
               mainTitleColor: $r('sys.color.font_primary'),
               subTitleColor: $r('sys.color.font_secondary')
             },
-            backIconStyle: { iconColor: $r('sys.color.icon_primary') },
-            menuStyle: { iconColor: $r('sys.color.icon_primary') }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           }
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -134,6 +134,9 @@ function TokenActionsMenuBuilder(host: Index) {
       .enabled(!host.multiSelectMode && host.displayTokens.length > 0)
       .onClick(() => host.openMultiSelectPage())
       .accessibilityText($r('app.string.menu_token_multi_select'))
+    MenuItem({ content: $r('app.string.token_group_manage') })
+      .onClick(() => host.openGroupManagement())
+      .accessibilityText($r('app.string.token_group_manage'))
   }
   .width(host.getTokenActionsMenuWidth())
   // 使用原生内嵌展开，让添加和排序选项在各自入口下方显示。
@@ -189,7 +192,6 @@ struct Index {
   @Local CurrentTokens: TokenConfig[] = [];
   @Local groupState: TokenGroupState = TokenGroupStore.getInstance().state;
   @Local groupSidebarOpen: boolean = false;
-  @Local tokenTitleCollapse: number = 0;
 
   onBackPress(): boolean {
     if (this.multiSelectMode && !this.isAppLockOverlayVisible) {
@@ -229,7 +231,6 @@ struct Index {
     }
     this.exitMultiSelect();
     this.groupState.selectedId = id;
-    this.tokenTitleCollapse = 0;
     this.tokenListScroller.scrollTo({ xOffset: 0, yOffset: 0 });
     if (this.selectedTokenUUID !== '' &&
       !this.displayTokens.some(token => token.TokenUUID === this.selectedTokenUUID)) {
@@ -1078,6 +1079,10 @@ struct Index {
     });
   }
 
+  openGroupManagement(): void {
+    this.groupSidebarOpen = true;
+  }
+
   getTokenActionsMenuWidth(): number | undefined {
     const uiContext = this.getUIContext();
     const measure = uiContext.getMeasureUtils();
@@ -1090,6 +1095,7 @@ struct Index {
       $r('app.string.menu_add_nfc_read'),
       $r('app.string.menu_token_sort_method'),
       $r('app.string.menu_token_multi_select'),
+      $r('app.string.token_group_manage'),
       $r('app.string.menu_token_sort_default'),
       $r('app.string.menu_token_sort_username_ascending'),
       $r('app.string.menu_token_sort_token_name_ascending'),
@@ -1314,11 +1320,6 @@ struct Index {
   @Builder
   HomeContentBuilder(multiSelect: boolean = false) {
     HomeTabs({
-      onTokenListScroll: (offset: number) => {
-        if (!multiSelect) {
-          this.tokenTitleCollapse = Math.min(1, Math.max(0, offset / 56));
-        }
-      },
       tokens: this.displayTokens,
       multiSelectMode: multiSelect,
       listStartOffset: multiSelect ? this.window.AvoidTopHeight + CommonConstants.AVOID_TOP_BASE_HEIGHT : 0,
@@ -1365,7 +1366,6 @@ struct Index {
         currentHomeTabIndex: this.currentHomeTabIndex,
         onSelectGroup: (id: string) => this.selectGroup(id),
         groupSidebarOpen: this.groupSidebarOpen,
-        tokenTitleCollapse: this.tokenTitleCollapse,
         $groupSidebarOpen: (open: boolean) => { this.groupSidebarOpen = open; },
         window: this.window,
         businessSplitEnabled: this.businessSplitEnabled,

--- a/entry/src/main/ets/pages/ShowCloudBackupHistoryPage.ets
+++ b/entry/src/main/ets/pages/ShowCloudBackupHistoryPage.ets
@@ -186,11 +186,11 @@ export struct ShowCloudBackupHistoryPage {
               mainTitleColor: $r('sys.color.font_primary'),
               subTitleColor: $r('sys.color.font_secondary')
             },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           },
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
+++ b/entry/src/main/ets/pages/ShowCloudSyncDetailsPage.ets
@@ -479,11 +479,11 @@ export struct ShowCloudSyncDetailsPage {
               mainTitleColor: $r('sys.color.font_primary'),
               subTitleColor: $r('sys.color.font_secondary')
             },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           },
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/ShowDataSyncDetailsPage.ets
+++ b/entry/src/main/ets/pages/ShowDataSyncDetailsPage.ets
@@ -152,11 +152,11 @@ export struct ShowDataSyncDetailsPage {
               mainTitleColor: $r('sys.color.font_primary'),
               subTitleColor: $r('sys.color.font_secondary')
             },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           },
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/SteamConfirmationsPage.ets
+++ b/entry/src/main/ets/pages/SteamConfirmationsPage.ets
@@ -238,10 +238,11 @@ export struct SteamConfirmationsPage {
                 mainTitleColor: $r('sys.color.font_primary'),
                 subTitleColor: $r('sys.color.font_secondary')
               },
-              backIconStyle: { iconColor: $r('sys.color.icon_primary') },
-              menuStyle: { iconColor: $r('sys.color.icon_primary') }
+              backIconStyle: MaterialTheme.navigationIconStyle(),
+              menuStyle: MaterialTheme.navigationIconStyle()
             }
           },
+          scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
           scrollEffectOpts: { enableScrollEffect: true, scrollEffectType: this.scrollEffectType },
           systemMaterialEffect: {
             materialType: MaterialTheme.hdsMaterialType(),

--- a/entry/src/main/ets/pages/TokenCardConfigPage.ets
+++ b/entry/src/main/ets/pages/TokenCardConfigPage.ets
@@ -134,14 +134,11 @@ export struct TokenCardConfigPage {
               mainTitleColor: $r('sys.color.font_primary'),
               subTitleColor: $r('sys.color.font_secondary')
             },
-            menuStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            }
+            menuStyle: MaterialTheme.navigationIconStyle(),
+            backIconStyle: MaterialTheme.navigationIconStyle()
           },
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/TokenMultiSelectPage.ets
+++ b/entry/src/main/ets/pages/TokenMultiSelectPage.ets
@@ -30,9 +30,11 @@ export struct TokenMultiSelectPage {
         originalStyle: {
           contentStyle: {
             titleStyle: { mainTitleColor: $r('sys.color.font_primary') },
-            backIconStyle: { iconColor: $r('sys.color.icon_primary') }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           }
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/TokenSearchPage.ets
+++ b/entry/src/main/ets/pages/TokenSearchPage.ets
@@ -192,11 +192,11 @@ export struct TokenSearchPage {
             titleStyle: {
               mainTitleColor: $r('sys.color.font_primary'),
             },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           },
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType,

--- a/entry/src/main/ets/pages/TokenSortPage.ets
+++ b/entry/src/main/ets/pages/TokenSortPage.ets
@@ -124,11 +124,11 @@ export struct TokenSortPage {
             titleStyle: {
               mainTitleColor: $r('sys.color.font_primary'),
             },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           },
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType,

--- a/entry/src/main/ets/pages/WatchSyncPage.ets
+++ b/entry/src/main/ets/pages/WatchSyncPage.ets
@@ -366,11 +366,11 @@ export struct WatchSyncPage {
               mainTitleColor: $r('sys.color.font_primary'),
               subTitleColor: $r('sys.color.font_secondary')
             },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           },
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/WebPage.ets
+++ b/entry/src/main/ets/pages/WebPage.ets
@@ -73,10 +73,11 @@ export struct WebPage {
                 mainTitleColor: $r('sys.color.font_primary'),
                 subTitleColor: $r('sys.color.font_secondary')
               },
-              backIconStyle: { iconColor: $r('sys.color.icon_primary') },
-              menuStyle: { iconColor: $r('sys.color.icon_primary') }
+              backIconStyle: MaterialTheme.navigationIconStyle(),
+              menuStyle: MaterialTheme.navigationIconStyle()
             }
           },
+          scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.scrollEffectType
@@ -122,11 +123,11 @@ export struct WebPage {
               mainTitleColor: $r('sys.color.font_primary'),
               subTitleColor: $r('sys.color.font_secondary')
             },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary')
-            }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           },
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         systemMaterialEffect: {
           materialType: MaterialTheme.hdsMaterialType(),
           materialLevel: hdsMaterial.MaterialLevel.ADAPTIVE

--- a/entry/src/main/ets/pages/setting/AboutSheet.ets
+++ b/entry/src/main/ets/pages/setting/AboutSheet.ets
@@ -243,11 +243,11 @@ export struct AboutSheet {
                 mainTitleColor: $r('sys.color.font_primary'),
                 subTitleColor: $r('sys.color.font_secondary')
               },
-              backIconStyle: {
-                iconColor: $r('sys.color.icon_primary')
-              }
+              backIconStyle: MaterialTheme.navigationIconStyle(),
+              menuStyle: MaterialTheme.navigationIconStyle()
             },
           },
+          scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.scrollEffectStyle

--- a/entry/src/main/ets/pages/setting/AgreementSheet.ets
+++ b/entry/src/main/ets/pages/setting/AgreementSheet.ets
@@ -95,11 +95,11 @@ export struct AgreementSheet {
                 mainTitleColor: $r('sys.color.font_primary'),
                 subTitleColor: $r('sys.color.font_secondary')
               },
-              backIconStyle: {
-                iconColor: $r('sys.color.icon_primary')
-              }
+              backIconStyle: MaterialTheme.navigationIconStyle(),
+              menuStyle: MaterialTheme.navigationIconStyle()
             },
           },
+          scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/setting/AppearanceSheet.ets
+++ b/entry/src/main/ets/pages/setting/AppearanceSheet.ets
@@ -312,11 +312,11 @@ export struct AppearanceSheet {
                 mainTitleColor: $r('sys.color.font_primary'),
                 subTitleColor: $r('sys.color.font_secondary')
               },
-              backIconStyle: {
-                iconColor: $r('sys.color.icon_primary')
-              }
+              backIconStyle: MaterialTheme.navigationIconStyle(),
+              menuStyle: MaterialTheme.navigationIconStyle()
             },
           },
+          scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/setting/BackupAndMigrationSheet.ets
+++ b/entry/src/main/ets/pages/setting/BackupAndMigrationSheet.ets
@@ -417,11 +417,11 @@ export struct BackupAndMigrationSheet {
                 mainTitleColor: $r('sys.color.font_primary'),
                 subTitleColor: $r('sys.color.font_secondary')
               },
-              backIconStyle: {
-                iconColor: $r('sys.color.icon_primary')
-              }
+              backIconStyle: MaterialTheme.navigationIconStyle(),
+              menuStyle: MaterialTheme.navigationIconStyle()
             },
           },
+          scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.scrollEffectStyle

--- a/entry/src/main/ets/pages/setting/DataSyncSheet.ets
+++ b/entry/src/main/ets/pages/setting/DataSyncSheet.ets
@@ -147,11 +147,11 @@ export struct DataSyncSheet {
                 mainTitleColor: $r('sys.color.font_primary'),
                 subTitleColor: $r('sys.color.font_secondary')
               },
-              backIconStyle: {
-                iconColor: $r('sys.color.icon_primary')
-              }
+              backIconStyle: MaterialTheme.navigationIconStyle(),
+              menuStyle: MaterialTheme.navigationIconStyle()
             },
           },
+          scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/setting/DeveloperOptionsSheet.ets
+++ b/entry/src/main/ets/pages/setting/DeveloperOptionsSheet.ets
@@ -146,11 +146,11 @@ export struct DeveloperOptionsSheet {
                 mainTitleColor: $r('sys.color.font_primary'),
                 subTitleColor: $r('sys.color.font_secondary')
               },
-              backIconStyle: {
-                iconColor: $r('sys.color.icon_primary')
-              }
+              backIconStyle: MaterialTheme.navigationIconStyle(),
+              menuStyle: MaterialTheme.navigationIconStyle()
             },
           },
+          scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/setting/FeedbackSheet.ets
+++ b/entry/src/main/ets/pages/setting/FeedbackSheet.ets
@@ -101,12 +101,15 @@ export struct FeedbackSheet {
         style: {
           originalStyle: {
             contentStyle: {
+              backIconStyle: MaterialTheme.navigationIconStyle(),
+              menuStyle: MaterialTheme.navigationIconStyle(),
               titleStyle: {
                 mainTitleColor: $r('sys.color.font_primary'),
                 subTitleColor: $r('sys.color.font_secondary')
               }
             },
           },
+          scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.scrollEffectType

--- a/entry/src/main/ets/pages/setting/SecuritySheet.ets
+++ b/entry/src/main/ets/pages/setting/SecuritySheet.ets
@@ -178,11 +178,11 @@ export struct SecuritySheet {
                 mainTitleColor: $r('sys.color.font_primary'),
                 subTitleColor: $r('sys.color.font_secondary')
               },
-              backIconStyle: {
-                iconColor: $r('sys.color.icon_primary')
-              }
+              backIconStyle: MaterialTheme.navigationIconStyle(),
+              menuStyle: MaterialTheme.navigationIconStyle()
             },
           },
+          scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
           scrollEffectOpts: {
             enableScrollEffect: true,
             scrollEffectType: this.scrollEffectStyle

--- a/entry/src/main/ets/pages/setting/UriImportSheet.ets
+++ b/entry/src/main/ets/pages/setting/UriImportSheet.ets
@@ -130,10 +130,11 @@ export struct UriImportSheet {
               mainTitleColor: $r('sys.color.font_primary'),
               subTitleColor: $r('sys.color.font_secondary')
             },
-            backIconStyle: { iconColor: $r('sys.color.icon_primary') },
-            menuStyle: { iconColor: $r('sys.color.icon_primary') }
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
           }
         },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: { enableScrollEffect: true, scrollEffectType: this.scrollEffectStyle },
         systemMaterialEffect: {
           materialType: MaterialTheme.hdsMaterialType(),

--- a/entry/src/main/ets/shell/AppShell.ets
+++ b/entry/src/main/ets/shell/AppShell.ets
@@ -5,7 +5,7 @@ import { ALL_TOKEN_GROUPS, FAVORITE_TOKEN_GROUP, TokenGroupState, TokenGroupStor
   showSnackBar, SnackBarNotifyType } from 'common';
 import { TokenGroupNameDialog } from '../dialogs/TokenGroupNameDialog';
 import { uniformTypeDescriptor } from '@kit.ArkData';
-import { HdsNavDestination, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType, hdsMaterial, HdsSideBar, BottomBuilderShowType } from '@kit.UIDesignKit';
+import { HdsNavDestination, HdsNavigation, HdsNavigationTitleMode, ScrollEffectType, HdsSideBar } from '@kit.UIDesignKit';
 import { AppWindowInfo, ROUTE_NAMES } from 'common';
 // [冷启动优化] 以下 NavDestination 页面仅在用户导航时触发评估
 import lazy { TokenCardConfigPage } from '../pages/TokenCardConfigPage'
@@ -87,7 +87,6 @@ export struct AppShell {
   @Local groupState: TokenGroupState = TokenGroupStore.getInstance().state;
   @Event onSelectGroup: (id: string) => void = () => {};
   @Param groupSidebarOpen: boolean = false;
-  @Param tokenTitleCollapse: number = 0;
   @Event $groupSidebarOpen: (open: boolean) => void = () => {};
   @Require @Param window: AppWindowInfo = new AppWindowInfo();
   @Require @Param businessSplitEnabled: boolean = true;
@@ -159,21 +158,6 @@ export struct AppShell {
 
   aboutToAppear(): void {
     this.$groupSidebarOpen(this.canShowGroupSidebar && this.embedGroupSidebar);
-  }
-
-  @LocalBuilder
-  TokenTitleBuilder() {
-    Text(this.tokenGroupTitle)
-      .id('token_group_title')
-      .fontSize(35 - 5 * this.tokenTitleCollapse)
-      .fontWeight(FontWeight.Bold)
-      .fontColor($r('sys.color.font_primary'))
-      .maxLines(1)
-      .textOverflow({ overflow: TextOverflow.Ellipsis })
-      .width('100%')
-      .height(56 - 8 * this.tokenTitleCollapse)
-      .padding({ left: this.window.WidthVp < 600 ? 16 : this.window.WidthVp < 840 ? 24 : 32,
-        right: this.window.WidthVp < 600 ? 16 : this.window.WidthVp < 840 ? 24 : 32 })
   }
 
   @LocalBuilder
@@ -390,30 +374,11 @@ export struct AppShell {
             titleStyle: {
               mainTitleColor: $r('sys.color.font_primary'),
             },
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary'),
-              backgroundColor: MaterialTheme.hdsMaterialType() === hdsMaterial.MaterialType.NONE ?
-                $r('sys.color.comp_background_gray') : undefined
-            },
-            menuStyle: {
-              iconColor: $r('sys.color.icon_primary'),
-              backgroundColor: MaterialTheme.hdsMaterialType() === hdsMaterial.MaterialType.NONE ?
-                $r('sys.color.comp_background_gray') : undefined
-            },
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle(),
           }
         },
-        scrollEffectStyle: {
-          contentStyle: {
-            backIconStyle: {
-              backgroundColor: MaterialTheme.hdsMaterialType() === hdsMaterial.MaterialType.NONE ?
-                $r('sys.color.comp_background_gray') : undefined
-            },
-            menuStyle: {
-              backgroundColor: MaterialTheme.hdsMaterialType() === hdsMaterial.MaterialType.NONE ?
-                $r('sys.color.comp_background_gray') : undefined
-            }
-          }
-        },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle(),
         scrollEffectOpts: {
           enableScrollEffect: true,
           scrollEffectType: this.scrollEffectType
@@ -424,12 +389,9 @@ export struct AppShell {
         }
       },
       content: {
-        title: this.currentHomeTabIndex === 0 ? undefined : { mainTitle: $r('app.string.tab_me') },
-        bottomBuilder: this.currentHomeTabIndex === 0 ? {
-          builder: (): void => this.TokenTitleBuilder(),
-          height: 56 - 8 * this.tokenTitleCollapse,
-          showType: BottomBuilderShowType.DIRECTLY_SHOW
-        } : undefined,
+        title: {
+          mainTitle: this.currentHomeTabIndex === 0 ? this.tokenGroupTitle : $r('app.string.tab_me')
+        },
         menu: {
           value: this.currentHomeTabIndex === 0 ? [
             {
@@ -457,51 +419,6 @@ export struct AppShell {
         }
       }
     })
-  }
-
-  /** 与侧边栏同级，仅用原生标题栏承载固定开关，保留 HDS 光感材质。 */
-  @LocalBuilder
-  SidebarTitleBarBuilder() {
-    HdsNavigation() {
-    }
-    .width(96)
-    .height('100%')
-    .hitTestBehavior(HitTestMode.Transparent)
-    .mode(NavigationMode.Stack)
-    .titleMode(HdsNavigationTitleMode.MINI)
-    .hideBackButton(false)
-    .hideToolBar(true)
-    .backgroundColor(Color.Transparent)
-    .titleBar({
-      avoidLayoutSafeArea: true,
-      enableComponentSafeArea: true,
-      style: {
-        originalStyle: {
-          contentStyle: {
-            backIconStyle: {
-              iconColor: $r('sys.color.icon_primary'),
-              backgroundColor: MaterialTheme.hdsMaterialType() === hdsMaterial.MaterialType.NONE ?
-                $r('sys.color.comp_background_gray') : undefined
-            }
-          }
-        },
-        scrollEffectOpts: { enableScrollEffect: false },
-        systemMaterialEffect: {
-          materialType: MaterialTheme.hdsMaterialType(),
-          materialLevel: MaterialTheme.hdsMaterialLevel()
-        }
-      },
-      content: {
-        backIcon: {
-          icon: this.groupSidebarOpen ? $r('sys.symbol.open_sidebar') : $r('sys.symbol.close_sidebar'),
-          label: this.groupSidebarOpen ? $r('app.string.token_group_close_sidebar') :
-            $r('app.string.token_group_open_sidebar'),
-          componentId: 'token_group_sidebar_toggle',
-          action: () => this.$groupSidebarOpen(!this.groupSidebarOpen)
-        }
-      }
-    })
-    .zIndex(1)
   }
 
   @LocalBuilder
@@ -544,9 +461,6 @@ export struct AppShell {
   build() {
     Stack({ alignContent: Alignment.TopStart }) {
       this.SidebarBuilder()
-      if (this.canShowGroupSidebar) {
-        this.SidebarTitleBarBuilder()
-      }
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/shell/AppShell.ets
+++ b/entry/src/main/ets/shell/AppShell.ets
@@ -193,6 +193,7 @@ export struct AppShell {
         tokens: this.tokens,
         scrollEffectType: this.scrollEffectType,
         onAdd: () => this.openNewGroupDialog(),
+        onClose: () => this.$groupSidebarOpen(false),
         onSelect: (id: string) => {
           this.onSelectGroup(id);
           if (!this.embedGroupSidebar) {
@@ -449,18 +450,27 @@ export struct AppShell {
     })
     .width('100%')
     .height('100%')
-    .onClick((event: ClickEvent) => {
-      // 仅关闭悬浮侧边栏，侧栏内点击和宽屏嵌入模式保持原行为。
-      if (this.canShowGroupSidebar && this.groupSidebarOpen && !this.embedGroupSidebar &&
-        event.x >= Math.min(380, this.window.WidthVp * 0.78)) {
-        this.$groupSidebarOpen(false);
-      }
-    })
+
   }
 
   build() {
     Stack({ alignContent: Alignment.TopStart }) {
       this.SidebarBuilder()
+      if (this.canShowGroupSidebar && this.groupSidebarOpen) {
+        // 独立命中区拦截侧栏外点击，避免底层控件消费事件或被误触。
+        Row() {
+          Blank()
+            .width(this.embedGroupSidebar ? 240 : Math.min(380, this.window.WidthVp * 0.78))
+            .hitTestBehavior(HitTestMode.None)
+          Column() {}
+            .layoutWeight(1)
+            .height('100%')
+            .onClick(() => this.$groupSidebarOpen(false))
+        }
+        .width('100%')
+        .height('100%')
+        .hitTestBehavior(HitTestMode.Transparent)
+      }
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/shell/SheetCoordinator.ets
+++ b/entry/src/main/ets/shell/SheetCoordinator.ets
@@ -17,6 +17,7 @@ import { AppStorageV2 } from '@kit.ArkUI';
 import { HdsNavigation, HdsNavigationTitleMode, ScrollEffectType } from '@kit.UIDesignKit';
 import lazy { HuaweiAccountManager, HuaweiUserInfo, HuaweiAccountLoginError } from 'common';
 import { MaterialSheetStyle } from '../components/MaterialSheetStyle';
+import { MaterialTheme } from '../components/MaterialTheme';
 import { SettingItem } from '../components/SettingItem';
 import { SubItemButton } from '../components/SubItemButton';
 import { SubItemDivider } from '../components/SubItemDivider';
@@ -400,6 +401,15 @@ export struct SheetCoordinator {
     .titleBar({
       avoidLayoutSafeArea: true,
       enableComponentSafeArea: true,
+      style: {
+        originalStyle: {
+          contentStyle: {
+            backIconStyle: MaterialTheme.navigationIconStyle(),
+            menuStyle: MaterialTheme.navigationIconStyle()
+          }
+        },
+        scrollEffectStyle: MaterialTheme.navigationScrollStyle()
+      },
       content: {
         title: {
           mainTitle: $r('app.string.huawei_account_current')


### PR DESCRIPTION
## 改动说明

统一标题栏与分组侧栏的交互、配色，修复关闭沉浸光感后各页面图标背景不一致的问题。

- 所有页面 HdsNavigation / HdsNavDestination 标题栏的返回图标与菜单图标共用 original / scroll 配色；未启用光感时使用系统灰色背景，启用时保留原生材质效果。
- 主令牌页改为与“我的”页一致的原生 MINI 标题，保留当前分组名称。
- 移除主页独立分组按钮，在菜单“多选”下新增“管理分组”；侧栏自身的 Hds 标题栏提供收起按钮，点击侧栏外部区域关闭侧栏。
- 沉浸光感保持默认开启，默认材质厚度改为“厚”（THICK），保留已保存的用户偏好。
- 删除沉浸光感设置描述中“不影响……”的说明，同步简体、繁体及英文资源。

## 改动类型

- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 重构（refactor）
- [x] 样式调整（style）
- [ ] 文档（docs）
- [ ] 构建 / 依赖 / 配置（chore）

## 检查清单

- [x] **目标分支已选择 `dev`**（不是 `main`）
- [x] 已基于最新 `dev` 创建分支并 rebase，无冲突（已 fetch，当前分支包含最新 dev，落后 0 / 领先 2，无需额外 rebase）
- [x] 本地构建通过（通过 `devecocli run --module entry` 执行 assembleHap）
- [x] 已在真机 / 模拟器上测试，行为符合预期（用户确认）
- [x] commit message 遵循 Conventional Commits 规范
- [x] 未提交本地的 `build-profile.json5` 签名配置、IDE 缓存等产物

## 测试说明

- **已完成真机测试（用户确认）**。设备：HUAWEI Mate 80 Pro Max。
- 助手执行记录：最终代码已构建成功，并成功安装、启动到上述真机；未另外执行自动化 UI 测试或界面回归。
- LocalUnit / `hvigorw test`：按用户要求未在本地运行，不声明测试全绿。合并前仍需等待 Quality CI 通过及维护者 review。
- 未提交本地未跟踪的 `entry/src/main/cpp/`。

## 截图 / 录屏（如涉及 UI 改动）

暂未提供截图或录屏，待补充；本次未额外采集界面验证素材。
