### PR TITLE
test: 三阶段单测落地，逻辑层行覆盖 27%→75.1%、分支→70.3%

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -67,6 +67,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Setup HarmonyOS CLI tools
         uses: ErBWs/setup-ohos@v2
         with:
@@ -103,6 +108,14 @@ jobs:
             exit 1
           fi
           echo "All LocalUnit tests passed - $SUMMARY"
+
+      # hvigorw test regenerates coverageReport.json alongside test_result.txt.
+      # Gate: logic-layer (common + entry crypto/steam/oath/utils, device-only
+      # files excluded per docs/TEST_PLAN.md) line & branch coverage must not
+      # regress against scripts/coverage-baseline.json.
+      - name: Check logic-layer coverage regression
+        run: node scripts/check-coverage.mjs
+        shell: bash
 
   build:
     name: Build HAP (all modules)

--- a/AppScope/app.json5
+++ b/AppScope/app.json5
@@ -2,7 +2,7 @@
   "app": {
     "bundleName": "smartcityshenzhen.yylx.totptoken",
     "vendor": "opensource",
-    "versionCode": 1003000,
+    "versionCode": 1003001,
     "versionName": "1.3.0",
     "icon": "$media:app_icon",
     "label": "$string:app_name",

--- a/common/Index.ets
+++ b/common/Index.ets
@@ -48,3 +48,5 @@ export * from './src/main/ets/utils/importers/URIImporter';
 export * from './src/main/ets/utils/proto/ProtoReader';
 export * from './src/main/ets/utils/proto/ProtoWriter';
 export * from './src/main/ets/utils/GoogleAuthMigration';
+export * from './src/main/ets/utils/StoragePorts';
+export * from './src/main/ets/utils/TokenKvBatch';

--- a/common/Index.ets
+++ b/common/Index.ets
@@ -50,3 +50,4 @@ export * from './src/main/ets/utils/proto/ProtoWriter';
 export * from './src/main/ets/utils/GoogleAuthMigration';
 export * from './src/main/ets/utils/StoragePorts';
 export * from './src/main/ets/utils/TokenKvBatch';
+export * from './src/main/ets/utils/TransferProtocol';

--- a/common/src/main/ets/models/ResponsiveLayoutPolicy.ets
+++ b/common/src/main/ets/models/ResponsiveLayoutPolicy.ets
@@ -19,14 +19,20 @@ export class ResponsiveLayoutState {
  * 将物理像素窗口尺寸统一转换为 vp 后计算布局，避免组件各自复制断点逻辑。
  */
 export class ResponsiveLayoutPolicy {
+  /** 设备端入口：px → vp 换算后委托 {@link resolveVp}。 */
   static resolve(uiContext: UIContext, size: window.Size): ResponsiveLayoutState {
+    return ResponsiveLayoutPolicy.resolveVp(uiContext.px2vp(size.width), uiContext.px2vp(size.height));
+  }
+
+  /** 纯计算入口：直接接收 vp 数值，LocalUnit 可离线覆盖断点决策。 */
+  static resolveVp(widthVp: number, heightVp: number): ResponsiveLayoutState {
     const state = new ResponsiveLayoutState();
-    state.widthVp = uiContext.px2vp(size.width);
-    state.heightVp = uiContext.px2vp(size.height);
-    state.heightToWidthRatio = state.widthVp > 0 ? state.heightVp / state.widthVp : 0;
+    state.widthVp = widthVp;
+    state.heightVp = heightVp;
+    state.heightToWidthRatio = widthVp > 0 ? heightVp / widthVp : 0;
     // 一级导航位置只取决于横向断点；业务分栏还需满足宽高比，二者不能共用同一布尔值。
-    state.useSideNavigation = state.widthVp >= RESPONSIVE_SIDE_NAV_MIN_WIDTH_VP;
-    state.allowSplit = state.widthVp >= RESPONSIVE_SPLIT_MIN_WIDTH_VP &&
+    state.useSideNavigation = widthVp >= RESPONSIVE_SIDE_NAV_MIN_WIDTH_VP;
+    state.allowSplit = widthVp >= RESPONSIVE_SPLIT_MIN_WIDTH_VP &&
       state.heightToWidthRatio < RESPONSIVE_SPLIT_MAX_ASPECT_RATIO;
     return state;
   }

--- a/common/src/main/ets/utils/AppPreference.ets
+++ b/common/src/main/ets/utils/AppPreference.ets
@@ -1,5 +1,6 @@
 import { PreferenceManager } from "./PreferenceManager";
 import { AppStorageV2 } from "@kit.ArkUI";
+import { hilog } from '@kit.PerformanceAnalysisKit';
 
 /**
  * 事件名称常量
@@ -645,7 +646,11 @@ export class AppPreference {
    */
   public static setPreference(key: string, value: SettingValue): void {
     AppPreference.settings.set(key, value);
-    AppPreference.prefMgr.setValue<SettingValue>(key, value);
+    // 内存缓存是权威读取来源；持久化失败（如 LocalUnit/无上下文环境）不产生未处理拒绝，
+    // 但留 warn 痕迹（磁盘满等真实故障重启即丢，需可诊断）。
+    AppPreference.prefMgr.setValue<SettingValue>(key, value).catch(() => {
+      hilog.warn(0xFF00, 'AppPreference', 'persist failed for key: ' + key);
+    });
   }
 
   /**

--- a/common/src/main/ets/utils/AssetSecretStore.ets
+++ b/common/src/main/ets/utils/AssetSecretStore.ets
@@ -2,6 +2,8 @@ import { asset } from '@kit.AssetStoreKit';
 import { util } from '@kit.ArkTS';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { BusinessError } from '@kit.BasicServicesKit';
+import { SecretStore } from './StoragePorts';
+import { utf8ByteLength } from './SteamAuth';
 
 const TAG = 'AssetSecretStore';
 const DOMAIN = 0xFF00;
@@ -36,7 +38,7 @@ function uint8ArrayToString(arr: Uint8Array): string {
  * - DATA_LABEL_NORMAL_1: 写入时附加统一标签，供未来属性级批量查询使用
  *   注意：存量 ASSET 条目无此标签，未来采用标签查询前需执行一次性 re-upsert 迁移
  */
-export class AssetSecretStore {
+export class AssetSecretStore implements SecretStore {
   private static instance: AssetSecretStore;
 
   private constructor() {}
@@ -53,7 +55,7 @@ export class AssetSecretStore {
     if (secret.length === 0) {
       return false;
     }
-    return stringToUint8Array(secret).byteLength <= MAX_SECRET_BYTES;
+    return utf8ByteLength(secret) <= MAX_SECRET_BYTES;
   }
 
   /** 构建 ASSET ALIAS: {ALIAS_PREFIX}{tokenUUID} */

--- a/common/src/main/ets/utils/BackupRestoreHelper.ets
+++ b/common/src/main/ets/utils/BackupRestoreHelper.ets
@@ -28,19 +28,57 @@ const TAG = 'BackupRestoreHelper';
  */
 
 /**
+ * 换机迁移 KV 端口：加密 KV ↔ 非加密 KV 的拷贝与清理。
+ * 生产实现包装 KvManager（distributedKVStore，LocalUnit 不可用）；
+ * performBackup/performRestore 的编排决策（何时清理、计数返回、错误传播）经端口可测。
+ */
+export interface DeviceMigrationKv {
+  initForBackup(ctx: common.Context): Promise<void>;
+  /** 加密KV → 非加密KV，返回同步条数 */
+  copyToNoEncrypt(): Promise<number>;
+  /** 非加密KV → 加密KV，返回恢复条数 */
+  copyToEncrypt(): Promise<number>;
+  /** 清空非加密KV（明文中转数据） */
+  clearNoEncrypt(): Promise<void>;
+}
+
+class KvManagerDeviceMigration implements DeviceMigrationKv {
+  async initForBackup(ctx: common.Context): Promise<void> {
+    await KvManager.getInstance().initKvManagerForBackup(ctx);
+  }
+
+  async copyToNoEncrypt(): Promise<number> {
+    return KvManager.getInstance().DataSyncToNoEncryptDatabase();
+  }
+
+  async copyToEncrypt(): Promise<number> {
+    return KvManager.getInstance().DataSyncToEncryptDatabase();
+  }
+
+  async clearNoEncrypt(): Promise<void> {
+    await KvManager.getInstance().ClearNoEncryptDatabase();
+  }
+}
+
+function defaultMigrationKv(): DeviceMigrationKv {
+  return new KvManagerDeviceMigration();
+}
+
+/**
  * 执行换机备份：加密KV → 非加密KV.
  * 备份完成后不清理非加密KV，因为系统需要在onBackup之后传输非加密KV文件到新设备.
- * DataSyncToNoEncryptDatabase内部会先清空非加密KV再写入，避免旧数据残留.
+ * copyToNoEncrypt内部会先清空非加密KV再写入，避免旧数据残留.
  * 操作失败时抛出Error，由BackupExtension感知并处理.
  *
  * @param ctx - BackupExtensionContext
+ * @param migrationKv - 换机迁移 KV 端口（默认 KvManager；测试注入内存实现）
  * @returns 同步条数
  */
-export async function performBackup(ctx: common.Context): Promise<number> {
+export async function performBackup(ctx: common.Context, migrationKv: DeviceMigrationKv = defaultMigrationKv()):
+  Promise<number> {
   hilog.info(0, TAG, 'performBackup start');
-  const kvMgr = KvManager.getInstance();
-  await kvMgr.initKvManagerForBackup(ctx);
-  const count = await kvMgr.DataSyncToNoEncryptDatabase();
+  await migrationKv.initForBackup(ctx);
+  const count = await migrationKv.copyToNoEncrypt();
   hilog.info(0, TAG, `performBackup: synced ${count} entries to non-encrypted KV.`);
   return count;
 }
@@ -48,19 +86,20 @@ export async function performBackup(ctx: common.Context): Promise<number> {
 /**
  * 执行换机恢复：非加密KV → 加密KV.
  * 仅在恢复成功（count > 0）时才清理非加密KV，避免恢复失败时清除唯一数据副本.
- * DataSyncToEncryptDatabase失败时抛出Error，由BackupExtension感知并处理.
+ * copyToEncrypt失败时抛出Error，由BackupExtension感知并处理.
  *
  * @param ctx - BackupExtensionContext
+ * @param migrationKv - 换机迁移 KV 端口（默认 KvManager；测试注入内存实现）
  * @returns 恢复条数
  */
-export async function performRestore(ctx: common.Context): Promise<number> {
+export async function performRestore(ctx: common.Context, migrationKv: DeviceMigrationKv = defaultMigrationKv()):
+  Promise<number> {
   hilog.info(0, TAG, 'performRestore start');
-  const kvMgr = KvManager.getInstance();
-  await kvMgr.initKvManagerForBackup(ctx);
-  const count = await kvMgr.DataSyncToEncryptDatabase();
+  await migrationKv.initForBackup(ctx);
+  const count = await migrationKv.copyToEncrypt();
   if (count > 0) {
     hilog.info(0, TAG, `performRestore: restored ${count} entries to encrypted KV.`);
-    await kvMgr.ClearNoEncryptDatabase();
+    await migrationKv.clearNoEncrypt();
     hilog.info(0, TAG, 'performRestore: non-encrypted KV cleared.');
   } else {
     hilog.info(0, TAG, 'performRestore: no entries restored, skipping clear to preserve data.');

--- a/common/src/main/ets/utils/BleTokenTransfer.ets
+++ b/common/src/main/ets/utils/BleTokenTransfer.ets
@@ -6,6 +6,16 @@ import { TokenConfig, sanitizedTokenForTransfer } from './TokenConfig';
 import { AppPreference } from './AppPreference';
 import { decryptBlePayload, encryptBlePayload } from './CryptoUtils';
 import { WEAR_SYNC_PREF_KEYS, SettingValuePair, saveTokensBatch, applyWearSettings } from './WearEngineTransfer';
+import {
+  TransferBatch,
+  TransferFrameBuilder,
+  TransferFrameEvent,
+  TransferFrameEventKind,
+  TransferFrameOptions,
+  TransferFrameReceiver,
+  concatenateChunks,
+  utf8Decode,
+} from './TransferProtocol';
 
 const TAG = 'BleTokenTransfer';
 const DOMAIN = 0xFF01;
@@ -97,23 +107,6 @@ function withTimeout<T>(op: Promise<T>, timeoutMs: number, timeoutMsg: string): 
   });
 }
 
-/** 传输头部帧结构 */
-interface TransferHeader {
-  total: number;
-  count: number;
-  /** 消息类型: 缺省为 tokens(向后兼容旧版发送端) */
-  type?: string;
-}
-
-interface ReceiveState {
-  inProgress: boolean;
-  total: number;
-  count: number;
-  type: string;
-  received: number;
-  chunks: Array<Uint8Array>;
-}
-
 /** 消息类型常量 */
 const MSG_TYPE_TOKENS = 'tokens';
 const MSG_TYPE_SETTINGS = 'settings';
@@ -140,15 +133,12 @@ export class BleTokenServer {
   private gattServer: ble.GattServer | undefined = undefined;
   /** 进行中的启动流程(单飞: 并发 start 共享同一结果, 收敛后按需补启) */
   private startPromise: Promise<void> | undefined = undefined;
-  private receive: ReceiveState = BleTokenServer.newReceiveState();
+  /** 分片协议接收状态机(Phase 3 抽至 TransferProtocol, 无前缀模式 + 512KB 上限) */
+  private receiver: TransferFrameReceiver =
+    new TransferFrameReceiver({ headerPrefix: '', maxTotal: MAX_RECEIVE } as TransferFrameOptions);
   private onTokensSaved: ((count: number) => void) | undefined = undefined;
   private onSettingsApplied: (() => void) | undefined = undefined;
   private onSyncStatus: ((status: BleSyncStatus, count: number) => void) | undefined = undefined;
-
-  /** 空白接收状态(批次开始/结束/失败时统一以此重置) */
-  private static newReceiveState(): ReceiveState {
-    return { inProgress: false, total: 0, count: 0, type: MSG_TYPE_TOKENS, received: 0, chunks: [] };
-  }
 
   public static getInstance(): BleTokenServer {
     if (!BleTokenServer.instance) {
@@ -300,7 +290,7 @@ export class BleTokenServer {
 
   /** 重置接收状态机: 丢弃未完整接收的批次残留 */
   private resetReceive(): void {
-    this.receive = BleTokenServer.newReceiveState();
+    this.receiver.reset();
   }
 
   /** 释放 GattServer 实例: 逐段注销监听并 close, 单段失败不阻断其余段(防句柄滞留) */
@@ -329,45 +319,37 @@ export class BleTokenServer {
    * 分片协议接收: 首帧为头 JSON, 之后为数据分片, 收满后重组分发.
    * 头帧到达即视为新批次开始(重置接收状态), 并上报"接收中"状态.
    * 收尾帧(收满 total)的写应答延后到处理完成后回发, 使手机端拿到真实入库结果.
+   *
+   * 帧判定委托 {@link TransferFrameReceiver}: 无前缀模式下数据分片为加密随机字节,
+   * 不可能解析出合法头, 解析成功即视为头帧(批次中途到达则丢弃残留, 干净重启).
    */
   private handleWrite(req: ble.CharacteristicWriteRequest): void {
-    let batchComplete = false;
+    let completed: TransferBatch | null = null;
     try {
       const bytes: Uint8Array = new Uint8Array(req.value);
-      if (!this.receive.inProgress) {
-        // 首帧: 头 JSON {"total":N,"count":M,"type":T}; 复用 tryParseHeader 校验
-        // (JSON 标量如 "5" 经 typeof 守卫拒绝, 避免写 total=undefined 卡住批次)
-        const header = this.tryParseHeader(bytes);
-        if (header === null) {
-          hilog.error(DOMAIN, TAG, 'invalid transfer header');
-          this.resetReceive();
-          this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
-          this.sendWriteResponse(req, false);
-          return;
-        }
-        this.startBatch(header);
-      } else {
-        // 批次中途检测新头帧: 手机端超时中断后立即重试时, 上一半批残留 inProgress,
-        // 新头帧若被当数据分片并入会致本次重试必败; 数据分片为加密随机字节,
-        // 不可能解析出合法头, 解析成功即视为新批次开始(残留丢弃, 干净重启)
-        const retryHeader = this.tryParseHeader(bytes);
-        if (retryHeader !== null) {
-          hilog.warn(DOMAIN, TAG, `stale batch discarded, new batch header received: total=${retryHeader.total}`);
-          this.startBatch(retryHeader);
-        } else {
-          this.receive.chunks.push(bytes);
-          this.receive.received += bytes.byteLength;
-          if (this.receive.received >= this.receive.total) {
-            batchComplete = true;
-          }
-        }
-      }
-      if (batchComplete) {
-        // 收尾帧: 应答延后到处理完成(成功 status 0 / 失败非 0), 手机端据此给出真实反馈
-        this.assembleAndSave(req);
-      } else {
-        // 非收尾帧: GATT 写事务必须有响应, 否则客户端写入会阻塞直至超时失败
+      const event: TransferFrameEvent = this.receiver.onFrame(bytes);
+      if (event.kind === TransferFrameEventKind.BATCH_STARTED) {
+        // 头帧: 开新批次并上报"接收中"
+        hilog.info(DOMAIN, TAG,
+          `receive start: total=${event.header?.total}, count=${event.header?.count}, type=${event.header?.type}`);
+        this.onSyncStatus?.(BleSyncStatus.RECEIVING, 0);
         this.sendWriteResponse(req, true);
+      } else if (event.kind === TransferFrameEventKind.CHUNK_ACCEPTED) {
+        // 非收尾数据帧: GATT 写事务必须有响应, 否则客户端写入会阻塞直至超时失败
+        this.sendWriteResponse(req, true);
+      } else if (event.kind === TransferFrameEventKind.BATCH_COMPLETE) {
+        // 收尾帧: 应答延后到处理完成(成功 status 0 / 失败非 0), 手机端据此给出真实反馈
+        completed = event.batch;
+      } else {
+        // 孤儿帧(非法传输头): 重置状态并上报失败, 回失败应答
+        hilog.error(DOMAIN, TAG, 'invalid transfer header');
+        this.receiver.reset();
+        this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
+        this.sendWriteResponse(req, false);
+        return;
+      }
+      if (completed !== null) {
+        this.assembleAndSave(completed, req);
       }
     } catch (err) {
       let e: BusinessError = err as BusinessError;
@@ -376,30 +358,6 @@ export class BleTokenServer {
       this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
       this.sendWriteResponse(req, false);
     }
-  }
-
-  /** 开启新批次: 重置接收状态机并上报"接收中" */
-  private startBatch(header: TransferHeader): void {
-    this.receive = {
-      inProgress: true, total: header.total, count: header.count,
-      type: header.type ?? MSG_TYPE_TOKENS, received: 0, chunks: []
-    };
-    this.onSyncStatus?.(BleSyncStatus.RECEIVING, 0);
-    hilog.info(DOMAIN, TAG, `receive start: total=${header.total}, count=${header.count}, type=${this.receive.type}`);
-  }
-
-  /** 尝试把帧解析为合法传输头(批次中途新头帧检测用); 非头帧/非法头返回 null */
-  private tryParseHeader(bytes: Uint8Array): TransferHeader | null {
-    try {
-      const decoder = new util.TextDecoder('utf-8');
-      const header = JSON.parse(decoder.decodeToString(bytes)) as TransferHeader;
-      if (header && typeof header.total === 'number' && header.total > 0 && header.total <= MAX_RECEIVE) {
-        return header;
-      }
-    } catch (err) {
-      // 加密数据分片解码/解析必然失败, 属正常路径
-    }
-    return null;
   }
 
   /** 回发写应答: status 0 表示成功, 非 0 使手机端写入失败(真实结果反馈) */
@@ -423,30 +381,22 @@ export class BleTokenServer {
 
   /**
    * 重组全部数据分片, 解密后按 type 分发: 令牌走共享入库, 设置走共享应用.
-   * 分片先快照到局部变量并立即重置接收状态机(后续新批次可立即开始, 互不残留),
+   * 收齐时接收状态机已复位(后续新批次可立即开始, 互不残留),
    * 重组/解密/处理的任何失败路径均上报失败并丢弃本批次, 收尾帧回失败应答.
    *
+   * @param batch 收齐的批次快照
    * @param finalReq 收尾帧写请求(处理完成后回发应答; 无则静默处理)
    */
-  private async assembleAndSave(finalReq?: ble.CharacteristicWriteRequest): Promise<void> {
-    const chunks: Array<Uint8Array> = this.receive.chunks;
-    const total: number = this.receive.total;
-    const msgType: string = this.receive.type;
-    this.resetReceive();
+  private async assembleAndSave(batch: TransferBatch, finalReq?: ble.CharacteristicWriteRequest): Promise<void> {
     let ok = false;
     try {
-      const full: Uint8Array = new Uint8Array(total);
-      let offset: number = 0;
-      for (let i = 0; i < chunks.length; i++) {
-        full.set(chunks[i], offset);
-        offset += chunks[i].byteLength;
-      }
-      if (offset !== total) {
+      if (batch.receivedBytes !== batch.total) {
         // 分片总量与头不符(交叠写入/异常发送方): 判失败, 丢弃本批次
-        hilog.error(DOMAIN, TAG, `chunk size mismatch: got ${offset}, expect ${total}`);
+        hilog.error(DOMAIN, TAG, `chunk size mismatch: got ${batch.receivedBytes}, expect ${batch.total}`);
         this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
         return;
       }
+      const full: Uint8Array = concatenateChunks(batch.total, batch.chunks);
       // 应用层解密(AES-256-GCM): 失败视为载荷被篡改或密钥版本不匹配, 丢弃且不入库
       const plain: Uint8Array | null = await decryptBlePayload(full);
       if (plain === null) {
@@ -454,13 +404,12 @@ export class BleTokenServer {
         this.onSyncStatus?.(BleSyncStatus.FAILED, 0);
         return;
       }
-      const decoder = new util.TextDecoder('utf-8');
-      if (msgType === MSG_TYPE_SETTINGS) {
-        const pairs = JSON.parse(decoder.decodeToString(plain)) as Array<SettingValuePair>;
+      if (batch.type === MSG_TYPE_SETTINGS) {
+        const pairs = JSON.parse(utf8Decode(plain)) as Array<SettingValuePair>;
         await applyWearSettings(pairs);
         this.onSettingsApplied?.();
       } else {
-        const tokens = JSON.parse(decoder.decodeToString(plain)) as TokenConfig[];
+        const tokens = JSON.parse(utf8Decode(plain)) as TokenConfig[];
         hilog.info(DOMAIN, TAG, `received ${tokens.length} tokens, saving...`);
         const saved = await saveTokensBatch(tokens);
         this.onTokensSaved?.(saved);
@@ -757,7 +706,8 @@ export class BleTokenClient {
   }
 
   /**
-   * 分片协议公共实现: 配对门禁 → 服务发现 → 应用层加密 → 首帧头(type) → 数据分片.
+   * 分片发送公共实现: 配对门禁 → 服务发现 → 应用层加密 → 首帧头(type) → 数据分片.
+   * 帧构建委托 {@link TransferFrameBuilder}(无前缀, ≤MAX_CHUNK, 收尾帧标记放宽超时).
    */
   private async sendPayload(plain: Uint8Array, count: number, type: string): Promise<void> {
     if (!this.gattClient) {
@@ -772,25 +722,16 @@ export class BleTokenClient {
       await withTimeout(this.gattClient.getServices(), GATT_OP_TIMEOUT_MS, 'BLE getServices timeout');
     hilog.info(DOMAIN, TAG, `services discovered: ${services.length}`);
 
-    const encoder = new util.TextEncoder();
     // 应用层加密(AES-256-GCM): 载荷格式 [MAGIC][iv][tag][ciphertext], 分片协议不变
     const encrypted: Uint8Array = await encryptBlePayload(plain);
-    const total: number = encrypted.byteLength;
 
-    // 首帧: 头 {"total":N,"count":M,"type":T}
-    const headerBytes: Uint8Array = encoder.encodeInto(JSON.stringify({ total: total, count: count, type: type }));
-    await this.writeFrame(headerBytes);
-
-    // 数据分片(收尾帧用放宽超时: 其应答延后到手表端处理完成)
-    let offset: number = 0;
-    while (offset < total) {
-      const end: number = Math.min(offset + MAX_CHUNK, total);
-      const chunk: Uint8Array = new Uint8Array(end - offset);
-      chunk.set(encrypted.subarray(offset, end));
-      await this.writeFrame(chunk, offset + chunk.byteLength >= total);
-      offset = end;
+    // 首帧: 头 {"total":N,"count":M,"type":T}; 数据分片(收尾帧用放宽超时: 其应答延后到手表端处理完成)
+    const builder = new TransferFrameBuilder('', MAX_CHUNK);
+    const frames = builder.buildFrames(encrypted, count, type);
+    for (let i = 0; i < frames.length; i++) {
+      await this.writeFrame(frames[i].bytes, frames[i].isFinal);
     }
-    hilog.info(DOMAIN, TAG, `sendPayload done: type=${type}, count=${count}, ${total} encrypted bytes`);
+    hilog.info(DOMAIN, TAG, `sendPayload done: type=${type}, count=${count}, ${encrypted.byteLength} encrypted bytes`);
   }
 
   private async writeFrame(data: Uint8Array, isFinal: boolean = false): Promise<void> {

--- a/common/src/main/ets/utils/CloudBackupCrypto.ets
+++ b/common/src/main/ets/utils/CloudBackupCrypto.ets
@@ -14,6 +14,126 @@ const KEY_SIZE = 16;
 /** 旧版 mock 文件的 salt 前缀标识，用于向后兼容检测 */
 const MOCK_SALT_PREFIX = 'mock_salt_';
 
+/**
+ * 可注入的 base64 编解码器。
+ *
+ * 实测 `util.Base64Helper` 在 LocalUnit / Previewer 运行时下**静默返回空数据**
+ * （不抛异常），因此三段式 header 的编解码与 AES 同样走注入：
+ * 生产用 UtilBase64Codec，测试注入纯 TS 编解码（SteamCrypto.base64Encode 等）。
+ */
+export interface Base64Codec {
+  /** UTF-8 文本 → base64 */
+  encodeText(text: string): string;
+  /** base64 → UTF-8 文本 */
+  decodeText(base64Str: string): string;
+  /** 字节 → base64 */
+  encodeBytes(data: Uint8Array): string;
+  /** base64 → 字节 */
+  decodeBytes(base64Str: string): Uint8Array;
+}
+
+/** 默认编解码器：@kit.ArkTS 的 util.Base64Helper（设备端专用）。 */
+export class UtilBase64Codec implements Base64Codec {
+  private helper: util.Base64Helper = new util.Base64Helper();
+
+  encodeText(text: string): string {
+    const uint8Array = new Uint8Array(buffer.from(text, 'utf-8').buffer);
+    return this.helper.encodeToStringSync(uint8Array);
+  }
+
+  decodeText(base64Str: string): string {
+    const uint8Array = this.helper.decodeSync(base64Str);
+    return buffer.from(uint8Array).toString('utf-8');
+  }
+
+  encodeBytes(data: Uint8Array): string {
+    return this.helper.encodeToStringSync(data);
+  }
+
+  decodeBytes(base64Str: string): Uint8Array {
+    return this.helper.decodeSync(base64Str);
+  }
+}
+
+/**
+ * 可注入的备份加密引擎（沿用 HttpTransport/Sleeper 的注入模式）。
+ *
+ * 生产环境使用 {@link CryptoFrameworkBackupEngine}；LocalUnit / Previewer 下
+ * cryptoFramework 不可用（静默返回空数据），测试注入纯 TS 引擎覆盖
+ * 三段式格式、签名校验与 mock 兼容分支——真正的 AES/PBKDF2 数值正确性
+ * 由 ohosTest 真机用例回归。
+ */
+export interface BackupCryptoEngine {
+  /** CSPRNG 随机字节。salt/iv 必须不可预测，测试可注入确定性实现。 */
+  randomBytes(length: number): Uint8Array;
+  /** SHA-256 十六进制摘要，用于三段式的签名段。 */
+  sha256Hex(data: string): Promise<string>;
+  /** AES-128|CBC|PKCS7 加密，密钥由 PBKDF2|SHA256(password, salt) 派生。 */
+  aesCbcEncrypt(plaintext: Uint8Array, password: string, salt: Uint8Array,
+    iv: Uint8Array): Promise<Uint8Array>;
+  /** AES-128|CBC|PKCS7 解密，密钥派生方式同上。 */
+  aesCbcDecrypt(ciphertext: Uint8Array, password: string, salt: Uint8Array,
+    iv: Uint8Array): Promise<Uint8Array>;
+}
+
+/** 默认引擎：cryptoFramework AES-128|CBC|PKCS7 + PBKDF2|SHA256（设备端专用）。 */
+export class CryptoFrameworkBackupEngine implements BackupCryptoEngine {
+  randomBytes(length: number): Uint8Array {
+    // 必须用 CSPRNG：salt/iv 若可预测，AES-CBC 密文可被离线攻击。
+    // 委托 CryptoUtils.randomBytes（cryptoFramework.createRandom），保持单一实现。
+    return randomBytes(length);
+  }
+
+  async sha256Hex(data: string): Promise<string> {
+    const md = cryptoFramework.createMd('SHA256');
+    const inputData = new Uint8Array(buffer.from(data, 'utf-8').buffer);
+    await md.update({ data: inputData });
+    const result = await md.digest();
+    return buffer.from(result.data).toString('hex');
+  }
+
+  async aesCbcEncrypt(plaintext: Uint8Array, password: string, salt: Uint8Array,
+    iv: Uint8Array): Promise<Uint8Array> {
+    const symKey = await deriveKey(password, salt);
+    const cipher = cryptoFramework.createCipher('AES128|CBC|PKCS7');
+    const ivSpec: cryptoFramework.IvParamsSpec = {
+      algName: 'IvParamsSpec',
+      iv: { data: iv },
+    };
+    await cipher.init(cryptoFramework.CryptoMode.ENCRYPT_MODE, symKey, ivSpec);
+    const result = await cipher.doFinal({ data: plaintext });
+    return result.data;
+  }
+
+  async aesCbcDecrypt(ciphertext: Uint8Array, password: string, salt: Uint8Array,
+    iv: Uint8Array): Promise<Uint8Array> {
+    const symKey = await deriveKey(password, salt);
+    const cipher = cryptoFramework.createCipher('AES128|CBC|PKCS7');
+    const ivSpec: cryptoFramework.IvParamsSpec = {
+      algName: 'IvParamsSpec',
+      iv: { data: iv },
+    };
+    await cipher.init(cryptoFramework.CryptoMode.DECRYPT_MODE, symKey, ivSpec);
+    const result = await cipher.doFinal({ data: ciphertext });
+    return result.data;
+  }
+}
+
+/** PBKDF2|SHA256 密钥派生：将密码字符串 + salt 迭代生成 AES-128 对称密钥 */
+async function deriveKey(password: string, salt: Uint8Array): Promise<cryptoFramework.SymKey> {
+  const spec: cryptoFramework.PBKDF2Spec = {
+    algName: 'PBKDF2',
+    password: password,
+    salt: salt,
+    iterations: PBKDF2_ITERATIONS,
+    keySize: KEY_SIZE,
+  };
+  const kdf = cryptoFramework.createKdf('PBKDF2|SHA256');
+  const symKeyBlob = await kdf.generateSecret(spec);
+  const aesGenerator = cryptoFramework.createSymKeyGenerator('AES128');
+  return aesGenerator.convertKey(symKeyBlob);
+}
+
 /** 加密模式枚举：NONE=未加密（旧 mock 格式），HUAWEI_ACCOUNT=华为账号绑定密钥加密 */
 export enum CloudBackupCryptoMode {
   NONE = 0,
@@ -63,15 +183,24 @@ export class CloudBackupTokenError extends Error {
  */
 export class CloudBackupCrypto {
   private static instance: CloudBackupCrypto | null = null;
-  private base64Helper: util.Base64Helper = new util.Base64Helper();
+  private readonly engine: BackupCryptoEngine;
+  private readonly codec: Base64Codec;
 
-  private constructor() {
+  private constructor(engine?: BackupCryptoEngine, codec?: Base64Codec) {
+    this.engine = engine !== undefined ? engine : new CryptoFrameworkBackupEngine();
+    this.codec = codec !== undefined ? codec : new UtilBase64Codec();
   }
 
   static getInstance(): CloudBackupCrypto {
     if (!CloudBackupCrypto.instance) {
       CloudBackupCrypto.instance = new CloudBackupCrypto();
     }
+    return CloudBackupCrypto.instance;
+  }
+
+  /** 测试注入：替换单例并绑定给定引擎/编解码器，返回新实例。 */
+  static useEngineForTest(engine: BackupCryptoEngine, codec?: Base64Codec): CloudBackupCrypto {
+    CloudBackupCrypto.instance = new CloudBackupCrypto(engine, codec);
     return CloudBackupCrypto.instance;
   }
 
@@ -105,8 +234,8 @@ export class CloudBackupCrypto {
       throw new CloudBackupTokenError('Encryption requires a valid mode', 3);
     }
 
-    const salt = this.generateRandomBytes(KEY_SIZE);
-    const iv = this.generateRandomBytes(KEY_SIZE);
+    const salt = this.engine.randomBytes(KEY_SIZE);
+    const iv = this.engine.randomBytes(KEY_SIZE);
 
     const saltB64 = this.uint8ArrayToBase64(salt);
     const ivB64 = this.uint8ArrayToBase64(iv);
@@ -124,11 +253,11 @@ export class CloudBackupCrypto {
     };
 
     const plaintextBytes = new Uint8Array(buffer.from(plaintext, 'utf-8').buffer);
-    const ciphertext = await this.aesEncrypt(plaintextBytes, key, salt, iv);
+    const ciphertext = await this.engine.aesCbcEncrypt(plaintextBytes, key, salt, iv);
 
     const headerB64 = this.encodeBase64(JSON.stringify(header));
     const payloadB64 = this.uint8ArrayToBase64(ciphertext);
-    const hash = await this.computeSha256(headerB64 + TOKEN_SEPARATOR + payloadB64);
+    const hash = await this.engine.sha256Hex(headerB64 + TOKEN_SEPARATOR + payloadB64);
 
     hilog.info(DOMAIN, TAG, `encrypt: version=2, tokenCount=${tokenCount}, size=${header.size}`);
     return headerB64 + TOKEN_SEPARATOR + payloadB64 + TOKEN_SEPARATOR + hash;
@@ -167,7 +296,7 @@ export class CloudBackupCrypto {
     const iv = this.base64ToUint8Array(header.iv);
     const ciphertext = this.base64ToUint8Array(payloadB64);
 
-    const plaintextBytes = await this.aesDecrypt(ciphertext, key, salt, iv);
+    const plaintextBytes = await this.engine.aesCbcDecrypt(ciphertext, key, salt, iv);
     const result = buffer.from(plaintextBytes).toString('utf-8');
 
     hilog.info(DOMAIN, TAG, `decrypt: version=${header.version}, decrypted size=${result.length}`);
@@ -203,93 +332,25 @@ export class CloudBackupCrypto {
     }
   }
 
-  /** AES-128|CBC|PKCS7 加密：通过 PBKDF2 派生密钥后执行对称加密 */
-  private async aesEncrypt(
-    plaintext: Uint8Array,
-    password: string,
-    salt: Uint8Array,
-    iv: Uint8Array,
-  ): Promise<Uint8Array> {
-    const symKey = await this.deriveKey(password, salt);
-    const cipher = cryptoFramework.createCipher('AES128|CBC|PKCS7');
-    const ivSpec: cryptoFramework.IvParamsSpec = {
-      algName: 'IvParamsSpec',
-      iv: { data: iv },
-    };
-    await cipher.init(cryptoFramework.CryptoMode.ENCRYPT_MODE, symKey, ivSpec);
-    const result = await cipher.doFinal({ data: plaintext });
-    return result.data;
-  }
-
-  /** AES-128|CBC|PKCS7 解密：通过 PBKDF2 派生密钥后执行对称解密 */
-  private async aesDecrypt(
-    ciphertext: Uint8Array,
-    password: string,
-    salt: Uint8Array,
-    iv: Uint8Array,
-  ): Promise<Uint8Array> {
-    const symKey = await this.deriveKey(password, salt);
-    const cipher = cryptoFramework.createCipher('AES128|CBC|PKCS7');
-    const ivSpec: cryptoFramework.IvParamsSpec = {
-      algName: 'IvParamsSpec',
-      iv: { data: iv },
-    };
-    await cipher.init(cryptoFramework.CryptoMode.DECRYPT_MODE, symKey, ivSpec);
-    const result = await cipher.doFinal({ data: ciphertext });
-    return result.data;
-  }
-
-  /** PBKDF2|SHA256 密钥派生：将密码字符串 + salt 迭代 10000 次生成 AES-128 对称密钥 */
-  private async deriveKey(password: string, salt: Uint8Array): Promise<cryptoFramework.SymKey> {
-    const spec: cryptoFramework.PBKDF2Spec = {
-      algName: 'PBKDF2',
-      password: password,
-      salt: salt,
-      iterations: PBKDF2_ITERATIONS,
-      keySize: KEY_SIZE,
-    };
-    const kdf = cryptoFramework.createKdf('PBKDF2|SHA256');
-    const symKeyBlob = await kdf.generateSecret(spec);
-    const aesGenerator = cryptoFramework.createSymKeyGenerator('AES128');
-    return aesGenerator.convertKey(symKeyBlob);
-  }
-
-  private generateRandomBytes(length: number): Uint8Array {
-    // 必须用 CSPRNG：salt/iv 若可预测，AES-CBC 密文可被离线攻击。
-    // 这里委托 CryptoUtils.randomBytes（cryptoFramework.createRandom）。
-    return randomBytes(length);
-  }
-
   private encodeBase64(text: string): string {
-    const uint8Array = new Uint8Array(buffer.from(text, 'utf-8').buffer);
-    return this.base64Helper.encodeToStringSync(uint8Array);
+    return this.codec.encodeText(text);
   }
 
   private decodeBase64(base64Str: string): string {
-    const uint8Array = this.base64Helper.decodeSync(base64Str);
-    return buffer.from(uint8Array).toString('utf-8');
+    return this.codec.decodeText(base64Str);
   }
 
   private uint8ArrayToBase64(data: Uint8Array): string {
-    return this.base64Helper.encodeToStringSync(data);
+    return this.codec.encodeBytes(data);
   }
 
   private base64ToUint8Array(base64Str: string): Uint8Array {
-    return this.base64Helper.decodeSync(base64Str);
-  }
-
-  /** 计算 SHA256 哈希，返回十六进制字符串，用于 JWT-like 签名段 */
-  private async computeSha256(data: string): Promise<string> {
-    const md = cryptoFramework.createMd('SHA256');
-    const inputData = new Uint8Array(buffer.from(data, 'utf-8').buffer);
-    await md.update({ data: inputData });
-    const result = await md.digest();
-    return buffer.from(result.data).toString('hex');
+    return this.codec.decodeBytes(base64Str);
   }
 
   /** 验证 SHA256 签名：比较计算值与期望值是否一致 */
   private async verifySha256(data: string, expectedHex: string): Promise<boolean> {
-    const actualHex = await this.computeSha256(data);
+    const actualHex = await this.engine.sha256Hex(data);
     return actualHex === expectedHex;
   }
 }

--- a/common/src/main/ets/utils/CloudBackupManager.ets
+++ b/common/src/main/ets/utils/CloudBackupManager.ets
@@ -4,20 +4,116 @@ import { CloudBackupCrypto, CloudBackupRecord, CloudBackupTokenError } from './C
 import { TokenStore } from './TokenStore';
 import { TokenConfig, sanitizedTokenForBackup } from './TokenConfig';
 import { TokenGroup, TokenGroupStore } from './TokenGroupStore';
-import { fileIo as fs, cloudSync, fileUri } from '@kit.CoreFileKit';
+import { cloudSync, fileUri } from '@kit.CoreFileKit';
 import { common } from '@kit.AbilityKit';
-import { buffer } from '@kit.ArkTS';
 import { DeviceInfoHelper } from './DeviceInfoHelper';
 import { HuaweiAccountManager } from './HuaweiAccountManager';
 import { SyncTimeHelper } from './SyncTimeHelper';
 import { TokenIconPacks } from './TokenUtils';
 import { IconPackCloudBackup, PackMetaEntry } from './IconPackCloudBackup';
+import { FsGateway, FileIoFsGateway } from './StoragePorts';
+import { BACKUP_FILE_EXT, BACKUP_FILE_PREFIX, isBackupFileName, parseBackupTimestamp } from './CommonUtils';
 
 const TAG = 'CloudBackupManager';
 const DOMAIN = 0xFF00;
 const MAX_BACKUP_COUNT = 5;
-const BACKUP_FILE_PREFIX = 'otp_backup_';
-const BACKUP_FILE_EXT = '.enc';
+
+/** 华为账号状态端口（生产：HuaweiAccountManager 单例）。 */
+export interface CloudBackupAccountPort {
+  isUserLogin(): boolean;
+  unionId(): string;
+}
+
+/** 设备标识端口（生产：DeviceInfoHelper 单例）。 */
+export interface CloudBackupDevicePort {
+  deviceId(): string;
+  deviceName(): string;
+}
+
+/** 令牌数据端口（生产：TokenStore 单例）。 */
+export interface CloudBackupTokenPort {
+  getTokens(): Promise<TokenConfig[]>;
+  updateToken(token: TokenConfig): Promise<void>;
+}
+
+/** 分组目录端口（生产：TokenGroupStore 单例）。 */
+export interface CloudBackupGroupPort {
+  currentGroups(): TokenGroup[];
+  merge(groups: TokenGroup[] | undefined): Promise<void>;
+}
+
+/** 图标包云备份端口（生产：IconPackCloudBackup 单例）。 */
+export interface CloudBackupIconPort {
+  backupIconPacks(): Promise<boolean>;
+  clearCloudBackup(): Promise<boolean>;
+}
+
+/** 云端同步触发端口（生产：cloudSync.FileSync）。 */
+export interface CloudSyncStarter {
+  start(): Promise<void>;
+}
+
+/** LocalUnit 测试注入项（cloudDir 就绪时跳过 init() 的 AppStorage 依赖）。 */
+export interface CloudBackupTestDeps {
+  fs?: FsGateway;
+  account?: CloudBackupAccountPort;
+  device?: CloudBackupDevicePort;
+  tokens?: CloudBackupTokenPort;
+  groups?: CloudBackupGroupPort;
+  icons?: CloudBackupIconPort;
+  sync?: CloudSyncStarter;
+  cloudDir?: string;
+}
+
+class HuaweiAccountAdapter implements CloudBackupAccountPort {
+  isUserLogin(): boolean {
+    return HuaweiAccountManager.getInstance().userLogin;
+  }
+
+  unionId(): string {
+    return HuaweiAccountManager.getInstance().userAccount.unionId;
+  }
+}
+
+class DeviceInfoAdapter implements CloudBackupDevicePort {
+  deviceId(): string {
+    return DeviceInfoHelper.getInstance().getDeviceId();
+  }
+
+  deviceName(): string {
+    return DeviceInfoHelper.getInstance().getDeviceName();
+  }
+}
+
+class TokenStoreAdapter implements CloudBackupTokenPort {
+  async getTokens(): Promise<TokenConfig[]> {
+    return TokenStore.getInstance().getTokens();
+  }
+
+  async updateToken(token: TokenConfig): Promise<void> {
+    await TokenStore.getInstance().updateToken(token);
+  }
+}
+
+class TokenGroupStoreAdapter implements CloudBackupGroupPort {
+  currentGroups(): TokenGroup[] {
+    return TokenGroupStore.getInstance().state.groups;
+  }
+
+  merge(groups: TokenGroup[] | undefined): Promise<void> {
+    return TokenGroupStore.getInstance().merge(groups);
+  }
+}
+
+class IconPackCloudBackupAdapter implements CloudBackupIconPort {
+  backupIconPacks(): Promise<boolean> {
+    return IconPackCloudBackup.getInstance().backupIconPacks();
+  }
+
+  clearCloudBackup(): Promise<boolean> {
+    return IconPackCloudBackup.getInstance().clearCloudBackup();
+  }
+}
 
 /**
  * 云备份载荷：将 TokenConfig[] 包装为结构化格式，附带图标包启用列表和元数据。
@@ -55,14 +151,19 @@ class CloudBackupPayload {
  * 每台设备（按 ODID 区分）最多保留 {@link MAX_BACKUP_COUNT} 份备份，
  * 超出时自动删除最旧的一份。
  *
+ * ## Phase 2 解耦
+ * 文件系统经 {@link FsGateway} 端口、账号/设备/令牌/分组/图标包经各自端口访问，
+ * LocalUnit 注入内存/假实现测试编排逻辑（见 docs/TEST_PLAN.md 第 4 节）。
+ *
  * @module CloudBackupManager
  */
 export class CloudBackupManager {
   private static instance: CloudBackupManager | null = null;
-  private crypto: CloudBackupCrypto = CloudBackupCrypto.getInstance();
   private context: common.UIAbilityContext | undefined = undefined;
   private cloudDir: string = '';
   private fileSync: cloudSync.FileSync | null = null;
+  private testDeps: CloudBackupTestDeps | null = null;
+  private readonly productionFs: FsGateway = new FileIoFsGateway();
 
   private constructor() {
   }
@@ -72,6 +173,53 @@ export class CloudBackupManager {
       CloudBackupManager.instance = new CloudBackupManager();
     }
     return CloudBackupManager.instance;
+  }
+
+  /** 测试注入：LocalUnit 下云文件/账号/设备 API 不可用，替换全部端口。 */
+  useDepsForTest(deps: CloudBackupTestDeps): void {
+    this.testDeps = deps;
+    if (deps.cloudDir !== undefined && deps.cloudDir.length > 0) {
+      // 语义上 context/cloudDir 已就绪：init() 直接短路，不再读 AppStorage
+      this.context = new Object() as common.UIAbilityContext;
+      this.cloudDir = deps.cloudDir;
+    }
+  }
+
+  /** 测试复位：恢复生产端口与未初始化状态（与 IconPackCloudBackup.resetForTest 对称，防单例跨套件污染）。 */
+  resetForTest(): void {
+    this.testDeps = null;
+    this.context = undefined;
+    this.cloudDir = '';
+    this.fileSync = null;
+  }
+
+  private get fsPort(): FsGateway {
+    return this.testDeps?.fs !== undefined ? this.testDeps.fs : this.productionFs;
+  }
+
+  private get accountPort(): CloudBackupAccountPort {
+    return this.testDeps?.account !== undefined ? this.testDeps.account : new HuaweiAccountAdapter();
+  }
+
+  private get devicePort(): CloudBackupDevicePort {
+    return this.testDeps?.device !== undefined ? this.testDeps.device : new DeviceInfoAdapter();
+  }
+
+  private get tokenPort(): CloudBackupTokenPort {
+    return this.testDeps?.tokens !== undefined ? this.testDeps.tokens : new TokenStoreAdapter();
+  }
+
+  private get groupPort(): CloudBackupGroupPort {
+    return this.testDeps?.groups !== undefined ? this.testDeps.groups : new TokenGroupStoreAdapter();
+  }
+
+  private get iconPort(): CloudBackupIconPort {
+    return this.testDeps?.icons !== undefined ? this.testDeps.icons : new IconPackCloudBackupAdapter();
+  }
+
+  /** 每次调用时取加密实例：测试用 useEngineForTest 替换单例后这里拿到的就是新实例。 */
+  private get crypto(): CloudBackupCrypto {
+    return CloudBackupCrypto.getInstance();
   }
 
   /** 初始化云备份管理器：获取 UIAbilityContext、确保云端目录存在。幂等，重复调用安全。 */
@@ -97,12 +245,12 @@ export class CloudBackupManager {
   /** 确保云端备份目录存在，不存在则递归创建 */
   private async ensureCloudDirExists(): Promise<void> {
     try {
-      const stat = await fs.stat(this.cloudDir);
+      const stat = await this.fsPort.stat(this.cloudDir);
       hilog.info(DOMAIN, TAG, `ensureCloudDirExists: exists, location=${stat.location}`);
     } catch (e) {
       hilog.warn(DOMAIN, TAG, `ensureCloudDirExists: not exist, creating`);
       try {
-        await fs.mkdir(this.cloudDir);
+        await this.fsPort.makeDir(this.cloudDir);
         hilog.info(DOMAIN, TAG, 'ensureCloudDirExists: created');
       } catch (err) {
         hilog.error(DOMAIN, TAG, `ensureCloudDirExists: create error=${JSON.stringify(err)}`);
@@ -123,27 +271,26 @@ export class CloudBackupManager {
       return false;
     }
 
-    const accountMgr = HuaweiAccountManager.getInstance();
-    if (!accountMgr.userLogin) {
+    if (!this.accountPort.isUserLogin()) {
       hilog.warn(DOMAIN, TAG, 'backupToCloud: Huawei account not logged in, aborting');
       return false;
     }
 
-    const encryptKey = accountMgr.userAccount.unionId;
+    const encryptKey = this.accountPort.unionId();
     const mode = this.crypto.getMode(true);
-    const deviceId = DeviceInfoHelper.getInstance().getDeviceId();
-    const deviceName = DeviceInfoHelper.getInstance().getDeviceName();
+    const deviceId = this.devicePort.deviceId();
+    const deviceName = this.devicePort.deviceName();
 
     hilog.info(DOMAIN, TAG, `backupToCloud: starting backup, mode=${mode}`);
 
     // 构造 CloudBackupPayload：包含令牌、图标包启用列表、图标包元数据
     // 注意：载荷会被序列化后上传云端，必须剥离 Steam 高权限凭证
     // （identity_secret / refresh_token / revocation_code），TokenSecret 保留以便恢复后显示动态码
-    const tokens = await TokenStore.getInstance().getTokens();
+    const tokens = await this.tokenPort.getTokens();
     const enabledPacks = TokenIconPacks.enabled_packs;
     const payload = new CloudBackupPayload();
     payload.tokens = tokens.map((token: TokenConfig): TokenConfig => sanitizedTokenForBackup(token));
-    payload.groups = [...TokenGroupStore.getInstance().state.groups];
+    payload.groups = [...this.groupPort.currentGroups()];
     payload.enabledPacks = enabledPacks;
     const metaList: PackMetaEntry[] = [];
     for (const p of TokenIconPacks.aegis_icon_packs) {
@@ -172,10 +319,8 @@ export class CloudBackupManager {
     const filePath = `${this.cloudDir}/${fileName}`;
 
     try {
-      const file = fs.openSync(filePath, fs.OpenMode.WRITE_ONLY | fs.OpenMode.CREATE | fs.OpenMode.TRUNC);
-      const writeLen = fs.writeSync(file.fd, token);
-      fs.closeSync(file);
-      hilog.info(DOMAIN, TAG, `backupToCloud: wrote ${writeLen} bytes to ${fileName}`);
+      await this.fsPort.writeTextFile(filePath, token);
+      hilog.info(DOMAIN, TAG, `backupToCloud: wrote ${token.length} chars to ${fileName}`);
     } catch (e) {
       hilog.error(DOMAIN, TAG, `backupToCloud: write error=${JSON.stringify(e)}`);
       return false;
@@ -196,7 +341,7 @@ export class CloudBackupManager {
     hilog.info(DOMAIN, TAG, 'backupToCloud: completed successfully');
 
     // 图标包文件备份：fire-and-forget，不阻塞 token 备份成功返回
-    IconPackCloudBackup.getInstance().backupIconPacks().then((iconResult) => {
+    this.iconPort.backupIconPacks().then((iconResult) => {
       hilog.info(DOMAIN, TAG, `backupToCloud: icon pack backup result=${iconResult}`);
     }).catch((err: Error) => {
       hilog.error(DOMAIN, TAG, `backupToCloud: icon pack backup failed: ${err.message}`);
@@ -208,7 +353,7 @@ export class CloudBackupManager {
   /**
    * 从云端恢复最新的备份数据
    *
-   * 解密后逐条调用 `TokenStore.updateToken` 写入本地 KV。
+   * 解密后逐条调用令牌端口写入本地 KV。
    * @returns 是否成功
    */
   async restoreFromCloud(): Promise<boolean> {
@@ -218,8 +363,7 @@ export class CloudBackupManager {
       return false;
     }
 
-    const accountMgr = HuaweiAccountManager.getInstance();
-    if (!accountMgr.userLogin) {
+    if (!this.accountPort.isUserLogin()) {
       hilog.warn(DOMAIN, TAG, 'restoreFromCloud: Huawei account not logged in, aborting');
       return false;
     }
@@ -244,7 +388,7 @@ export class CloudBackupManager {
       return false;
     }
 
-    if (!HuaweiAccountManager.getInstance().userLogin) {
+    if (!this.accountPort.isUserLogin()) {
       hilog.warn(DOMAIN, TAG, 'clearCloudStorage: Huawei account not logged in, aborting');
       return false;
     }
@@ -258,7 +402,7 @@ export class CloudBackupManager {
       }
       AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '0');
       // 同步清除图标包云端备份（fire-and-forget）
-      IconPackCloudBackup.getInstance().clearCloudBackup();
+      this.iconPort.clearCloudBackup();
       hilog.info(DOMAIN, TAG, 'clearCloudStorage: completed');
       return true;
     } catch (e) {
@@ -275,12 +419,12 @@ export class CloudBackupManager {
       return false;
     }
 
-    if (!HuaweiAccountManager.getInstance().userLogin) {
+    if (!this.accountPort.isUserLogin()) {
       hilog.warn(DOMAIN, TAG, 'clearDeviceCloudStorage: Huawei account not logged in, aborting');
       return false;
     }
 
-    const deviceId = DeviceInfoHelper.getInstance().getDeviceId();
+    const deviceId = this.devicePort.deviceId();
     hilog.info(DOMAIN, TAG, `clearDeviceCloudStorage: clearing device=${deviceId}`);
 
     try {
@@ -291,7 +435,7 @@ export class CloudBackupManager {
       }
       AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '0');
       // 同步清除图标包云端备份（fire-and-forget）
-      IconPackCloudBackup.getInstance().clearCloudBackup();
+      this.iconPort.clearCloudBackup();
       hilog.info(DOMAIN, TAG, `clearDeviceCloudStorage: completed, deleted ${deviceRecords.length}`);
       return true;
     } catch (e) {
@@ -313,13 +457,13 @@ export class CloudBackupManager {
       return false;
     }
 
-    if (!HuaweiAccountManager.getInstance().userLogin) {
+    if (!this.accountPort.isUserLogin()) {
       hilog.warn(DOMAIN, TAG, 'clearDeviceNameCloudStorage: Huawei account not logged in, aborting');
       return false;
     }
 
-    const currentDeviceId = DeviceInfoHelper.getInstance().getDeviceId();
-    const currentDeviceName = DeviceInfoHelper.getInstance().getDeviceName();
+    const currentDeviceId = this.devicePort.deviceId();
+    const currentDeviceName = this.devicePort.deviceName();
     hilog.info(DOMAIN, TAG, `clearDeviceNameCloudStorage: name=${currentDeviceName}, excluding odid=${currentDeviceId}`);
 
     try {
@@ -332,7 +476,7 @@ export class CloudBackupManager {
       }
       if (staleRecords.length > 0) {
         // 仅在有实际删除时才清除图标包备份（避免不必要的云操作）
-        IconPackCloudBackup.getInstance().clearCloudBackup();
+        this.iconPort.clearCloudBackup();
       }
       hilog.info(DOMAIN, TAG, `clearDeviceNameCloudStorage: completed, deleted ${staleRecords.length}`);
       return true;
@@ -360,7 +504,7 @@ export class CloudBackupManager {
       return;
     }
 
-    if (!HuaweiAccountManager.getInstance().userLogin) {
+    if (!this.accountPort.isUserLogin()) {
       return;
     }
 
@@ -389,20 +533,19 @@ export class CloudBackupManager {
       return false;
     }
 
-    const accountMgr = HuaweiAccountManager.getInstance();
-    if (!accountMgr.userLogin) {
+    if (!this.accountPort.isUserLogin()) {
       hilog.warn(DOMAIN, TAG, 'restoreFromBackupRecord: Huawei account not logged in, aborting');
       return false;
     }
 
-    const encryptKey = accountMgr.userAccount.unionId;
+    const encryptKey = this.accountPort.unionId();
     const mode = this.crypto.getMode(true);
 
     hilog.info(DOMAIN, TAG, `restoreFromBackupRecord: id=${recordId}`);
 
     const filePath = `${this.cloudDir}/${recordId}`;
     try {
-      const stat = await fs.stat(filePath);
+      const stat = await this.fsPort.stat(filePath);
       hilog.info(DOMAIN, TAG, `restoreFromBackupRecord: file size=${stat.size}, location=${stat.location}`);
 
       if (stat.location === 2) {
@@ -410,7 +553,7 @@ export class CloudBackupManager {
         await this.cacheFile(filePath);
       }
 
-      const tokenContent = await this.readFileContent(filePath);
+      const tokenContent = await this.fsPort.readTextFile(filePath);
       hilog.info(DOMAIN, TAG, `restoreFromBackupRecord: read ${tokenContent.length} chars`);
 
       const decrypted = await this.crypto.decrypt(tokenContent, mode, encryptKey);
@@ -422,7 +565,7 @@ export class CloudBackupManager {
       const payload = JSON.parse(decrypted) as CloudBackupPayload;
       if (payload && payload.tokens !== undefined && payload.tokens !== null) {
         tokens = payload.tokens;
-        await TokenGroupStore.getInstance().merge(payload.groups);
+        await this.groupPort.merge(payload.groups);
         if (payload.enabledPacks !== undefined && payload.enabledPacks !== null) {
           enabledPacks = payload.enabledPacks;
         }
@@ -439,7 +582,7 @@ export class CloudBackupManager {
       hilog.info(DOMAIN, TAG, `restoreFromBackupRecord: token count=${tokens.length}`);
 
       for (const token of tokens) {
-        await TokenStore.getInstance().updateToken(token);
+        await this.tokenPort.updateToken(token);
       }
 
       hilog.info(DOMAIN, TAG, 'restoreFromBackupRecord: completed successfully');
@@ -474,7 +617,7 @@ export class CloudBackupManager {
   private async deleteBackupFile(fileName: string): Promise<boolean> {
     const filePath = `${this.cloudDir}/${fileName}`;
     try {
-      await fs.unlink(filePath);
+      await this.fsPort.deleteFile(filePath);
       hilog.info(DOMAIN, TAG, `deleteBackupFile: deleted ${fileName}`);
       return true;
     } catch (e) {
@@ -487,18 +630,17 @@ export class CloudBackupManager {
   private async listBackupRecords(): Promise<CloudBackupRecord[]> {
     const records: CloudBackupRecord[] = [];
     try {
-      const files = fs.listFileSync(this.cloudDir);
+      const files = await this.fsPort.listFiles(this.cloudDir);
 
       for (const fileName of files) {
-        if (!fileName.startsWith(BACKUP_FILE_PREFIX) || !fileName.endsWith(BACKUP_FILE_EXT)) {
+        if (!isBackupFileName(fileName)) {
           continue;
         }
 
         const filePath = `${this.cloudDir}/${fileName}`;
         try {
-          const stat = await fs.stat(filePath);
-          const timestampStr = fileName.replace(BACKUP_FILE_PREFIX, '').replace(BACKUP_FILE_EXT, '');
-          const timestamp = parseInt(timestampStr);
+          const stat = await this.fsPort.stat(filePath);
+          const timestamp = parseBackupTimestamp(fileName);
 
           if (isNaN(timestamp)) {
             continue;
@@ -509,7 +651,7 @@ export class CloudBackupManager {
           let deviceId = '';
           let deviceName = '';
           try {
-            const tokenContent = await this.readFileContent(filePath);
+            const tokenContent = await this.fsPort.readTextFile(filePath);
             const header = this.crypto.parseTokenHeader(tokenContent);
             tokenCount = header.tokenCount;
             fileSize = header.size;
@@ -547,24 +689,21 @@ export class CloudBackupManager {
     return records;
   }
 
-  /** 读取文件全部内容为 UTF-8 字符串 */
-  private async readFileContent(filePath: string): Promise<string> {
-    const stat = await fs.stat(filePath);
-    const file = fs.openSync(filePath, fs.OpenMode.READ_ONLY);
-    const bufferArray = new ArrayBuffer(stat.size);
-    const readLen = fs.readSync(file.fd, bufferArray);
-    fs.closeSync(file);
-    const uint8Array = new Uint8Array(bufferArray.slice(0, readLen));
-    return buffer.from(uint8Array).toString('utf-8');
-  }
-
   /** 触发 FileSync 将本地变更同步到云端 */
   private async syncToCloud(): Promise<void> {
-    if (!this.fileSync) {
-      this.fileSync = new cloudSync.FileSync();
+    if (this.testDeps?.sync !== undefined) {
+      try {
+        await this.testDeps.sync.start();
+        hilog.info(DOMAIN, TAG, 'syncToCloud: started');
+      } catch (e) {
+        hilog.error(DOMAIN, TAG, `syncToCloud: error=${JSON.stringify(e)}`);
+      }
+      return;
     }
-
     try {
+      if (!this.fileSync) {
+        this.fileSync = new cloudSync.FileSync();
+      }
       await this.fileSync.start();
       hilog.info(DOMAIN, TAG, 'syncToCloud: started');
     } catch (e) {
@@ -574,9 +713,13 @@ export class CloudBackupManager {
 
   /** 将云端文件缓存到本地（location=2 时文件仅存在云端，需先拉取） */
   private async cacheFile(filePath: string): Promise<void> {
-    const uri = fileUri.getUriFromPath(filePath);
-    const cache = new cloudSync.CloudFileCache();
+    // 测试注入下假文件系统内容均在本地，跳过云端缓存拉取
+    if (this.testDeps !== null) {
+      return;
+    }
     try {
+      const uri = fileUri.getUriFromPath(filePath);
+      const cache = new cloudSync.CloudFileCache();
       await cache.start(uri);
       hilog.info(DOMAIN, TAG, `cacheFile: cached ${filePath}`);
     } catch (e) {

--- a/common/src/main/ets/utils/CloudSyncTask.ets
+++ b/common/src/main/ets/utils/CloudSyncTask.ets
@@ -12,7 +12,7 @@ import { fileIo as fs } from '@kit.CoreFileKit';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { buffer, util } from '@kit.ArkTS';
 import { CloudBackupRecord, CloudBackupTokenHeader } from './CloudBackupCrypto';
-import { padZero } from './CommonUtils';
+import { formatRecordDate, isBackupFileName, parseBackupTimestamp } from './CommonUtils';
 
 
 
@@ -28,8 +28,6 @@ export async function checkCloudBackupRecords(cloudDir: string): Promise<number>
   let recordCount: number = 0;
   const TAG = 'CloudSyncTask';
   const DOMAIN = 0xFF00;
-  const BACKUP_FILE_PREFIX = 'otp_backup_';
-  const BACKUP_FILE_EXT = '.enc';
   try {
     try {
       await fs.stat(cloudDir);
@@ -45,8 +43,7 @@ export async function checkCloudBackupRecords(cloudDir: string): Promise<number>
 
     const files: Array<string> = fs.listFileSync(cloudDir);
     for (let i = 0; i < files.length; i++) {
-      const fileName: string = files[i];
-      if (fileName.startsWith(BACKUP_FILE_PREFIX) && fileName.endsWith(BACKUP_FILE_EXT)) {
+      if (isBackupFileName(files[i])) {
         recordCount++;
       }
     }
@@ -73,22 +70,19 @@ export async function loadBackupHistoryRecords(cloudDir: string): Promise<CloudB
   const records: CloudBackupRecord[] = [];
   const TAG = 'CloudSyncTask';
   const DOMAIN = 0xFF00;
-  const BACKUP_FILE_PREFIX = 'otp_backup_';
-  const BACKUP_FILE_EXT = '.enc';
 
   try {
     const files: Array<string> = fs.listFileSync(cloudDir);
     for (let i = 0; i < files.length; i++) {
       const fileName: string = files[i];
-      if (!fileName.startsWith(BACKUP_FILE_PREFIX) || !fileName.endsWith(BACKUP_FILE_EXT)) {
+      if (!isBackupFileName(fileName)) {
         continue;
       }
 
       const filePath: string = `${cloudDir}/${fileName}`;
       try {
         const stat = await fs.stat(filePath);
-        const timestampStr: string = fileName.replace(BACKUP_FILE_PREFIX, '').replace(BACKUP_FILE_EXT, '');
-        const timestamp: number = parseInt(timestampStr);
+        const timestamp: number = parseBackupTimestamp(fileName);
 
         if (isNaN(timestamp)) {
           continue;
@@ -119,9 +113,7 @@ export async function loadBackupHistoryRecords(cloudDir: string): Promise<CloudB
           hilog.warn(DOMAIN, TAG, `loadBackupHistoryRecords: parse header failed for ${fileName}`);
         }
 
-        const d: Date = new Date(timestamp);
-        const dateStr: string =
-          `${d.getFullYear()}-${padZero(d.getMonth() + 1)}-${padZero(d.getDate())} ${padZero(d.getHours())}:${padZero(d.getMinutes())}`;
+        const dateStr: string = formatRecordDate(timestamp);
 
         const record: CloudBackupRecord = {
           id: fileName,

--- a/common/src/main/ets/utils/CommonUtils.ets
+++ b/common/src/main/ets/utils/CommonUtils.ets
@@ -29,3 +29,25 @@ export function delay(ms: number): Promise<void> {
     setTimeout(() => resolve(), ms);
   });
 }
+
+// ---- 云备份文件名规则（CloudBackupManager 与 CloudSyncTask 共享）----
+
+/** 备份文件命名规则：`otp_backup_{毫秒时间戳}.enc` */
+export const BACKUP_FILE_PREFIX = 'otp_backup_';
+export const BACKUP_FILE_EXT = '.enc';
+
+/** 是否为备份文件（按前缀/后缀过滤） */
+export function isBackupFileName(fileName: string): boolean {
+  return fileName.startsWith(BACKUP_FILE_PREFIX) && fileName.endsWith(BACKUP_FILE_EXT);
+}
+
+/** 从备份文件名解析毫秒时间戳；非法（NaN）由调用方跳过 */
+export function parseBackupTimestamp(fileName: string): number {
+  return parseInt(fileName.replace(BACKUP_FILE_PREFIX, '').replace(BACKUP_FILE_EXT, ''));
+}
+
+/** 备份记录展示日期（与 SyncTimeHelper.formatTimestamp 同一格式） */
+export function formatRecordDate(timestamp: number): string {
+  const d: Date = new Date(timestamp);
+  return `${d.getFullYear()}-${padZero(d.getMonth() + 1)}-${padZero(d.getDate())} ${padZero(d.getHours())}:${padZero(d.getMinutes())}`;
+}

--- a/common/src/main/ets/utils/CryptoUtils.ets
+++ b/common/src/main/ets/utils/CryptoUtils.ets
@@ -1,5 +1,7 @@
 import { cryptoFramework } from '@kit.CryptoArchitectureKit';
 import { buffer, util } from '@kit.ArkTS';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { CryptoEngine, CryptoSealedBytes } from './StoragePorts';
 
 // ---- version markers for new ciphertext format ----
 // New encryptFile  : [MAGIC(4)] [salt:16] [iv:16] [ciphertext]
@@ -11,6 +13,13 @@ const HEADER_SIZE = 4 + 16 + 16; // MAGIC + salt + iv = 36
 const HEADER_U8_SIZE = 4 + 16;   // MAGIC_U8 + iv = 20
 const SALT_OFS = 4;
 const IV_OFS = 4 + 16;
+
+const PBKDF2_ITERATIONS = 600000;
+const PBKDF2_KEY_SIZE = 16;
+// legacy helpers (used only for V0 decryption)
+const LEGACY_IV_STR = 'ohtotptokenaesiv';
+const LEGACY_SALT = new Uint8Array(16); // zero salt
+const LEGACY_PBKDF2_ITERATIONS = 10000;
 
 function startsWith(data: Uint8Array, prefix: Uint8Array): boolean {
   if (data.length < prefix.length) return false;
@@ -27,84 +36,160 @@ function startsWith(data: Uint8Array, prefix: Uint8Array): boolean {
  * （`CloudBackupCrypto.generateRandomBytes` 曾是后者，salt/iv 可被预测）。
  */
 export function randomBytes(length: number): Uint8Array {
-  const result = cryptoFramework.createRandom().generateRandomSync(length);
-  return new Uint8Array(result.data);
+  return getEngine().randomBytes(length);
 }
 
-// ---- legacy helpers (used only for V0 decryption) ----
-const LEGACY_IV_STR = 'ohtotptokenaesiv';
-const LEGACY_SALT = new Uint8Array(16); // zero salt
+/**
+ * 密码学引擎端口（见 StoragePorts.CryptoEngine）。
+ * LocalUnit 下 cryptoFramework 静默失效，格式层用例经 useCryptoEngineForTest 注入
+ * 确定性假引擎；AES/PBKDF2/GCM 数值正确性由生产实现 + 真机 ohosTest 保证。
+ * 延迟构造：避免模块加载期引用声明在后的类。
+ */
+let engine: CryptoEngine | undefined = undefined;
 
-async function legacyDeriveKey(user_key: string): Promise<cryptoFramework.SymKey> {
-  let spec: cryptoFramework.PBKDF2Spec = {
-    algName: 'PBKDF2',
-    password: user_key,
-    salt: LEGACY_SALT,
-    iterations: 10000,
-    keySize: 16
-  };
-  let kdf = cryptoFramework.createKdf('PBKDF2|SHA256');
-  let symKeyBlob = await kdf.generateSecret(spec);
-  let aesGenerator = cryptoFramework.createSymKeyGenerator('AES128');
-  return aesGenerator.convertKeySync(symKeyBlob);
+const TAG = 'CryptoUtils';
+
+/**
+ * 测试注入：替换全局密码学引擎。
+ * 信任模型与 CloudBackupCrypto.useEngineForTest 一致——生产代码不得调用；
+ * 调用会留下 hilog.warn 审计痕迹（LocalUnit 下为空操作）。
+ */
+export function useCryptoEngineForTest(custom: CryptoEngine): void {
+  hilog.warn(0xFF00, TAG, 'useCryptoEngineForTest called (test-only entry point)');
+  engine = custom;
 }
 
-function legacyIvSpec(): cryptoFramework.IvParamsSpec {
-  // stringToIntArray('ohtotptokenaesiv') equivalent
-  const bytes = new Uint8Array(buffer.from(LEGACY_IV_STR).buffer);
-  return { algName: "IvParamsSpec", iv: { data: bytes } };
+/** 测试复位：恢复生产引擎并清除 BLE 派生密钥缓存（供套件间隔离）。 */
+export function resetCryptoEngineForTest(): void {
+  engine = undefined;
+  bleTransportKey = undefined;
 }
 
-async function deriveKey(user_key: string, salt: Uint8Array, iterations: number): Promise<cryptoFramework.SymKey> {
-  let spec: cryptoFramework.PBKDF2Spec = {
-    algName: 'PBKDF2',
-    password: user_key,
-    salt: salt,
-    iterations: iterations,
-    keySize: 16
-  };
-  let kdf = cryptoFramework.createKdf('PBKDF2|SHA256');
-  let symKeyBlob = await kdf.generateSecret(spec);
-  let aesGenerator = cryptoFramework.createSymKeyGenerator('AES128');
-  return aesGenerator.convertKeySync(symKeyBlob);
+function getEngine(): CryptoEngine {
+  let current = engine;
+  if (current === undefined) {
+    current = new CryptoFrameworkCryptoEngine();
+    engine = current;
+  }
+  return current;
 }
 
-export async function decryptFile(file_buf: Uint8Array, user_key: string): Promise<string> {
-  let salt: Uint8Array;
-  let iv: Uint8Array;
-  let cipherData: Uint8Array;
+/** cryptoFramework 生产实现（LocalUnit 不会执行到）。 */
+export class CryptoFrameworkCryptoEngine implements CryptoEngine {
+  randomBytes(length: number): Uint8Array {
+    return new Uint8Array(cryptoFramework.createRandom().generateRandomSync(length).data);
+  }
 
-  if (file_buf.length >= HEADER_SIZE && startsWith(file_buf, MAGIC)) {
-    // ---- V2 (new format): MAGIC + salt:16 + iv:16 + ciphertext ----
-    salt = file_buf.slice(SALT_OFS, SALT_OFS + 16);
-    iv = file_buf.slice(IV_OFS, IV_OFS + 16);
-    cipherData = file_buf.slice(HEADER_SIZE);
-    let aes_decoder = cryptoFramework.createCipher('AES128|CBC|PKCS7');
-    let aes_iv: cryptoFramework.IvParamsSpec = { algName: "IvParamsSpec", iv: { data: iv } };
-    let aes_key = await deriveKey(user_key, salt, 600000);
-    await aes_decoder.init(cryptoFramework.CryptoMode.DECRYPT_MODE, aes_key, aes_iv);
-    let decryptData = await aes_decoder.doFinal({ data: cipherData });
-    let decoder = new util.TextDecoder();
-    return decoder.decodeToString(decryptData.data);
-  } else {
-    // ---- V0 (legacy): raw ciphertext, hardcoded IV, zero salt ----
-    let aes_decoder = cryptoFramework.createCipher('AES128|CBC|PKCS7');
-    let aes_key = await legacyDeriveKey(user_key);
-    await aes_decoder.init(cryptoFramework.CryptoMode.DECRYPT_MODE, aes_key, legacyIvSpec());
-    let decryptData = await aes_decoder.doFinal({ data: file_buf });
-    let decoder = new util.TextDecoder();
-    return decoder.decodeToString(decryptData.data);
+  utf8Encode(text: string): Uint8Array {
+    return new Uint8Array(buffer.from(text, 'utf-8').buffer);
+  }
+
+  utf8Decode(data: Uint8Array): string {
+    const decoder = new util.TextDecoder();
+    return decoder.decodeToString(data);
+  }
+
+  async pbkdf2Derive(password: string, salt: Uint8Array, iterations: number, keySize: number): Promise<Uint8Array> {
+    let spec: cryptoFramework.PBKDF2Spec = {
+      algName: 'PBKDF2',
+      password: password,
+      salt: salt,
+      iterations: iterations,
+      keySize: keySize
+    };
+    let kdf = cryptoFramework.createKdf('PBKDF2|SHA256');
+    let symKeyBlob = await kdf.generateSecret(spec);
+    let aesGenerator = cryptoFramework.createSymKeyGenerator('AES128');
+    let symKey = aesGenerator.convertKeySync(symKeyBlob);
+    return new Uint8Array(symKey.getEncoded().data);
+  }
+
+  async sha256(data: Uint8Array): Promise<Uint8Array> {
+    let md = cryptoFramework.createMd('SHA256');
+    await md.update({ data: data });
+    return new Uint8Array((await md.digest()).data);
+  }
+
+  private async cbcCipher(mode: cryptoFramework.CryptoMode, key: Uint8Array, iv: Uint8Array):
+    Promise<cryptoFramework.Cipher> {
+    let aesKeyGen = cryptoFramework.createSymKeyGenerator('AES128');
+    let aesKey = aesKeyGen.convertKeySync({ data: key });
+    let aesCipher = cryptoFramework.createCipher('AES128|CBC|PKCS7');
+    let aesIv: cryptoFramework.IvParamsSpec = { algName: "IvParamsSpec", iv: { data: iv } };
+    await aesCipher.init(mode, aesKey, aesIv);
+    return aesCipher;
+  }
+
+  async aesCbcEncrypt(plain: Uint8Array, key: Uint8Array, iv: Uint8Array): Promise<Uint8Array> {
+    const cipher = await this.cbcCipher(cryptoFramework.CryptoMode.ENCRYPT_MODE, key, iv);
+    return new Uint8Array((await cipher.doFinal({ data: plain })).data);
+  }
+
+  async aesCbcDecrypt(cipherData: Uint8Array, key: Uint8Array, iv: Uint8Array): Promise<Uint8Array> {
+    const cipher = await this.cbcCipher(cryptoFramework.CryptoMode.DECRYPT_MODE, key, iv);
+    return new Uint8Array((await cipher.doFinal({ data: cipherData })).data);
+  }
+
+  async aesGcmSeal(plain: Uint8Array, key: Uint8Array, iv: Uint8Array, aad: Uint8Array): Promise<CryptoSealedBytes> {
+    let gcmParams: cryptoFramework.GcmParamsSpec = {
+      algName: 'GcmParamsSpec',
+      iv: { data: iv },
+      aad: { data: aad },
+      authTag: { data: new Uint8Array(BLE_TAG_LEN) }
+    };
+    let cipher = cryptoFramework.createCipher('AES256|GCM|NoPadding');
+    cipher.initSync(cryptoFramework.CryptoMode.ENCRYPT_MODE, await this.aes256Key(key), gcmParams);
+    // 官方指南行为: update(明文) 返回 ciphertext, doFinal(null) 返回 authTag
+    let enc: cryptoFramework.DataBlob = cipher.updateSync({ data: plain });
+    let tagData: cryptoFramework.DataBlob = cipher.doFinalSync(null);
+    let sealed = new CryptoSealedBytes();
+    sealed.ciphertext = new Uint8Array(enc.data);
+    // 双保险: 优先取 doFinal(null) 返回的完整 tag, 否则取副作用写入的 gcmParams.authTag
+    sealed.tag = tagData.data.length === BLE_TAG_LEN ? tagData.data : gcmParams.authTag.data;
+    return sealed;
+  }
+
+  async aesGcmOpen(cipherData: Uint8Array, key: Uint8Array, iv: Uint8Array, aad: Uint8Array,
+    tag: Uint8Array): Promise<Uint8Array> {
+    let gcmParams: cryptoFramework.GcmParamsSpec = {
+      algName: 'GcmParamsSpec',
+      iv: { data: iv },
+      aad: { data: aad },
+      authTag: { data: tag }
+    };
+    let cipher = cryptoFramework.createCipher('AES256|GCM|NoPadding');
+    cipher.initSync(cryptoFramework.CryptoMode.DECRYPT_MODE, await this.aes256Key(key), gcmParams);
+    let dec = cipher.doFinalSync({ data: cipherData });
+    return new Uint8Array(dec.data);
+  }
+
+  private async aes256Key(keyBytes: Uint8Array): Promise<cryptoFramework.SymKey> {
+    let keyGen = cryptoFramework.createSymKeyGenerator('AES256');
+    return keyGen.convertKeySync({ data: keyBytes });
   }
 }
 
+export async function decryptFile(file_buf: Uint8Array, user_key: string): Promise<string> {
+  if (file_buf.length >= HEADER_SIZE && startsWith(file_buf, MAGIC)) {
+    // ---- V2 (new format): MAGIC + salt:16 + iv:16 + ciphertext ----
+    let salt = file_buf.slice(SALT_OFS, SALT_OFS + 16);
+    let iv = file_buf.slice(IV_OFS, IV_OFS + 16);
+    let cipherData = file_buf.slice(HEADER_SIZE);
+    let keyBytes = await getEngine().pbkdf2Derive(user_key, salt, PBKDF2_ITERATIONS, PBKDF2_KEY_SIZE);
+    let plain = await getEngine().aesCbcDecrypt(cipherData, keyBytes, iv);
+    return getEngine().utf8Decode(plain);
+  }
+  // ---- V0 (legacy): raw ciphertext, hardcoded IV, zero salt ----
+  let keyBytes = await getEngine().pbkdf2Derive(user_key, LEGACY_SALT, LEGACY_PBKDF2_ITERATIONS, PBKDF2_KEY_SIZE);
+  let plain = await getEngine().aesCbcDecrypt(file_buf, keyBytes, getEngine().utf8Encode(LEGACY_IV_STR));
+  return getEngine().utf8Decode(plain);
+}
+
 export async function encryptFile(file_str: string, user_key: string): Promise<Uint8Array> {
-  let salt = randomBytes(16);
-  let iv = randomBytes(16);
-  let aes_encoder = cryptoFramework.createCipher('AES128|CBC|PKCS7');
-  let aes_iv: cryptoFramework.IvParamsSpec = { algName: "IvParamsSpec", iv: { data: iv } };
-  let aes_key = await deriveKey(user_key, salt, 600000);
-  aes_encoder.initSync(cryptoFramework.CryptoMode.ENCRYPT_MODE, aes_key, aes_iv);
-  let ciphertext = new Uint8Array((await aes_encoder.doFinal({ data: new Uint8Array(buffer.from(file_str).buffer) })).data);
+  let salt = getEngine().randomBytes(16);
+  let iv = getEngine().randomBytes(16);
+  let keyBytes = await getEngine().pbkdf2Derive(user_key, salt, PBKDF2_ITERATIONS, PBKDF2_KEY_SIZE);
+  let ciphertext = await getEngine().aesCbcEncrypt(getEngine().utf8Encode(file_str), keyBytes, iv);
   // Build V2 output: MAGIC(4) + salt(16) + iv(16) + ciphertext
   let output = new Uint8Array(HEADER_SIZE + ciphertext.length);
   output.set(MAGIC, 0);
@@ -113,14 +198,10 @@ export async function encryptFile(file_str: string, user_key: string): Promise<U
   output.set(ciphertext, HEADER_SIZE);
   return output;
 }
+
 export async function encryptUint8ArrayData(data: Uint8Array, symKeyBlob: cryptoFramework.DataBlob): Promise<Uint8Array> {
-  let iv = randomBytes(16);
-  let aes_encoder = cryptoFramework.createCipher('AES128|CBC|PKCS7');
-  let aes_iv: cryptoFramework.IvParamsSpec = { algName: "IvParamsSpec", iv: { data: iv } };
-  let aesGenerator = cryptoFramework.createSymKeyGenerator('AES128');
-  let aes_key = aesGenerator.convertKeySync(symKeyBlob);
-  aes_encoder.initSync(cryptoFramework.CryptoMode.ENCRYPT_MODE, aes_key, aes_iv);
-  let ciphertext = new Uint8Array((await aes_encoder.doFinal({ data: data })).data);
+  let iv = getEngine().randomBytes(16);
+  let ciphertext = await getEngine().aesCbcEncrypt(data, new Uint8Array(symKeyBlob.data), iv);
   // Build V2 output: MAGIC_U8(4) + iv(16) + ciphertext
   let output = new Uint8Array(HEADER_U8_SIZE + ciphertext.length);
   output.set(MAGIC_U8, 0);
@@ -128,6 +209,7 @@ export async function encryptUint8ArrayData(data: Uint8Array, symKeyBlob: crypto
   output.set(ciphertext, HEADER_U8_SIZE);
   return output;
 }
+
 export async function decryptUint8ArrayData(data: Uint8Array, symKeyBlob: cryptoFramework.DataBlob): Promise<Uint8Array | null> {
   try {
     let iv: Uint8Array;
@@ -138,16 +220,11 @@ export async function decryptUint8ArrayData(data: Uint8Array, symKeyBlob: crypto
       cipherData = data.slice(HEADER_U8_SIZE);
     } else {
       // Legacy: use hardcoded IV
-      iv = new Uint8Array(buffer.from(LEGACY_IV_STR).buffer);
+      iv = getEngine().utf8Encode(LEGACY_IV_STR);
       cipherData = data;
     }
 
-    let aes_decoder = cryptoFramework.createCipher('AES128|CBC|PKCS7');
-    let aes_iv: cryptoFramework.IvParamsSpec = { algName: "IvParamsSpec", iv: { data: iv } };
-    let aesGenerator = cryptoFramework.createSymKeyGenerator('AES128');
-    let aes_key = aesGenerator.convertKeySync(symKeyBlob);
-    await aes_decoder.init(cryptoFramework.CryptoMode.DECRYPT_MODE, aes_key, aes_iv);
-    return new Uint8Array((await aes_decoder.doFinal({ data: cipherData })).data);
+    return await getEngine().aesCbcDecrypt(cipherData, new Uint8Array(symKeyBlob.data), iv);
   } catch (_e) {
     return null;
   }
@@ -158,17 +235,16 @@ export async function decryptUint8ArrayData(data: Uint8Array, symKeyBlob: crypto
  *
  */
 export async function encryptStringData(data: string, symKeyBlob: cryptoFramework.DataBlob): Promise<Uint8Array> {
-  let dataBlob = new Uint8Array(buffer.from(data, 'utf-8').buffer);
-  return await encryptUint8ArrayData(dataBlob, symKeyBlob);
+  return await encryptUint8ArrayData(getEngine().utf8Encode(data), symKeyBlob);
 }
+
 export async function decryptStringData(data: Uint8Array, symKeyBlob: cryptoFramework.DataBlob): Promise<string | null> {
   try {
     let decryptData = await decryptUint8ArrayData(data, symKeyBlob);
     if (decryptData === null) {
       return null;
     }
-    let decoder = new util.TextDecoder();
-    return decoder.decodeToString(decryptData);
+    return getEngine().utf8Decode(decryptData);
   } catch (err) {
     return null;
   }
@@ -188,47 +264,27 @@ const BLE_HEADER_SIZE = 4 + BLE_IV_LEN + BLE_TAG_LEN; // MAGIC + iv + authTag = 
 const BLE_AAD = new Uint8Array(buffer.from('ohtotptoken-ble-aad-v1').buffer);
 const BLE_KEY_CONST = 'ohtotptoken-ble-transport-v1';
 
-let bleTransportKey: cryptoFramework.SymKey | undefined = undefined;
+let bleTransportKey: Uint8Array | undefined = undefined;
 
-async function getBleTransportKey(): Promise<cryptoFramework.SymKey> {
+async function getBleTransportKey(): Promise<Uint8Array> {
   if (bleTransportKey === undefined) {
-    let md = cryptoFramework.createMd('SHA256');
-    await md.update({ data: new Uint8Array(buffer.from(BLE_KEY_CONST).buffer) });
-    let digest: cryptoFramework.DataBlob = await md.digest();
-    let keyGen = cryptoFramework.createSymKeyGenerator('AES256');
-    bleTransportKey = keyGen.convertKeySync(digest);
+    bleTransportKey = await getEngine().sha256(getEngine().utf8Encode(BLE_KEY_CONST));
   }
   return bleTransportKey;
 }
 
 /**
  * 加密 BLE 传输载荷(手机端).
- *
- * GCM 加密模式下 authTag 的获取: 个别 SDK 版本由 doFinal(null) 返回,
- * 部分版本以副作用写入 gcmParams.authTag, 此处双保险读取.
  */
 export async function encryptBlePayload(plain: Uint8Array): Promise<Uint8Array> {
-  let iv = randomBytes(BLE_IV_LEN);
+  let iv = getEngine().randomBytes(BLE_IV_LEN);
   let key = await getBleTransportKey();
-  let gcmParams: cryptoFramework.GcmParamsSpec = {
-    algName: 'GcmParamsSpec',
-    iv: { data: iv },
-    aad: { data: BLE_AAD },
-    authTag: { data: new Uint8Array(BLE_TAG_LEN) }
-  };
-  let cipher = cryptoFramework.createCipher('AES256|GCM|NoPadding');
-  cipher.initSync(cryptoFramework.CryptoMode.ENCRYPT_MODE, key, gcmParams);
-  // 官方指南行为: update(明文) 返回 ciphertext, doFinal(null) 返回 authTag
-  let enc: cryptoFramework.DataBlob = cipher.updateSync({ data: plain });
-  let tagData: cryptoFramework.DataBlob = cipher.doFinalSync(null);
-  // 双保险: 优先取 doFinal(null) 返回的完整 tag, 否则取副作用写入的 gcmParams.authTag
-  let tag: Uint8Array = tagData.data.length === BLE_TAG_LEN ? tagData.data : gcmParams.authTag.data;
-  let ciphertext: Uint8Array = new Uint8Array(enc.data);
-  let out = new Uint8Array(BLE_HEADER_SIZE + ciphertext.length);
+  let sealed = await getEngine().aesGcmSeal(plain, key, iv, BLE_AAD);
+  let out = new Uint8Array(BLE_HEADER_SIZE + sealed.ciphertext.length);
   out.set(BLE_MAGIC, 0);
   out.set(iv, 4);
-  out.set(tag, 4 + BLE_IV_LEN);
-  out.set(ciphertext, BLE_HEADER_SIZE);
+  out.set(sealed.tag, 4 + BLE_IV_LEN);
+  out.set(sealed.ciphertext, BLE_HEADER_SIZE);
   return out;
 }
 
@@ -245,16 +301,7 @@ export async function decryptBlePayload(data: Uint8Array): Promise<Uint8Array | 
     let tag = data.slice(4 + BLE_IV_LEN, BLE_HEADER_SIZE);
     let ciphertext = data.slice(BLE_HEADER_SIZE);
     let key = await getBleTransportKey();
-    let gcmParams: cryptoFramework.GcmParamsSpec = {
-      algName: 'GcmParamsSpec',
-      iv: { data: iv },
-      aad: { data: BLE_AAD },
-      authTag: { data: tag }
-    };
-    let cipher = cryptoFramework.createCipher('AES256|GCM|NoPadding');
-    cipher.initSync(cryptoFramework.CryptoMode.DECRYPT_MODE, key, gcmParams);
-    let dec = cipher.doFinalSync({ data: ciphertext });
-    return new Uint8Array(dec.data);
+    return await getEngine().aesGcmOpen(ciphertext, key, iv, BLE_AAD, tag);
   } catch (e) {
     return null;
   }

--- a/common/src/main/ets/utils/FileUtils.ets
+++ b/common/src/main/ets/utils/FileUtils.ets
@@ -8,40 +8,64 @@ import { buffer } from '@kit.ArkTS';
 
 const BUFFER_SIZE = 4096;
 
-export async function readFileContent(uri: string): Promise<string> {
-  let content = '';
-  return await fs.open(uri, fs.OpenMode.READ_ONLY).then((f) => {
-    let buffer = new ArrayBuffer(BUFFER_SIZE);
-    let offset = 0;
-    let readOut = 0;
-    do {
-      readOut = fs.readSync(f.fd, buffer, { offset: offset });
-      content += intArrayToString(buffer.slice(0, readOut));
-      offset += BUFFER_SIZE;
-    } while (readOut == BUFFER_SIZE)
-    fs.close(f.fd);
-    return content;
-  });
+/** 分块读取端口：生产包装 fs.readSync，测试注入内存分块。 */
+export interface ChunkedTextReader {
+  /** 读取一个 BUFFER_SIZE 块到内部缓冲，返回实际字节数 */
+  readChunk(offset: number): number;
+  /** 当前块缓冲（readChunk 之后有效） */
+  chunkBuffer(): ArrayBuffer;
+  close(): void;
 }
-export async function readFileContentAndCheckSize(uri: string,MaxSize:number): Promise<string> {
+
+/** 固定块循环读取拼接文本（读满一块才继续）。从 readFileContent 抽出的可测核心。 */
+export async function readTextViaChunks(reader: ChunkedTextReader): Promise<string> {
   let content = '';
-  return await fs.open(uri, fs.OpenMode.READ_ONLY).then((f) => {
-    let stat= fs.statSync(f.fd);
-    if (stat.size>MaxSize) {
-      fs.close(f.fd);
-      return content;
-    }
-    let buffer = new ArrayBuffer(BUFFER_SIZE);
-    let offset = 0;
-    let readOut = 0;
-    do {
-      readOut = fs.readSync(f.fd, buffer, { offset: offset });
-      content += intArrayToString(buffer.slice(0, readOut));
-      offset += BUFFER_SIZE;
-    } while (readOut == BUFFER_SIZE)
+  let offset = 0;
+  let readOut = 0;
+  do {
+    readOut = reader.readChunk(offset);
+    content += intArrayToString(reader.chunkBuffer().slice(0, readOut));
+    offset += BUFFER_SIZE;
+  } while (readOut == BUFFER_SIZE)
+  reader.close();
+  return content;
+}
+
+class FsChunkedTextReader implements ChunkedTextReader {
+  private fd: number;
+  private chunk: ArrayBuffer = new ArrayBuffer(BUFFER_SIZE);
+
+  constructor(fd: number) {
+    this.fd = fd;
+  }
+
+  readChunk(offset: number): number {
+    this.chunk = new ArrayBuffer(BUFFER_SIZE);
+    return fs.readSync(this.fd, this.chunk, { offset: offset });
+  }
+
+  chunkBuffer(): ArrayBuffer {
+    return this.chunk;
+  }
+
+  close(): void {
+    fs.close(this.fd);
+  }
+}
+
+export async function readFileContent(uri: string): Promise<string> {
+  const f = await fs.open(uri, fs.OpenMode.READ_ONLY);
+  return await readTextViaChunks(new FsChunkedTextReader(f.fd));
+}
+
+export async function readFileContentAndCheckSize(uri: string, MaxSize: number): Promise<string> {
+  const f = await fs.open(uri, fs.OpenMode.READ_ONLY);
+  const stat = fs.statSync(f.fd);
+  if (stat.size > MaxSize) {
     fs.close(f.fd);
-    return content;
-  });
+    return '';
+  }
+  return await readTextViaChunks(new FsChunkedTextReader(f.fd));
 }
 
 export async function writeFileContent(uri: string, content: string): Promise<void> {
@@ -50,31 +74,76 @@ export async function writeFileContent(uri: string, content: string): Promise<vo
     fs.write(f.fd, content).then(() => {
       fs.close(f.fd);
     });
-  }).catch((reason: BusinessError)=>{
+  }).catch((reason: BusinessError) => {
     hilog.error(reason.code, 'FileUtils', reason.message)
   });
 }
-//写入文件确认文件是否重复 如果重复放弃写入
-export async function writeFileContentCheckHashEqual(uri: string, content: string): Promise<void> {
+
+/** 哈希防重写入端口：生产实现走 fs + Sha256Hash。 */
+export interface HashCompareWriteIo {
+  fileExists(uri: string): Promise<boolean>;
+  readText(uri: string): Promise<string>;
+  writeText(uri: string, content: string): Promise<void>;
+}
+
+//固定使用sha256比对是否相同hash 暂不考虑不同hash长度比对
+export function constantTimeCompare(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a[i] ^ b[i]; // 按位异或后累积差异
+  }
+
+  return result === 0;
+}
+
+/**
+ * 内容哈希相同则跳过写入（可测核心）。
+ * 文件不存在 → 直接写入；存在且哈希一致 → 跳过；不一致 → 覆盖写入。
+ */
+export async function writeTextIfHashDiffers(io: HashCompareWriteIo,
+  hash: (content: string) => Promise<Uint8Array>,
+  uri: string, content: string): Promise<void> {
   let isWrite = true;
-  if (await fs.access(uri)) {
-    let fileContent = await readFileContent(uri);
-    let fileHash = await Sha256Hash(fileContent);
-    let contentHash = await Sha256Hash(content);
-    isWrite = !constantTimeCompare(fileHash,contentHash);//比对哈希不同才写入
+  if (await io.fileExists(uri)) {
+    let fileContent = await io.readText(uri);
+    let fileHash = await hash(fileContent);
+    let contentHash = await hash(content);
+    isWrite = !constantTimeCompare(fileHash, contentHash);//比对哈希不同才写入
   }
   // 比对哈希不同才写入
   if (isWrite) {
-    //调整为覆盖写入 只写入 并且创建新文件
+    await io.writeText(uri, content);
+  }
+}
+
+class FsHashCompareWriteIo implements HashCompareWriteIo {
+  async fileExists(uri: string): Promise<boolean> {
+    return await fs.access(uri);
+  }
+
+  async readText(uri: string): Promise<string> {
+    return readFileContent(uri);
+  }
+
+  async writeText(uri: string, content: string): Promise<void> {
+    //调整为覆盖写入 只写入 并且创建新文件（与历史行为一致：写失败仅记日志不上抛）
     await fs.open(uri, fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC | fs.OpenMode.CREATE).then((f) => {
       fs.write(f.fd, content).then(() => {
         fs.close(f.fd);
       });
-    }).catch((reason: BusinessError)=>{
+    }).catch((reason: BusinessError) => {
       hilog.error(reason.code, 'FileUtils', reason.message)
     });
   }
+}
 
+//写入文件确认文件是否重复 如果重复放弃写入
+export async function writeFileContentCheckHashEqual(uri: string, content: string): Promise<void> {
+  await writeTextIfHashDiffers(new FsHashCompareWriteIo(), Sha256Hash, uri, content);
 }
 
 export async function Sha256Hash(content: string) {
@@ -103,17 +172,4 @@ export async function showSaveFilePicker(name: string[], filters: string[]): Pro
   let context = AppStorage.get<common.UIAbilityContext>('appContext') as common.UIAbilityContext;
   const documentViewPicker = new picker.DocumentViewPicker(context);
   return documentViewPicker.save(documentSaveOptions);
-}
-//固定使用sha256比对是否相同hash 暂不考虑不同hash长度比对
-function constantTimeCompare(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
-
-  let result = 0;
-  for (let i = 0; i < a.length; i++) {
-    result |= a[i] ^ b[i]; // 按位异或后累积差异
-  }
-
-  return result === 0;
 }

--- a/common/src/main/ets/utils/IconPackCloudBackup.ets
+++ b/common/src/main/ets/utils/IconPackCloudBackup.ets
@@ -1,13 +1,13 @@
 import { hilog } from '@kit.PerformanceAnalysisKit';
-import { fileIo as fs, cloudSync, fileUri } from '@kit.CoreFileKit';
+import { cloudSync, fileUri } from '@kit.CoreFileKit';
 import { common } from '@kit.AbilityKit';
 import { zlib } from '@kit.BasicServicesKit';
-import { buffer } from '@kit.ArkTS';
 import { AppPreference, PREF_KEYS, BUILTIN_DEFAULT_PACK_ID, EVENT_NAMES } from './AppPreference';
 import { TokenIconPacks } from './TokenUtils';
 import { SyncTimeHelper } from './SyncTimeHelper';
 import { HuaweiAccountManager } from './HuaweiAccountManager';
 import { DeviceInfoHelper } from './DeviceInfoHelper';
+import { FsGateway, FileIoFsGateway } from './StoragePorts';
 
 const TAG = 'IconPackCloudBackup';
 const DOMAIN = 0xFF00;
@@ -19,6 +19,68 @@ const META_JSON_NAME = 'icon_packs_meta.json';
  * checkCloudBackupNewer 只读取此文件而不用解压整个 zip，大幅降低冷启动开销。
  */
 const SYNC_META_FILE = 'icon_packs_sync_meta.json';
+
+/** zip 压缩/解压端口（生产：zlib，LocalUnit 不可用）。 */
+export interface IconPackArchiver {
+  compress(srcDir: string, destZip: string): Promise<void>;
+  decompress(zipPath: string, destDir: string): Promise<void>;
+}
+
+class ZlibIconPackArchiver implements IconPackArchiver {
+  async compress(srcDir: string, destZip: string): Promise<void> {
+    const options: zlib.Options = {
+      level: zlib.CompressLevel.COMPRESS_LEVEL_DEFAULT_COMPRESSION,
+    };
+    await zlib.compressFile(srcDir, destZip, options);
+  }
+
+  async decompress(zipPath: string, destDir: string): Promise<void> {
+    await zlib.decompressFile(zipPath, destDir);
+  }
+}
+
+/**
+ * 恢复时的启用列表合并策略（纯函数）：
+ * 以云端 enabledPacks 为基础（为空则回退内置默认包），追加本地独有的包（不丢失本地新增包）。
+ */
+export function mergeEnabledPacks(cloudEnabledPacks: string[], localPackUuids: string[]): string[] {
+  const basePacks = cloudEnabledPacks && cloudEnabledPacks.length > 0
+    ? cloudEnabledPacks
+    : [BUILTIN_DEFAULT_PACK_ID];
+  const merged = [...basePacks];
+  for (const localUuid of localPackUuids) {
+    if (!merged.includes(localUuid)) {
+      merged.push(localUuid);
+    }
+  }
+  return merged;
+}
+
+/** 设备标识端口（生产：DeviceInfoHelper，LocalUnit 不可用）。 */
+export interface IconPackDevicePort {
+  deviceId(): string;
+  deviceName(): string;
+}
+
+class DeviceInfoAdapter implements IconPackDevicePort {
+  deviceId(): string {
+    return DeviceInfoHelper.getInstance().getDeviceId();
+  }
+
+  deviceName(): string {
+    return DeviceInfoHelper.getInstance().getDeviceName();
+  }
+}
+
+/** LocalUnit 测试注入项（目录就绪时跳过 init() 的 AppStorage 依赖）。 */
+export interface IconPackBackupTestDeps {
+  fs?: FsGateway;
+  archiver?: IconPackArchiver;
+  device?: IconPackDevicePort;
+  filesDir?: string;
+  cloudDir?: string;
+  cacheDir?: string;
+}
 
 /**
  * 图标包云备份同步状态机
@@ -104,6 +166,10 @@ class SyncMetaRecord {
  * 不需要真正的锁。所有公开异步方法在入口处 tryTransition，在 finally 中回到 IDLE。
  *
  * 状态机生命周期：纯内存态，不持久化。应用重启后 singleton 重建，自动恢复 IDLE。
+ *
+ * ## Phase 2 解耦
+ * 文件系统经 {@link FsGateway} 端口、压缩经 {@link IconPackArchiver} 端口访问，
+ * 状态机/去抖/合并决策在 LocalUnit 下可测（见 docs/TEST_PLAN.md 第 4 节）。
  */
 export class IconPackCloudBackup {
   private static instance: IconPackCloudBackup | null = null;
@@ -114,6 +180,8 @@ export class IconPackCloudBackup {
   private fileSync: cloudSync.FileSync | null = null;
   /** 状态机当前状态，纯内存态，重启自动重置 */
   private syncState: IconPackSyncState = IconPackSyncState.IDLE;
+  private testDeps: IconPackBackupTestDeps | null = null;
+  private readonly productionFs: FsGateway = new FileIoFsGateway();
 
   private constructor() {
   }
@@ -123,6 +191,40 @@ export class IconPackCloudBackup {
       IconPackCloudBackup.instance = new IconPackCloudBackup();
     }
     return IconPackCloudBackup.instance;
+  }
+
+  /** 测试注入：LocalUnit 下 fileIo/zlib 不可用，替换文件系统/压缩端口与目录。 */
+  useDepsForTest(deps: IconPackBackupTestDeps): void {
+    this.testDeps = deps;
+    if (deps.cloudDir !== undefined || deps.filesDir !== undefined || deps.cacheDir !== undefined) {
+      // 语义上 context 已就绪：init() 直接短路，不再读 AppStorage
+      this.context = new Object() as common.UIAbilityContext;
+      this.cloudDir = deps.cloudDir !== undefined ? deps.cloudDir : this.cloudDir;
+      this.filesDir = deps.filesDir !== undefined ? deps.filesDir : this.filesDir;
+      this.cacheDir = deps.cacheDir !== undefined ? deps.cacheDir : this.cacheDir;
+    }
+  }
+
+  /** 重置测试注入（恢复生产端口与未初始化状态）。 */
+  resetForTest(): void {
+    this.testDeps = null;
+    this.context = undefined;
+    this.cloudDir = '';
+    this.filesDir = '';
+    this.cacheDir = '';
+    this.syncState = IconPackSyncState.IDLE;
+  }
+
+  private get fs(): FsGateway {
+    return this.testDeps?.fs !== undefined ? this.testDeps.fs : this.productionFs;
+  }
+
+  private get archiver(): IconPackArchiver {
+    return this.testDeps?.archiver !== undefined ? this.testDeps.archiver : new ZlibIconPackArchiver();
+  }
+
+  private get devicePort(): IconPackDevicePort {
+    return this.testDeps?.device !== undefined ? this.testDeps.device : new DeviceInfoAdapter();
   }
 
   async init(): Promise<void> {
@@ -200,12 +302,12 @@ export class IconPackCloudBackup {
     let hasContent = false;
 
     try {
-      const packFiles = fs.listFileSync(iconPackDir);
+      const packFiles = await this.fs.listFiles(iconPackDir);
       if (packFiles.length > 0) hasContent = true;
     } catch (_) {}
 
     try {
-      const userFiles = fs.listFileSync(userIconDir);
+      const userFiles = await this.fs.listFiles(userIconDir);
       if (userFiles.length > 0) hasContent = true;
     } catch (_) {}
 
@@ -237,53 +339,48 @@ export class IconPackCloudBackup {
 
     try {
       // 1. 清理并创建 staging 目录（防止上次中断残留旧文件污染本次备份）
+      await this.removeDirRecursive(stagingDir);
       try {
-        await this.removeDirRecursive(stagingDir);
-      } catch (_) {}
-      try {
-        await fs.mkdir(stagingDir);
+        await this.fs.makeDir(stagingDir);
       } catch (_) {}
 
       // 2. 写入元数据文件
-      const metaFile = fs.openSync(metaPath, fs.OpenMode.WRITE_ONLY | fs.OpenMode.CREATE | fs.OpenMode.TRUNC);
-      fs.writeSync(metaFile.fd, JSON.stringify(meta));
-      fs.closeSync(metaFile);
+      await this.fs.writeTextFile(metaPath, JSON.stringify(meta));
 
-      // 3. 递归拷贝 icon_packs 和 user_icons 到 staging（必须用 copyDirRecursive，fs.copyFile 不支持目录）
+      // 3. 递归拷贝 icon_packs 和 user_icons 到 staging（fs.copyFile 不支持目录）
       try {
         const destIconDir = stagingDir + '/icon_packs';
-        await fs.mkdir(destIconDir);
+        try {
+          await this.fs.makeDir(destIconDir);
+        } catch (_) {}
         await this.copyDirRecursive(iconPackDir, destIconDir);
       } catch (_) {}
       try {
         const destUserDir = stagingDir + '/user_icons';
-        await fs.mkdir(destUserDir);
+        try {
+          await this.fs.makeDir(destUserDir);
+        } catch (_) {}
         await this.copyDirRecursive(userIconDir, destUserDir);
       } catch (_) {}
 
       // 4. 压缩 staging 目录为 zip
-      const options: zlib.Options = {
-        level: zlib.CompressLevel.COMPRESS_LEVEL_DEFAULT_COMPRESSION,
-      };
-      await zlib.compressFile(stagingDir, tempZipPath, options);
+      await this.archiver.compress(stagingDir, tempZipPath);
 
       // 5. 将 zip 复制到 cloudDir
       const cloudZipPath = this.cloudDir + '/' + ICON_PACK_BACKUP_ZIP;
-      await fs.copyFile(tempZipPath, cloudZipPath);
+      await this.fs.copyFile(tempZipPath, cloudZipPath);
 
       // 6. 写入伴生元数据文件（~1-2KB，含设备信息、时间戳、图标包列表）
       const syncMeta = new SyncMetaRecord();
       syncMeta.version = 1;
       syncMeta.timestamp = now;
-      syncMeta.deviceId = DeviceInfoHelper.getInstance().getDeviceId();
-      syncMeta.deviceName = DeviceInfoHelper.getInstance().getDeviceName();
+      syncMeta.deviceId = this.devicePort.deviceId();
+      syncMeta.deviceName = this.devicePort.deviceName();
       syncMeta.enabledPacks = TokenIconPacks.enabled_packs;
       syncMeta.deletedPacks = [];
       syncMeta.packs = packEntries;
       const syncMetaPath = this.cloudDir + '/' + SYNC_META_FILE;
-      const syncMetaFile = fs.openSync(syncMetaPath, fs.OpenMode.WRITE_ONLY | fs.OpenMode.CREATE | fs.OpenMode.TRUNC);
-      fs.writeSync(syncMetaFile.fd, JSON.stringify(syncMeta));
-      fs.closeSync(syncMetaFile);
+      await this.fs.writeTextFile(syncMetaPath, JSON.stringify(syncMeta));
 
       // 7. 触发云端同步（zip + 伴生文件一起上传）
       await this.syncToCloud();
@@ -297,7 +394,7 @@ export class IconPackCloudBackup {
     } finally {
       await this.removeDirRecursive(stagingDir);
       try {
-        await fs.unlink(tempZipPath);
+        await this.fs.deleteFile(tempZipPath);
       } catch (_) {}
     }
   }
@@ -333,12 +430,12 @@ export class IconPackCloudBackup {
 
     const syncMetaPath = this.cloudDir + '/' + SYNC_META_FILE;
     try {
-      const stat = await fs.stat(syncMetaPath);
+      const stat = await this.fs.stat(syncMetaPath);
       if (stat.location === 2) {
         await this.cacheFile(syncMetaPath);
       }
 
-      const content = await this.readFileContent(syncMetaPath);
+      const content = await this.fs.readTextFile(syncMetaPath);
       const meta = JSON.parse(content) as SyncMetaRecord;
       const cloudTs = meta.timestamp || 0;
       hilog.info(DOMAIN, TAG, `checkCloudBackupNewer: cloudTs=${cloudTs}, localTs=${lastRestoreTs}, device=${meta.deviceName}`);
@@ -376,7 +473,7 @@ export class IconPackCloudBackup {
     const cloudZipPath = this.cloudDir + '/' + ICON_PACK_BACKUP_ZIP;
     try {
       // 若文件仍在云端（location=2），先缓存到本地
-      const stat = await fs.stat(cloudZipPath);
+      const stat = await this.fs.stat(cloudZipPath);
       if (stat.location === 2) {
         await this.cacheFile(cloudZipPath);
       }
@@ -384,19 +481,19 @@ export class IconPackCloudBackup {
       // 解压到临时目录（cacheDir，不直接写 filesDir）
       const tempDir = this.cacheDir + '/icon_pack_restore';
       try {
-        await fs.mkdir(tempDir);
+        await this.fs.makeDir(tempDir);
       } catch (_) {}
 
-      await zlib.decompressFile(cloudZipPath, tempDir);
+      await this.archiver.decompress(cloudZipPath, tempDir);
 
       // 确保目标目录存在
       const iconPackDir = this.filesDir + '/icon_packs';
       const userIconDir = this.filesDir + '/user_icons';
       try {
-        fs.mkdirSync(iconPackDir);
+        await this.fs.makeDir(iconPackDir);
       } catch (_) {}
       try {
-        fs.mkdirSync(userIconDir);
+        await this.fs.makeDir(userIconDir);
       } catch (_) {}
 
       // 选择性拷贝：只还原 icon_packs 和 user_icons 子目录
@@ -412,7 +509,7 @@ export class IconPackCloudBackup {
       // 读取元数据
       let meta: IconPackMetaRecord | null = null;
       try {
-        const metaContent = await this.readFileContent(tempDir + '/' + META_JSON_NAME);
+        const metaContent = await this.fs.readTextFile(tempDir + '/' + META_JSON_NAME);
         meta = JSON.parse(metaContent) as IconPackMetaRecord;
       } catch (_) {}
 
@@ -438,16 +535,8 @@ export class IconPackCloudBackup {
         await this.refreshIconPackState();
 
         // 合并策略：以云端 enabledPacks 为基础，追加本地独有的包（不丢失本地新增包）
-        const basePacks = meta.enabledPacks && meta.enabledPacks.length > 0
-          ? meta.enabledPacks
-          : [BUILTIN_DEFAULT_PACK_ID];
-        let merged = [...basePacks];
         const localPacks = TokenIconPacks.aegis_icon_packs.map(p => p.uuid);
-        for (const localUuid of localPacks) {
-          if (!merged.includes(localUuid)) {
-            merged.push(localUuid);
-          }
-        }
+        const merged = mergeEnabledPacks(meta.enabledPacks, localPacks);
 
         TokenIconPacks.enabled_packs = merged;
         AppPreference.saveEnabledPacks(merged);
@@ -476,7 +565,7 @@ export class IconPackCloudBackup {
 
     await TokenIconPacks.addUserIconPack(userIconDir);
     try {
-      const paths = await fs.listFile(iconPackDir);
+      const paths = await this.fs.listFiles(iconPackDir);
       for (const path of paths) {
         const fullPath = iconPackDir + '/' + path;
         if (TokenIconPacks.aegis_icon_packs.some(pack => pack.on_device_path === fullPath)) {
@@ -509,7 +598,7 @@ export class IconPackCloudBackup {
 
     const cloudZipPath = this.cloudDir + '/' + ICON_PACK_BACKUP_ZIP;
     try {
-      const stat = await fs.stat(cloudZipPath);
+      const stat = await this.fs.stat(cloudZipPath);
       result.exists = true;
       result.size = stat.size;
     } catch (_) {}
@@ -517,11 +606,11 @@ export class IconPackCloudBackup {
     // 从伴生元数据文件读取详细信息（包列表、来源设备等）
     const syncMetaPath = this.cloudDir + '/' + SYNC_META_FILE;
     try {
-      const smStat = await fs.stat(syncMetaPath);
+      const smStat = await this.fs.stat(syncMetaPath);
       if (smStat.location === 2) {
         await this.cacheFile(syncMetaPath);
       }
-      const content = await this.readFileContent(syncMetaPath);
+      const content = await this.fs.readTextFile(syncMetaPath);
       const meta = JSON.parse(content) as SyncMetaRecord;
       result.packCount = meta.packs?.length ?? 0;
       result.sourceDeviceId = meta.deviceId ?? '';
@@ -548,10 +637,10 @@ export class IconPackCloudBackup {
     try {
       const cloudZipPath = this.cloudDir + '/' + ICON_PACK_BACKUP_ZIP;
       try {
-        await fs.unlink(cloudZipPath);
+        await this.fs.deleteFile(cloudZipPath);
       } catch (_) {}
       try {
-        await fs.unlink(this.cloudDir + '/' + SYNC_META_FILE);
+        await this.fs.deleteFile(this.cloudDir + '/' + SYNC_META_FILE);
       } catch (_) {}
       await this.syncToCloud();
       hilog.info(DOMAIN, TAG, 'clearCloudBackup: completed');
@@ -580,10 +669,14 @@ export class IconPackCloudBackup {
 
   /** 触发 FileSync.start() 将 cloudDir 变更同步到云端（复用实例避免重复创建） */
   private async syncToCloud(): Promise<void> {
-    if (!this.fileSync) {
-      this.fileSync = new cloudSync.FileSync();
+    // 测试注入下无需真实云同步
+    if (this.testDeps !== null) {
+      return;
     }
     try {
+      if (!this.fileSync) {
+        this.fileSync = new cloudSync.FileSync();
+      }
       await this.fileSync.start();
       hilog.info(DOMAIN, TAG, 'syncToCloud: started');
     } catch (e) {
@@ -593,9 +686,13 @@ export class IconPackCloudBackup {
 
   /** 将云端文件（location=2）缓存到本地，以便读取内容 */
   private async cacheFile(filePath: string): Promise<void> {
-    const uri = fileUri.getUriFromPath(filePath);
-    const cache = new cloudSync.CloudFileCache();
+    // 测试注入下假文件系统内容均在本地，跳过云端缓存拉取
+    if (this.testDeps !== null) {
+      return;
+    }
     try {
+      const uri = fileUri.getUriFromPath(filePath);
+      const cache = new cloudSync.CloudFileCache();
       await cache.start(uri);
       hilog.info(DOMAIN, TAG, `cacheFile: cached ${filePath}`);
     } catch (e) {
@@ -603,41 +700,23 @@ export class IconPackCloudBackup {
     }
   }
 
-  private async readFileContent(filePath: string): Promise<string> {
-    let file: fs.File | null = null;
-    try {
-      const stat = await fs.stat(filePath);
-      file = await fs.open(filePath, fs.OpenMode.READ_ONLY);
-      const bufferArray = new ArrayBuffer(stat.size);
-      const readLen = await fs.read(file.fd, bufferArray);
-      const uint8Array = new Uint8Array(bufferArray.slice(0, readLen));
-      return buffer.from(uint8Array).toString('utf-8');
-    } finally {
-      if (file) {
-        try {
-          await fs.close(file);
-        } catch (_) {}
-      }
-    }
-  }
-
   private async removeDirRecursive(dirPath: string): Promise<void> {
     try {
-      const files = await fs.listFile(dirPath);
+      const files = await this.fs.listFiles(dirPath);
       for (const file of files) {
         const fullPath = dirPath + '/' + file;
         try {
-          const stat = await fs.stat(fullPath);
-          if (stat.isDirectory()) {
+          const stat = await this.fs.stat(fullPath);
+          if (stat.isDirectory) {
             await this.removeDirRecursive(fullPath);
           } else {
-            await fs.unlink(fullPath);
+            await this.fs.deleteFile(fullPath);
           }
         } catch (e) {
           hilog.warn(DOMAIN, TAG, `removeDirRecursive: failed to remove ${fullPath}: ${JSON.stringify(e)}`);
         }
       }
-      await fs.rmdir(dirPath);
+      await this.fs.removeDir(dirPath);
     } catch (e) {
       hilog.warn(DOMAIN, TAG, `removeDirRecursive: failed to process ${dirPath}: ${JSON.stringify(e)}`);
     }
@@ -645,19 +724,19 @@ export class IconPackCloudBackup {
 
   private async copyDirRecursive(srcDir: string, destDir: string): Promise<void> {
     try {
-      const files = await fs.listFile(srcDir);
+      const files = await this.fs.listFiles(srcDir);
       for (const file of files) {
         const srcPath = srcDir + '/' + file;
         const destPath = destDir + '/' + file;
         try {
-          const stat = await fs.stat(srcPath);
-          if (stat.isDirectory()) {
+          const stat = await this.fs.stat(srcPath);
+          if (stat.isDirectory) {
             try {
-              await fs.mkdir(destPath);
+              await this.fs.makeDir(destPath);
             } catch (_) {}
             await this.copyDirRecursive(srcPath, destPath);
           } else {
-            await fs.copyFile(srcPath, destPath);
+            await this.fs.copyFile(srcPath, destPath);
           }
         } catch (e) {
           hilog.warn(DOMAIN, TAG, `copyDirRecursive: failed to copy ${srcPath}: ${JSON.stringify(e)}`);

--- a/common/src/main/ets/utils/IconPackCloudBackup.ets
+++ b/common/src/main/ets/utils/IconPackCloudBackup.ets
@@ -3,7 +3,7 @@ import { cloudSync, fileUri } from '@kit.CoreFileKit';
 import { common } from '@kit.AbilityKit';
 import { zlib } from '@kit.BasicServicesKit';
 import { AppPreference, PREF_KEYS, BUILTIN_DEFAULT_PACK_ID, EVENT_NAMES } from './AppPreference';
-import { TokenIconPacks } from './TokenUtils';
+import { TokenIconPacks, AegisIconPack } from './TokenUtils';
 import { SyncTimeHelper } from './SyncTimeHelper';
 import { HuaweiAccountManager } from './HuaweiAccountManager';
 import { DeviceInfoHelper } from './DeviceInfoHelper';
@@ -72,11 +72,64 @@ class DeviceInfoAdapter implements IconPackDevicePort {
   }
 }
 
+/**
+ * 图标包注册表端口（Phase 3，docs/TEST_PLAN.md 第 4 节）。
+ * 恢复成功链路（deletedPacks 清理 → 磁盘重载 → enabledPacks 合并应用）经此端口
+ * 访问 TokenIconPacks 静态状态，LocalUnit 注入内存假实现全测；
+ * 生产适配器保证真机行为不变（磁盘加载/偏好读写归 TokenIconPacks/AppPreference）。
+ */
+export interface IconPackRegistry {
+  /** 当前已加载的自定义图标包（含无效包） */
+  listPacks(): AegisIconPack[];
+  /** 从 user_icons 目录重载用户图标 */
+  loadUserIcons(userIconDir: string): Promise<void>;
+  /** 从设备目录加载图标包（pack.json 解析 + 磁盘读取） */
+  addPackFromDevice(path: string): Promise<void>;
+  /** 删除图标包（清理预览缓存、enabledPacks 过滤、磁盘目录删除） */
+  removePack(pack: AegisIconPack): Promise<void>;
+  getEnabledPacks(): string[];
+  setEnabledPacks(packs: string[]): void;
+  /** 从偏好重新加载 enabledPacks 到内存（恢复前的干净基线） */
+  reloadEnabledPacksFromPreference(): void;
+}
+
+/** {@link IconPackRegistry} 生产实现：委托 TokenIconPacks 静态接口。 */
+class TokenIconPacksRegistry implements IconPackRegistry {
+  listPacks(): AegisIconPack[] {
+    return TokenIconPacks.aegis_icon_packs;
+  }
+
+  async loadUserIcons(userIconDir: string): Promise<void> {
+    await TokenIconPacks.addUserIconPack(userIconDir);
+  }
+
+  async addPackFromDevice(path: string): Promise<void> {
+    await TokenIconPacks.addAegisIconPack(path);
+  }
+
+  async removePack(pack: AegisIconPack): Promise<void> {
+    await TokenIconPacks.removeAegisIconPack(pack);
+  }
+
+  getEnabledPacks(): string[] {
+    return TokenIconPacks.enabled_packs;
+  }
+
+  setEnabledPacks(packs: string[]): void {
+    TokenIconPacks.enabled_packs = packs;
+  }
+
+  reloadEnabledPacksFromPreference(): void {
+    TokenIconPacks.enabled_packs = AppPreference.loadEnabledPacks();
+  }
+}
+
 /** LocalUnit 测试注入项（目录就绪时跳过 init() 的 AppStorage 依赖）。 */
 export interface IconPackBackupTestDeps {
   fs?: FsGateway;
   archiver?: IconPackArchiver;
   device?: IconPackDevicePort;
+  registry?: IconPackRegistry;
   filesDir?: string;
   cloudDir?: string;
   cacheDir?: string;
@@ -182,6 +235,7 @@ export class IconPackCloudBackup {
   private syncState: IconPackSyncState = IconPackSyncState.IDLE;
   private testDeps: IconPackBackupTestDeps | null = null;
   private readonly productionFs: FsGateway = new FileIoFsGateway();
+  private readonly productionRegistry: IconPackRegistry = new TokenIconPacksRegistry();
 
   private constructor() {
   }
@@ -225,6 +279,10 @@ export class IconPackCloudBackup {
 
   private get devicePort(): IconPackDevicePort {
     return this.testDeps?.device !== undefined ? this.testDeps.device : new DeviceInfoAdapter();
+  }
+
+  private get registry(): IconPackRegistry {
+    return this.testDeps?.registry !== undefined ? this.testDeps.registry : this.productionRegistry;
   }
 
   async init(): Promise<void> {
@@ -318,7 +376,7 @@ export class IconPackCloudBackup {
 
     const now = Date.now();
     const packEntries: PackMetaEntry[] = [];
-    for (const p of TokenIconPacks.aegis_icon_packs) {
+    for (const p of this.registry.listPacks()) {
       const entry = new PackMetaEntry();
       entry.uuid = p.uuid;
       entry.name = p.name;
@@ -329,7 +387,7 @@ export class IconPackCloudBackup {
     const meta = new IconPackMetaRecord();
     meta.version = 1;
     meta.timestamp = now;
-    meta.enabledPacks = TokenIconPacks.enabled_packs;
+    meta.enabledPacks = this.registry.getEnabledPacks();
     meta.deletedPacks = [];
     meta.packs = packEntries;
 
@@ -376,7 +434,7 @@ export class IconPackCloudBackup {
       syncMeta.timestamp = now;
       syncMeta.deviceId = this.devicePort.deviceId();
       syncMeta.deviceName = this.devicePort.deviceName();
-      syncMeta.enabledPacks = TokenIconPacks.enabled_packs;
+      syncMeta.enabledPacks = this.registry.getEnabledPacks();
       syncMeta.deletedPacks = [];
       syncMeta.packs = packEntries;
       const syncMetaPath = this.cloudDir + '/' + SYNC_META_FILE;
@@ -520,10 +578,10 @@ export class IconPackCloudBackup {
         // 处理云端标记为已删除的图标包
         if (meta.deletedPacks && meta.deletedPacks.length > 0) {
           for (const deletedUuid of meta.deletedPacks) {
-            const pack = TokenIconPacks.aegis_icon_packs.find(p => p.uuid === deletedUuid);
+            const pack = this.registry.listPacks().find(p => p.uuid === deletedUuid);
             if (pack) {
               try {
-                await TokenIconPacks.removeAegisIconPack(pack);
+                await this.registry.removePack(pack);
               } catch (e) {
                 hilog.warn(DOMAIN, TAG, `restoreIconPacks: failed to delete pack ${deletedUuid}: ${JSON.stringify(e)}`);
               }
@@ -531,14 +589,14 @@ export class IconPackCloudBackup {
           }
         }
 
-        // 在 merge 前重新从磁盘加载图标包，使 TokenIconPacks 内存状态包含新拷贝的文件
+        // 在 merge 前重新从磁盘加载图标包，使注册表内存状态包含新拷贝的文件
         await this.refreshIconPackState();
 
         // 合并策略：以云端 enabledPacks 为基础，追加本地独有的包（不丢失本地新增包）
-        const localPacks = TokenIconPacks.aegis_icon_packs.map(p => p.uuid);
+        const localPacks = this.registry.listPacks().map(p => p.uuid);
         const merged = mergeEnabledPacks(meta.enabledPacks, localPacks);
 
-        TokenIconPacks.enabled_packs = merged;
+        this.registry.setEnabledPacks(merged);
         AppPreference.saveEnabledPacks(merged);
         AppPreference.setPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME, `${meta.timestamp}`);
 
@@ -556,23 +614,23 @@ export class IconPackCloudBackup {
   }
 
   /**
-   * 从磁盘重新加载图标包到 TokenIconPacks 内存（在 merge enabledPacks 前调用）
+   * 从磁盘重新加载图标包到注册表内存（在 merge enabledPacks 前调用）
    * 包含：user_icons 目录 + icon_packs 下所有子目录 + enabled_packs 偏好
    */
   private async refreshIconPackState(): Promise<void> {
     const iconPackDir = this.filesDir + '/icon_packs';
     const userIconDir = this.filesDir + '/user_icons';
 
-    await TokenIconPacks.addUserIconPack(userIconDir);
+    await this.registry.loadUserIcons(userIconDir);
     try {
       const paths = await this.fs.listFiles(iconPackDir);
       for (const path of paths) {
         const fullPath = iconPackDir + '/' + path;
-        if (TokenIconPacks.aegis_icon_packs.some(pack => pack.on_device_path === fullPath)) {
+        if (this.registry.listPacks().some(pack => pack.on_device_path === fullPath)) {
           continue;
         }
         try {
-          await TokenIconPacks.addAegisIconPack(fullPath);
+          await this.registry.addPackFromDevice(fullPath);
         } catch (err) {
           hilog.warn(DOMAIN, TAG, `refreshIconPackState: failed to load pack ${path}: ${JSON.stringify(err)}`);
         }
@@ -580,7 +638,7 @@ export class IconPackCloudBackup {
     } catch (err) {
       hilog.warn(DOMAIN, TAG, `refreshIconPackState: failed to list ${iconPackDir}: ${JSON.stringify(err)}`);
     }
-    TokenIconPacks.enabled_packs = AppPreference.loadEnabledPacks();
+    this.registry.reloadEnabledPacksFromPreference();
   }
 
   /** 查询云端图标包备份状态（是否存在、包数量、大小、来源设备等），供 UI 展示 */
@@ -618,7 +676,7 @@ export class IconPackCloudBackup {
       result.packs = meta.packs ?? [];
     } catch (_) {
       // 伴生文件不存在（旧版本备份），回退到本地内存
-      result.packCount = TokenIconPacks.aegis_icon_packs.length;
+      result.packCount = this.registry.listPacks().length;
     }
 
     return result;

--- a/common/src/main/ets/utils/KvManager.ets
+++ b/common/src/main/ets/utils/KvManager.ets
@@ -4,11 +4,78 @@ import { BusinessError } from '@kit.BasicServicesKit';
 import { AppPreference, EVENT_NAMES, PREF_KEYS } from './AppPreference';
 import { distributedDeviceManager } from '@kit.DistributedServiceKit';
 import { TokenConfig } from './TokenConfig';
-import { TokenBatchProgressCallback, TokenBatchStage, reportTokenBatchProgress } from './TokenBatchProgress';
+import { TokenBatchProgressCallback } from './TokenBatchProgress';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { fileIo as fs } from "@kit.CoreFileKit";
+import { KvBatchEntry, LegacyTokenKv, TokenKvStore, TransactionalKv } from './StoragePorts';
+import { commitTokenBatchInChunks, migrateLegacyTokenEntries } from './TokenKvBatch';
 
-export class KvManager {
+/** SingleKVStore 事务原语适配 TokenKvBatch 的 TransactionalKv 端口。 */
+class KvStoreTransactionAdapter implements TransactionalKv {
+  private store: distributedKVStore.SingleKVStore;
+
+  constructor(store: distributedKVStore.SingleKVStore) {
+    this.store = store;
+  }
+
+  async startTransaction(): Promise<void> {
+    await this.store.startTransaction();
+  }
+
+  async putBatch(entries: KvBatchEntry[]): Promise<void> {
+    const distEntries: distributedKVStore.Entry[] = entries.map((entry: KvBatchEntry): distributedKVStore.Entry => {
+      return { key: entry.key, value: { type: distributedKVStore.ValueType.STRING, value: entry.value } };
+    });
+    await this.store.putBatch(distEntries);
+  }
+
+  async deleteBatch(keys: string[]): Promise<void> {
+    await this.store.deleteBatch(keys);
+  }
+
+  async commit(): Promise<void> {
+    await this.store.commit();
+  }
+
+  async rollback(): Promise<void> {
+    await this.store.rollback();
+  }
+}
+
+/** SingleKVStore 读写适配 TokenKvBatch 的旧版本迁移端口。 */
+class KvStoreLegacyAdapter implements LegacyTokenKv {
+  private store: distributedKVStore.SingleKVStore;
+
+  constructor(store: distributedKVStore.SingleKVStore) {
+    this.store = store;
+  }
+
+  async getRawEntries(prefix: string): Promise<KvBatchEntry[]> {
+    const entries = await this.store.getEntries(prefix);
+    return entries.map((entry: distributedKVStore.Entry): KvBatchEntry => {
+      return { key: entry.key, value: entry.value.value as string };
+    });
+  }
+
+  async getString(key: string): Promise<string | null> {
+    try {
+      const data = await this.store.get(key);
+      return data ? data as string : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  async setString(key: string, value: string): Promise<void> {
+    await this.store.put(key, value);
+  }
+
+  async deleteValue(key: string): Promise<void> {
+    await this.store.delete(key);
+  }
+}
+
+export class KvManager implements TokenKvStore {
   //单版本分布式键值数据库
   private _kvMgr: distributedKVStore.KVManager | undefined = undefined;
   private _kvStore: distributedKVStore.SingleKVStore | undefined = undefined;
@@ -24,14 +91,11 @@ export class KvManager {
     return pending;
   }
 
-  /** 原子提交令牌变更；按平台 MAX_BATCH_SIZE=128 分块，不逐条 put/delete。 */
+  /** 原子提交令牌变更；分块/事务编排委托 TokenKvBatch.commitTokenBatchInChunks。 */
   async saveTokenBatch(prefix: string, tokens: TokenConfig[], deletedUuids: string[] = [],
     onProgress?: TokenBatchProgressCallback): Promise<void> {
-    const entries: distributedKVStore.Entry[] = tokens.map((token: TokenConfig): distributedKVStore.Entry => {
-      return {
-        key: `${prefix}${token.TokenUUID}`,
-        value: { type: distributedKVStore.ValueType.STRING, value: JSON.stringify(token) }
-      };
+    const entries: KvBatchEntry[] = tokens.map((token: TokenConfig): KvBatchEntry => {
+      return { key: `${prefix}${token.TokenUUID}`, value: JSON.stringify(token) };
     });
     const keys = deletedUuids.map(uuid => `${prefix}${uuid}`);
     if (entries.length === 0 && keys.length === 0) {
@@ -42,26 +106,7 @@ export class KvManager {
       if (!store) {
         throw new Error('Token batch failed: KV store not initialized');
       }
-      const total = entries.length + keys.length;
-      reportTokenBatchProgress(onProgress, TokenBatchStage.SAVING, 0, total);
-      await store.startTransaction();
-      try {
-        for (let offset = 0; offset < entries.length; offset += 128) {
-          await store.putBatch(entries.slice(offset, offset + 128));
-          reportTokenBatchProgress(onProgress, TokenBatchStage.SAVING, Math.min(offset + 128, entries.length), total);
-        }
-        for (let offset = 0; offset < keys.length; offset += 128) {
-          await store.deleteBatch(keys.slice(offset, offset + 128));
-          reportTokenBatchProgress(onProgress, TokenBatchStage.SAVING,
-            entries.length + Math.min(offset + 128, keys.length), total);
-        }
-        reportTokenBatchProgress(onProgress, TokenBatchStage.COMMITTING);
-        await store.commit();
-      } catch (error) {
-        reportTokenBatchProgress(onProgress, TokenBatchStage.ROLLING_BACK);
-        await store.rollback();
-        throw new Error((error as BusinessError).message);
-      }
+      await commitTokenBatchInChunks(new KvStoreTransactionAdapter(store), entries, keys, onProgress);
     });
   }
 
@@ -76,6 +121,11 @@ export class KvManager {
       KvManager.instance = new KvManager();
     }
     return KvManager.instance;
+  }
+
+  /** TokenKvStore 端口的初始化入口（主进程：读取 AppStorage 上下文并建库）。 */
+  init(): Promise<void> {
+    return this.initKvManager();
   }
 
   /**
@@ -245,25 +295,13 @@ export class KvManager {
   }
 
   // 使用getEntries模拟一个可以兼容的数组 这样可以规避多设备覆盖的问题
+  // 旧版本键迁移委托 TokenKvBatch.migrateLegacyTokenEntries。
   async getTokenArray(prefix: string): Promise<TokenConfig[]> {
     let token_array: TokenConfig[] = [];
     if (this._kvStore) {
       try {
         // load from old version
-        const old_prefixKey = "$.SA_token_uuids_";
-        const old_entries = await this._kvStore.getEntries(old_prefixKey);
-        for (let i = 0; i < old_entries.length; i++) {
-          const old_key = old_entries[i].key;
-          // remove old prefix list
-          this.deleteValue(old_key);
-          // convert old to new token store format
-          const old_token_uuid = old_key.substring(old_prefixKey.length);
-          const old_token_key = "token_" + old_token_uuid;
-          const old_token_value = await this.getString(old_token_key);
-          const new_token_key = prefix + old_token_uuid;
-          await this.setString(new_token_key, old_token_value??'');
-          await this.deleteValue(old_token_key);
-        }
+        await migrateLegacyTokenEntries(new KvStoreLegacyAdapter(this._kvStore), prefix);
 
         const entries = await this._kvStore.getEntries(prefix);
         entries.forEach((item) => {

--- a/common/src/main/ets/utils/SteamSecretStore.ets
+++ b/common/src/main/ets/utils/SteamSecretStore.ets
@@ -1,3 +1,4 @@
+import { NamedSecretStore } from './StoragePorts';
 import { AssetSecretStore } from './AssetSecretStore';
 import { joinSecretChunks, splitSecretChunks, SteamAuth } from './SteamAuth';
 
@@ -25,7 +26,7 @@ const MAX_REFRESH_CHUNKS = 8;
 
 export class SteamSecretStore {
   private static instance: SteamSecretStore;
-  private assets: AssetSecretStore = AssetSecretStore.getInstance();
+  private assets: NamedSecretStore = AssetSecretStore.getInstance();
 
   private constructor() {}
 
@@ -34,6 +35,11 @@ export class SteamSecretStore {
       SteamSecretStore.instance = new SteamSecretStore();
     }
     return SteamSecretStore.instance;
+  }
+
+  /** 测试注入：LocalUnit 下 asset 不可用，替换为内存别名密钥后端。 */
+  useBackendForTest(assets: NamedSecretStore): void {
+    this.assets = assets;
   }
 
   private alias(tokenUUID: string, field: string): string {

--- a/common/src/main/ets/utils/StoragePorts.ets
+++ b/common/src/main/ets/utils/StoragePorts.ets
@@ -1,0 +1,213 @@
+import { fileIo as fs } from '@kit.CoreFileKit';
+import { buffer } from '@kit.ArkTS';
+import { TokenConfig } from './TokenConfig';
+import { TokenBatchProgressCallback } from './TokenBatchProgress';
+
+/**
+ * 分组目录 KV 后端接口（历史名，Phase 1 引入；Phase 2 并入本文件端口族）。
+ * TokenGroupStore 与 TokenKvStore 共享此标称祖先：
+ * TokenStore 加载时用同一后端驱动 TokenGroupStore，测试注入一个实现即可覆盖两者。
+ */
+export interface TokenGroupKvBackend {
+  getValue<T>(key: string): Promise<T | null>;
+  setValue<T>(key: string, value: T): Promise<void>;
+}
+
+/**
+ * Phase 2 存储与密钥解耦端口（docs/TEST_PLAN.md 第 4 节）。
+ *
+ * 四个核心端口家族：
+ * - {@link KeyValueStore} / {@link TokenKvStore}：键值与令牌主存储（生产 KvManager/PreferenceManager）
+ * - {@link SecretStore} / {@link NamedSecretStore}：TEE 密钥读写（生产 AssetSecretStore）
+ * - {@link CryptoEngine}：密码学引擎（生产 cryptoFramework，LocalUnit 不可用）
+ * - {@link FsGateway}：文件系统网关（生产 fileIo/cloudSync，LocalUnit 不可用）
+ *
+ * 业务层（TokenStore/CloudBackupManager/CryptoUtils 等）只依赖端口，
+ * 测试注入内存/确定性假实现，真机行为由生产适配器保证。
+ *
+ * 注：UTF-8 字节长度工具使用 SteamAuth.utf8ByteLength（避免 common/Index 的
+ * star-export 命名冲突），本文件不再重复导出。
+ */
+
+/**
+ * 通用键值存储端口。
+ * 生产实现：KvManager（加密 KV）、PreferenceManager（preferences）。
+ */
+export interface KeyValueStore {
+  getValue<T>(key: string): Promise<T | null>;
+  setValue<T>(key: string, value: T): Promise<void>;
+  deleteValue(key: string): Promise<void>;
+}
+
+/** 批量条目：值统一为 JSON 字符串（与加密 KV 的存储形态一致）。 */
+export interface KvBatchEntry {
+  key: string;
+  value: string;
+}
+
+/**
+ * 令牌主存储端口（分组目录后端 + 令牌数组/事务批量）。
+ * 生产实现为 KvManager；TokenStore 仅依赖本端口。
+ */
+export interface TokenKvStore extends TokenGroupKvBackend {
+  /** 初始化底层存储（生产 KvManager.initKvManager，测试为 no-op） */
+  init(): Promise<void>;
+  getTokenArray(prefix: string): Promise<TokenConfig[]>;
+  saveTokenBatch(prefix: string, tokens: TokenConfig[], deletedUuids?: string[],
+    onProgress?: TokenBatchProgressCallback): Promise<void>;
+}
+
+/** 分布式 KV 事务原语端口（供分块提交/回滚编排使用）。 */
+export interface TransactionalKv {
+  startTransaction(): Promise<void>;
+  putBatch(entries: KvBatchEntry[]): Promise<void>;
+  deleteBatch(keys: string[]): Promise<void>;
+  commit(): Promise<void>;
+  rollback(): Promise<void>;
+}
+
+/** 旧版本令牌键迁移所需的最小 KV 读写端口。 */
+export interface LegacyTokenKv {
+  getRawEntries(prefix: string): Promise<KvBatchEntry[]>;
+  getString(key: string): Promise<string | null>;
+  setString(key: string, value: string): Promise<void>;
+  deleteValue(key: string): Promise<void>;
+}
+
+/**
+ * 任意别名密钥存储端口（ASSET 语义）。
+ * Steam 分片凭证（SteamSecretStore）依赖本端口而非具体 AssetSecretStore。
+ */
+export interface NamedSecretStore {
+  upsertNamedSecret(alias: string, secret: string): Promise<boolean>;
+  queryNamedSecret(alias: string): Promise<string | null>;
+  removeNamedSecret(alias: string): Promise<void>;
+}
+
+/**
+ * 令牌密钥存储端口（生产实现为 AssetSecretStore / TEE 硬件保护）。
+ * TokenStore 的迁移三重验证、降级判断只依赖本端口。
+ */
+export interface SecretStore extends NamedSecretStore {
+  /** Secret 的 UTF-8 字节长度是否在存储限制内（≤900 字节） */
+  isSecretSizeValid(secret: string): boolean;
+  upsertSecret(tokenUUID: string, secret: string): Promise<boolean>;
+  querySecret(tokenUUID: string): Promise<string | null>;
+  removeSecret(tokenUUID: string): Promise<void>;
+  batchQuerySecrets(tokenUUIDs: string[]): Promise<Map<string, string>>;
+}
+
+/** GCM 加封结果：密文与认证标签分离返回。 */
+export class CryptoSealedBytes {
+  ciphertext: Uint8Array = new Uint8Array(0);
+  tag: Uint8Array = new Uint8Array(0);
+}
+
+/**
+ * 密码学引擎端口：屏蔽 cryptoFramework（LocalUnit 下静默失效）。
+ * CryptoUtils 的格式/协议逻辑（魔数、salt/iv 布局、legacy 兼容分支）只依赖本端口，
+ * 数值正确性（AES/PBKDF2/GCM 向量）由真机 ohosTest 与生产实现保证。
+ */
+export interface CryptoEngine {
+  randomBytes(length: number): Uint8Array;
+  utf8Encode(text: string): Uint8Array;
+  utf8Decode(data: Uint8Array): string;
+  /** PBKDF2-SHA256 派生对称密钥字节 */
+  pbkdf2Derive(password: string, salt: Uint8Array, iterations: number, keySize: number): Promise<Uint8Array>;
+  sha256(data: Uint8Array): Promise<Uint8Array>;
+  /** AES-CBC-PKCS7 加密；key 为原始密钥字节（AES-128） */
+  aesCbcEncrypt(plain: Uint8Array, key: Uint8Array, iv: Uint8Array): Promise<Uint8Array>;
+  /** AES-CBC-PKCS7 解密；填充非法时抛异常 */
+  aesCbcDecrypt(cipher: Uint8Array, key: Uint8Array, iv: Uint8Array): Promise<Uint8Array>;
+  /** AES-256-GCM 加密，返回密文与 16 字节认证标签 */
+  aesGcmSeal(plain: Uint8Array, key: Uint8Array, iv: Uint8Array, aad: Uint8Array): Promise<CryptoSealedBytes>;
+  /** AES-256-GCM 解密；认证失败抛异常 */
+  aesGcmOpen(cipher: Uint8Array, key: Uint8Array, iv: Uint8Array, aad: Uint8Array, tag: Uint8Array): Promise<Uint8Array>;
+}
+
+/** 文件状态（location: 0=本地 2=仅云端）。 */
+export class FsStatInfo {
+  size: number = 0;
+  location: number = 0;
+  isDirectory: boolean = false;
+}
+
+/**
+ * 文件系统网关端口：屏蔽 @kit.CoreFileKit 的 fileIo/cloudSync。
+ * 覆盖云备份编排所需的最小面（stat/list/read/write/mkdir/unlink/copy）。
+ */
+export interface FsGateway {
+  stat(path: string): Promise<FsStatInfo>;
+  listFiles(dir: string): Promise<string[]>;
+  readTextFile(path: string): Promise<string>;
+  writeTextFile(path: string, content: string): Promise<void>;
+  writeBinaryFile(path: string, data: Uint8Array): Promise<void>;
+  makeDir(path: string): Promise<void>;
+  /** 删除空目录（fs.rmdir 语义） */
+  removeDir(path: string): Promise<void>;
+  deleteFile(path: string): Promise<void>;
+  copyFile(src: string, dest: string): Promise<void>;
+}
+
+/** 文本文件读写端口（本地备份管线用；生产实现走 FileUtils）。 */
+export interface BackupTextIo {
+  readText(uri: string): Promise<string>;
+  writeText(uri: string, content: string): Promise<void>;
+}
+
+/** {@link FsGateway} 的生产实现：包装 @kit.CoreFileKit fileIo。 */
+export class FileIoFsGateway implements FsGateway {
+  async stat(path: string): Promise<FsStatInfo> {
+    const raw = await fs.stat(path);
+    const info = new FsStatInfo();
+    info.size = raw.size;
+    info.location = raw.location;
+    info.isDirectory = raw.isDirectory();
+    return info;
+  }
+
+  async listFiles(dir: string): Promise<string[]> {
+    return fs.listFileSync(dir);
+  }
+
+  async readTextFile(path: string): Promise<string> {
+    const info = await this.stat(path);
+    const file = fs.openSync(path, fs.OpenMode.READ_ONLY);
+    try {
+      const arrayBuffer = new ArrayBuffer(info.size);
+      const readLen = fs.readSync(file.fd, arrayBuffer);
+      return buffer.from(new Uint8Array(arrayBuffer.slice(0, readLen))).toString('utf-8');
+    } finally {
+      fs.closeSync(file);
+    }
+  }
+
+  async writeTextFile(path: string, content: string): Promise<void> {
+    await this.writeBinaryFile(path, new Uint8Array(buffer.from(content, 'utf-8').buffer));
+  }
+
+  async writeBinaryFile(path: string, data: Uint8Array): Promise<void> {
+    const file = fs.openSync(path, fs.OpenMode.WRITE_ONLY | fs.OpenMode.CREATE | fs.OpenMode.TRUNC);
+    try {
+      fs.writeSync(file.fd, data);
+    } finally {
+      fs.closeSync(file);
+    }
+  }
+
+  async makeDir(path: string): Promise<void> {
+    await fs.mkdir(path);
+  }
+
+  async removeDir(path: string): Promise<void> {
+    await fs.rmdir(path);
+  }
+
+  async deleteFile(path: string): Promise<void> {
+    await fs.unlink(path);
+  }
+
+  async copyFile(src: string, dest: string): Promise<void> {
+    await fs.copyFile(src, dest);
+  }
+}

--- a/common/src/main/ets/utils/TokenBackup.ets
+++ b/common/src/main/ets/utils/TokenBackup.ets
@@ -1,14 +1,23 @@
-import { readFileContent, writeFileContent,writeFileContentCheckHashEqual } from "./FileUtils";
+import { readFileContent, writeFileContentCheckHashEqual } from "./FileUtils";
 import { TokenConfig } from "./TokenConfig";
 import { TokenBatchProgressCallback, TokenBatchStage, reportTokenBatchProgress } from './TokenBatchProgress';
 import { TokenGroup, TokenGroupStore } from './TokenGroupStore';
+import { BackupTextIo } from './StoragePorts';
 import { base32Decode, base32Encode, intArrayToString, stringToIntArray } from "./TokenUtils";
 import { decryptFile, encryptFile } from "./CryptoUtils";
-import { JSON } from "@kit.ArkTS";
-import { promptAction } from "@kit.ArkUI";
-import { fileUri } from "@kit.CoreFileKit";
 
 const TOKEN_BACKUP_MAGIC = 0x55aaeebb;
+
+/** BackupTextIo 生产实现：走 FileUtils（fs + 哈希防重复写入）。 */
+class FileUtilsBackupTextIo implements BackupTextIo {
+  async readText(uri: string): Promise<string> {
+    return readFileContent(uri);
+  }
+
+  async writeText(uri: string, content: string): Promise<void> {
+    await writeFileContentCheckHashEqual(uri, content);
+  }
+}
 
 export class TokenBackup {
   magic: number;
@@ -24,17 +33,18 @@ export class TokenBackup {
   }
 }
 
-export async function saveBackupToFile(file_uri: string, backup: TokenBackup, do_encrypt: boolean = false, password: string = ''): Promise<void> {
+export async function saveBackupToFile(file_uri: string, backup: TokenBackup, do_encrypt: boolean = false,
+  password: string = '', io: BackupTextIo = new FileUtilsBackupTextIo()): Promise<void> {
   const backup_json = JSON.stringify(backup);
   const backup_raw = do_encrypt ? await encryptFile(backup_json, password) : stringToIntArray(backup_json);
   const b32_encoded = base32Encode(backup_raw);
-  await writeFileContentCheckHashEqual(file_uri, b32_encoded);
+  await io.writeText(file_uri, b32_encoded);
 }
 
 export async function restoreFromBackup(file_uri: string, is_encrypt: boolean = false, password: string = '',
-  onProgress?: TokenBatchProgressCallback): Promise<TokenBackup> {
+  onProgress?: TokenBatchProgressCallback, io: BackupTextIo = new FileUtilsBackupTextIo()): Promise<TokenBackup> {
   reportTokenBatchProgress(onProgress, TokenBatchStage.READING);
-  const file_content = await readFileContent(file_uri);
+  const file_content = await io.readText(file_uri);
   reportTokenBatchProgress(onProgress, TokenBatchStage.DECODING);
   const b32_decoded = base32Decode(file_content);
   if (is_encrypt) {

--- a/common/src/main/ets/utils/TokenCardStore.ets
+++ b/common/src/main/ets/utils/TokenCardStore.ets
@@ -3,6 +3,7 @@ import { TokenConfig, otpType } from "./TokenConfig";
 import { TokenStore } from "./TokenStore";
 import { generateOTP } from "./TokenUtils";
 import { AppPreference, PREF_KEYS } from "./AppPreference";
+import { KeyValueStore } from "./StoragePorts";
 import { systemDateTime } from "@kit.BasicServicesKit";
 
 export interface CardConfig {
@@ -40,7 +41,8 @@ export function emptyCardData(formId: string, formName: string): Record<string, 
 
 export class TokenCardStore {
   private static instance: TokenCardStore;
-  private prefMgr: PreferenceManager = PreferenceManager.getInstance();
+  // 卡片配置的 KV 端口：生产 PreferenceManager（preferences），测试注入内存实现。
+  private prefStore: KeyValueStore = PreferenceManager.getInstance();
 
   private constructor() {}
 
@@ -51,17 +53,22 @@ export class TokenCardStore {
     return TokenCardStore.instance;
   }
 
+  /** 测试注入：LocalUnit 下 preferences 不可用，替换为内存 KV。 */
+  useStoreForTest(store: KeyValueStore): void {
+    this.prefStore = store;
+  }
+
   async saveCardConfig(config: CardConfig): Promise<void> {
-    await this.prefMgr.setValue<string>(`${CARD_CONFIG_PREFIX}${config.formId}`, JSON.stringify(config));
-    const configs = await this.prefMgr.getValue<string[]>(CARD_CONFIGS_KEY) ?? [];
+    await this.prefStore.setValue<string>(`${CARD_CONFIG_PREFIX}${config.formId}`, JSON.stringify(config));
+    const configs = await this.prefStore.getValue<string[]>(CARD_CONFIGS_KEY) ?? [];
     if (!configs.includes(config.formId)) {
       configs.push(config.formId);
-      await this.prefMgr.setValue<string[]>(CARD_CONFIGS_KEY, configs);
+      await this.prefStore.setValue<string[]>(CARD_CONFIGS_KEY, configs);
     }
   }
 
   async getCardConfig(formId: string): Promise<CardConfig | null> {
-    const raw = await this.prefMgr.getValue<string>(`${CARD_CONFIG_PREFIX}${formId}`);
+    const raw = await this.prefStore.getValue<string>(`${CARD_CONFIG_PREFIX}${formId}`);
     if (raw) {
       return JSON.parse(raw) as CardConfig;
     }
@@ -69,17 +76,17 @@ export class TokenCardStore {
   }
 
   async removeCardConfig(formId: string): Promise<void> {
-    await this.prefMgr.deleteValue(`${CARD_CONFIG_PREFIX}${formId}`);
-    const configs = await this.prefMgr.getValue<string[]>(CARD_CONFIGS_KEY) ?? [];
+    await this.prefStore.deleteValue(`${CARD_CONFIG_PREFIX}${formId}`);
+    const configs = await this.prefStore.getValue<string[]>(CARD_CONFIGS_KEY) ?? [];
     const idx = configs.indexOf(formId);
     if (idx >= 0) {
       configs.splice(idx, 1);
-      await this.prefMgr.setValue<string[]>(CARD_CONFIGS_KEY, configs);
+      await this.prefStore.setValue<string[]>(CARD_CONFIGS_KEY, configs);
     }
   }
 
   async getCardConfigList(): Promise<string[]> {
-    const configs = await this.prefMgr.getValue<string[]>(CARD_CONFIGS_KEY);
+    const configs = await this.prefStore.getValue<string[]>(CARD_CONFIGS_KEY);
     return configs ?? [];
   }
 

--- a/common/src/main/ets/utils/TokenGroupStore.ets
+++ b/common/src/main/ets/utils/TokenGroupStore.ets
@@ -1,15 +1,13 @@
 import { AppStorageV2 } from '@kit.ArkUI';
 import { util } from '@kit.ArkTS';
 import { KvManager } from './KvManager';
+import { TokenGroupKvBackend } from './StoragePorts';
 
 export const ALL_TOKEN_GROUPS: string = '__all__';
 export const FAVORITE_TOKEN_GROUP: string = '__favorites__';
 
-/** 分组目录的 KV 后端接口：生产环境由 KvManager 实现，测试注入内存实现（Phase 2 将沉淀为 KeyValueStore）。 */
-export interface TokenGroupKvBackend {
-  getValue<T>(key: string): Promise<T | null>;
-  setValue<T>(key: string, value: T): Promise<void>;
-}
+// TokenGroupKvBackend 已并入 StoragePorts 端口族（Phase 2）；
+// 通过 common/Index 的 `export * from StoragePorts` 继续按原名导出。
 
 export class TokenGroup {
   id: string = '';

--- a/common/src/main/ets/utils/TokenGroupStore.ets
+++ b/common/src/main/ets/utils/TokenGroupStore.ets
@@ -5,6 +5,12 @@ import { KvManager } from './KvManager';
 export const ALL_TOKEN_GROUPS: string = '__all__';
 export const FAVORITE_TOKEN_GROUP: string = '__favorites__';
 
+/** 分组目录的 KV 后端接口：生产环境由 KvManager 实现，测试注入内存实现（Phase 2 将沉淀为 KeyValueStore）。 */
+export interface TokenGroupKvBackend {
+  getValue<T>(key: string): Promise<T | null>;
+  setValue<T>(key: string, value: T): Promise<void>;
+}
+
 export class TokenGroup {
   id: string = '';
   name: string = '';
@@ -29,14 +35,20 @@ export class TokenGroupState {
 export class TokenGroupStore {
   private static instance: TokenGroupStore = new TokenGroupStore();
   private readonly key: string = '_token_groups_v1';
+  private kvBackend: TokenGroupKvBackend = KvManager.getInstance();
   readonly state: TokenGroupState = AppStorageV2.connect(TokenGroupState, () => new TokenGroupState())!;
 
   static getInstance(): TokenGroupStore {
     return TokenGroupStore.instance;
   }
 
+  /** 测试注入：LocalUnit 下 distributedKVStore 不可用，替换为内存后端。 */
+  useKvBackendForTest(kv: TokenGroupKvBackend): void {
+    this.kvBackend = kv;
+  }
+
   async load(): Promise<void> {
-    const groups = await KvManager.getInstance().getValue<TokenGroup[]>(this.key) ?? [];
+    const groups = await this.kvBackend.getValue<TokenGroup[]>(this.key) ?? [];
     this.state.groups = groups.map(group => new TokenGroup(group.id, group.name, group.color));
     this.reconcileSelection();
   }
@@ -50,7 +62,7 @@ export class TokenGroupStore {
   }
 
   private async save(groups: TokenGroup[]): Promise<void> {
-    await KvManager.getInstance().setValue(this.key, groups);
+    await this.kvBackend.setValue(this.key, groups);
     this.state.groups = groups;
     this.reconcileSelection();
   }

--- a/common/src/main/ets/utils/TokenKvBatch.ets
+++ b/common/src/main/ets/utils/TokenKvBatch.ets
@@ -1,0 +1,59 @@
+import { KvBatchEntry, LegacyTokenKv, TransactionalKv } from './StoragePorts';
+import { TokenBatchProgressCallback, TokenBatchStage, reportTokenBatchProgress } from './TokenBatchProgress';
+
+/** 平台单次批量写入上限（distributedKVStore.putBatch/deleteBatch 限制）。 */
+const MAX_BATCH_SIZE = 128;
+
+/** 旧版本令牌存储的键前缀（Phase 2 之前的历史格式）。 */
+const LEGACY_PREFIX = '$.SA_token_uuids_';
+
+/**
+ * 事务内分块提交令牌批量写入：按 MAX_BATCH_SIZE 分块 put/delete，
+ * 全部成功后 commit；任一步失败 rollback 并向上抛错（调用方据此回滚内存状态）。
+ * 从 KvManager.saveTokenBatch 抽出，事务原语经 {@link TransactionalKv} 端口注入。
+ */
+export async function commitTokenBatchInChunks(store: TransactionalKv, entries: KvBatchEntry[],
+  deleteKeys: string[], onProgress?: TokenBatchProgressCallback): Promise<void> {
+  if (entries.length === 0 && deleteKeys.length === 0) {
+    return;
+  }
+  const total = entries.length + deleteKeys.length;
+  reportTokenBatchProgress(onProgress, TokenBatchStage.SAVING, 0, total);
+  await store.startTransaction();
+  try {
+    for (let offset = 0; offset < entries.length; offset += MAX_BATCH_SIZE) {
+      await store.putBatch(entries.slice(offset, offset + MAX_BATCH_SIZE));
+      reportTokenBatchProgress(onProgress, TokenBatchStage.SAVING,
+        Math.min(offset + MAX_BATCH_SIZE, entries.length), total);
+    }
+    for (let offset = 0; offset < deleteKeys.length; offset += MAX_BATCH_SIZE) {
+      await store.deleteBatch(deleteKeys.slice(offset, offset + MAX_BATCH_SIZE));
+      reportTokenBatchProgress(onProgress, TokenBatchStage.SAVING,
+        entries.length + Math.min(offset + MAX_BATCH_SIZE, deleteKeys.length), total);
+    }
+    reportTokenBatchProgress(onProgress, TokenBatchStage.COMMITTING);
+    await store.commit();
+  } catch (error) {
+    reportTokenBatchProgress(onProgress, TokenBatchStage.ROLLING_BACK);
+    await store.rollback();
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+/**
+ * 旧版本令牌存储迁移：`$.SA_token_uuids_{uuid}` 列表键 + `token_{uuid}` 值键
+ * → `{newPrefix}{uuid}`。逐条搬运并删除旧键；失败由调用方容忍（下次加载重试）。
+ * 从 KvManager.getTokenArray 抽出，KV 读写经 {@link LegacyTokenKv} 端口注入。
+ */
+export async function migrateLegacyTokenEntries(kv: LegacyTokenKv, newPrefix: string): Promise<void> {
+  const oldEntries = await kv.getRawEntries(LEGACY_PREFIX);
+  for (let i = 0; i < oldEntries.length; i++) {
+    const oldKey = oldEntries[i].key;
+    await kv.deleteValue(oldKey);
+    const oldTokenUuid = oldKey.substring(LEGACY_PREFIX.length);
+    const oldTokenKey = 'token_' + oldTokenUuid;
+    const oldTokenValue = await kv.getString(oldTokenKey);
+    await kv.setString(newPrefix + oldTokenUuid, oldTokenValue ?? '');
+    await kv.deleteValue(oldTokenKey);
+  }
+}

--- a/common/src/main/ets/utils/TokenStore.ets
+++ b/common/src/main/ets/utils/TokenStore.ets
@@ -2,9 +2,9 @@ import { KvManager } from "./KvManager";
 import { TokenConfig, otpType, copyTokenConfig, sanitizedTokenForTransfer } from "./TokenConfig";
 import { TokenGroupStore } from './TokenGroupStore';
 import { TokenBatchProgressCallback, TokenBatchStage, reportTokenBatchProgress } from './TokenBatchProgress';
-import { RdbManager } from "./RdbManager";
 import { common } from '@kit.AbilityKit';
 import { EVENT_NAMES, PREF_KEYS, AppPreference } from "./AppPreference";
+import { SecretStore, TokenKvStore } from './StoragePorts';
 import { AssetSecretStore } from './AssetSecretStore';
 import { SteamSecretStore } from './SteamSecretStore';
 import { SteamAuth } from './SteamAuth';
@@ -40,9 +40,11 @@ const DOMAIN = 0xFF00;
  * 此变更需确保 BackupRestoreHelper / CloudBackupManager 等备份恢复路径兼容。
  */
 export class TokenStore {
+  // 设备专属能力（换机分布式同步/整库文件备份）不参与端口注入，保持具体引用。
   private kvMgr: KvManager = KvManager.getInstance();
-  private rdbMgr: RdbManager = RdbManager.getInstance();
-  private assetStore: AssetSecretStore = AssetSecretStore.getInstance();
+  // 令牌主存储与密钥读写走端口（Phase 2 解耦，见 docs/TEST_PLAN.md 第 4 节）。
+  private kvBackend: TokenKvStore = KvManager.getInstance();
+  private assetStore: SecretStore = AssetSecretStore.getInstance();
   private steamSecretStore: SteamSecretStore = SteamSecretStore.getInstance();
   private token_array: TokenConfig[] = [];
   private appCtx: common.UIAbilityContext | undefined = undefined;
@@ -51,6 +53,22 @@ export class TokenStore {
 
   private token_prefix: string = "_token_uuid_";
   private mutationQueue: Promise<void> = Promise.resolve();
+
+  /**
+   * 测试注入：LocalUnit 下 distributedKVStore/asset 不可用，
+   * 替换 KV/密钥端口并清空内存状态，隔离用例间污染。
+   */
+  public useBackendsForTest(kv: TokenKvStore, secrets: SecretStore, steam?: SteamSecretStore): void {
+    this.kvBackend = kv;
+    this.assetStore = secrets;
+    if (steam !== undefined) {
+      this.steamSecretStore = steam;
+    }
+    this.token_array = [];
+    this.init_done = false;
+    this.mutationQueue = Promise.resolve();
+    this.appCtx = undefined;
+  }
 
   // 排序、单条编辑、批量操作和重新加载共享队列，避免 await 期间互相覆盖内存快照。
   private enqueueMutation(operation: () => Promise<void>): Promise<void> {
@@ -87,7 +105,7 @@ export class TokenStore {
     if (this.init_done) {
       return;
     }
-    await this.kvMgr.initKvManager();
+    await this.kvBackend.init();
     await this.LoadTokenByDataBase();
     this.init_done = true;
   }
@@ -95,7 +113,7 @@ export class TokenStore {
   public async LoadTokenByDataBase(): Promise<void> {
     return this.enqueueMutation(async () => {
       await TokenGroupStore.getInstance().load();
-      this.token_array = await this.kvMgr.getTokenArray(this.token_prefix);
+      this.token_array = await this.kvBackend.getTokenArray(this.token_prefix);
       // KV 里的对象是 JSON 裸数据：TokenConfig/SteamAuth 都没有原型方法，
       // 统一用 copyTokenConfig 重建实例，否则后续调用实例方法会崩溃
       this.token_array = this.token_array.map((token: TokenConfig): TokenConfig => copyTokenConfig(token));
@@ -227,7 +245,7 @@ export class TokenStore {
    * 否则尝试从 ASSET 回填。ASSET 不可用时 KV 中的 Secret 作为安全后裔。
    */
   public async queryToken(token_uuid: string): Promise<TokenConfig> {
-    let token = await this.kvMgr.getValue<TokenConfig>(`${this.token_prefix}${token_uuid}`);
+    let token = await this.kvBackend.getValue<TokenConfig>(`${this.token_prefix}${token_uuid}`);
     if (token && token.TokenSecret.length === 0) {
       const secret = await this.assetStore.querySecret(token_uuid);
       if (secret !== null) {
@@ -267,7 +285,7 @@ export class TokenStore {
    * 用于 RankScore 等非 Secret 字段变更场景，避免不必要的 TEE 硬件调用。
    */
   private async saveTokenKvOnly(token: TokenConfig): Promise<void> {
-    await this.kvMgr.setValue<TokenConfig>(`${this.token_prefix}${token.TokenUUID}`, token);
+    await this.kvBackend.setValue<TokenConfig>(`${this.token_prefix}${token.TokenUUID}`, token);
   }
 
   public async moveTokenToGroup(uuid: string, groupId: string): Promise<void> {
@@ -311,7 +329,7 @@ export class TokenStore {
         return updated;
       });
       if (changed.length > 0) {
-        await this.kvMgr.saveTokenBatch(this.token_prefix, changed, [], onProgress);
+        await this.kvBackend.saveTokenBatch(this.token_prefix, changed, [], onProgress);
         this.token_array = next;
         this.emitTokenChanged();
       }
@@ -343,7 +361,7 @@ export class TokenStore {
         next[i] = updated;
         changed.push(updated);
       }
-      await this.kvMgr.saveTokenBatch(this.token_prefix, changed);
+      await this.kvBackend.saveTokenBatch(this.token_prefix, changed);
       this.token_array = next;
       this.emitTokenChanged();
     });
@@ -403,7 +421,7 @@ export class TokenStore {
     // KV 副本必须剥离 Steam 凭证与 mafile 密钥：TokenConfig 会被手表同步原样序列化，
     // 高权限字段（identity_secret / refresh_token / revocation_code）只允许留在 ASSET。
     const kvWrites = writes.map((token: TokenConfig): TokenConfig => sanitizedTokenForTransfer(token));
-    await this.kvMgr.saveTokenBatch(this.token_prefix, kvWrites, [], onProgress);
+    await this.kvBackend.saveTokenBatch(this.token_prefix, kvWrites, [], onProgress);
     this.token_array = next;
     const secretWrites = writes.filter(token => originalSecrets.get(token.TokenUUID) !== token.TokenSecret);
     if (secretWrites.length > 0) {
@@ -465,7 +483,7 @@ export class TokenStore {
           changed.push(updated);
         }
       }
-      await this.kvMgr.saveTokenBatch(this.token_prefix, changed, removed.map(token => token.TokenUUID), onProgress);
+      await this.kvBackend.saveTokenBatch(this.token_prefix, changed, removed.map(token => token.TokenUUID), onProgress);
       this.token_array = next;
       reportTokenBatchProgress(onProgress, TokenBatchStage.REMOVING_SECRETS, 0, removed.length);
       for (let i = 0; i < removed.length; i++) {

--- a/common/src/main/ets/utils/TransferProtocol.ets
+++ b/common/src/main/ets/utils/TransferProtocol.ets
@@ -1,0 +1,353 @@
+import { TokenConfig } from './TokenConfig';
+
+/**
+ * 手机↔手表 传输协议纯类层（Phase 3，docs/TEST_PLAN.md 第 4 节）。
+ *
+ * BLE（GATT 写特征）与 WearEngine（P2P 消息）共用同一分片协议：
+ * - 首帧: JSON 头 {"total": 数据总字节数, "count": 消息数, "type": "tokens"|"settings"}
+ *   （WearEngine 首帧额外带 "OTPW" 前缀以区分头帧与数据帧）
+ * - 后续帧: ≤ maxChunk 的加密载荷分片（AES-256-GCM，[MAGIC][iv][tag][ciphertext]）
+ * - 接收方按 total 重组，解密后按 type 分发
+ *
+ * 本文件把分帧构建、头解析、接收状态机与令牌批次 UUID 复用抽成纯类：
+ * - 不依赖任何 @ohos 系统 API（UTF-8 编解码为纯 TS 实现），LocalUnit 可全分支测试；
+ * - 生产帧序/重组语义与抽离前逐分支等价（见各类注释），真机行为由 ohosTest 冒烟兜底。
+ */
+
+/** 传输头部帧结构（BLE 与 WearEngine 共用） */
+export interface TransferHeader {
+  total: number;
+  count: number;
+  /** 消息类型: 缺省为 tokens(向后兼容旧版发送端) */
+  type?: string;
+}
+
+/** 纯 TS UTF-8 编码（合法标量与 util.TextEncoder.encodeInto 字节级一致，含代理对；孤立代理编为 U+FFFD，对齐 WHATWG TextEncoder）。 */
+export function utf8Encode(text: string): Uint8Array {
+  const out: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    let code = text.charCodeAt(i);
+    if (code >= 0xD800 && code <= 0xDBFF && i + 1 < text.length) {
+      const lo = text.charCodeAt(i + 1);
+      if (lo >= 0xDC00 && lo <= 0xDFFF) {
+        code = 0x10000 + ((code - 0xD800) << 10) + (lo - 0xDC00);
+        i++;
+      } else {
+        code = 0xFFFD;
+      }
+    } else if (code >= 0xD800 && code <= 0xDFFF) {
+      // 孤立代理（含尾部悬挂的高代理与任意低代理）
+      code = 0xFFFD;
+    }
+    if (code < 0x80) {
+      out.push(code);
+    } else if (code < 0x800) {
+      out.push(0xC0 | (code >> 6), 0x80 | (code & 63));
+    } else if (code < 0x10000) {
+      out.push(0xE0 | (code >> 12), 0x80 | ((code >> 6) & 63), 0x80 | (code & 63));
+    } else {
+      out.push(0xF0 | (code >> 18), 0x80 | ((code >> 12) & 63), 0x80 | ((code >> 6) & 63), 0x80 | (code & 63));
+    }
+  }
+  return new Uint8Array(out);
+}
+
+/** UTF-8 续字节（0x80-0xBF）。 */
+function isContinuation(b: number): boolean {
+  return b >= 0x80 && b < 0xC0;
+}
+
+/**
+ * 纯 TS UTF-8 解码（lenient）：非法/截断/过度编码/代理区编码序列以 U+FFFD 替换并跳过
+ * （与 TextDecoder 的 replacement 容错对齐，序列合法性含续字节取值范围与首字节边界）。
+ * 协议用途：合法载荷精确还原，加密分片误当头帧时必然产出 JSON.parse 无法接受的内容。
+ */
+export function utf8Decode(data: Uint8Array): string {
+  let out = '';
+  let i = 0;
+  while (i < data.length) {
+    const b = data[i];
+    let code = -1;
+    let width = 1;
+    if (b < 0x80) {
+      code = b;
+    } else if (b >= 0xC2 && b < 0xE0 && i + 1 < data.length && isContinuation(data[i + 1])) {
+      code = ((b & 0x1F) << 6) | (data[i + 1] & 63);
+      width = 2;
+    } else if (b >= 0xE0 && b < 0xF0 && i + 2 < data.length
+      && isContinuation(data[i + 1]) && isContinuation(data[i + 2])) {
+      // 过度编码（E0 后 A0-BF 才合法）与代理区（ED 后 80-9F 才合法）
+      const ok = (b === 0xE0 && data[i + 1] >= 0xA0) || (b === 0xED && data[i + 1] < 0xA0)
+        || (b > 0xE0 && b < 0xED) || (b > 0xED && b < 0xF0);
+      if (ok) {
+        code = ((b & 0x0F) << 12) | ((data[i + 1] & 63) << 6) | (data[i + 2] & 63);
+        width = 3;
+      }
+    } else if (b >= 0xF0 && b < 0xF5 && i + 3 < data.length
+      && isContinuation(data[i + 1]) && isContinuation(data[i + 2]) && isContinuation(data[i + 3])) {
+      // F0 后 90-BF 才合法（防过度编码），F4 后 80-8F 才合法（防超出 U+10FFFF）
+      const ok = (b === 0xF0 && data[i + 1] >= 0x90) || (b === 0xF4 && data[i + 1] < 0x90)
+        || (b > 0xF0 && b < 0xF4);
+      if (ok) {
+        code = ((b & 0x07) << 18) | ((data[i + 1] & 63) << 12) | ((data[i + 2] & 63) << 6) | (data[i + 3] & 63);
+        width = 4;
+      }
+    }
+    if (code < 0) {
+      out += String.fromCharCode(0xFFFD);
+      i += 1;
+      continue;
+    }
+    i += width;
+    if (code >= 0x10000) {
+      code -= 0x10000;
+      out += String.fromCharCode(0xD800 + (code >> 10), 0xDC00 + (code & 1023));
+    } else {
+      out += String.fromCharCode(code);
+    }
+  }
+  return out;
+}
+
+/** 发送侧一帧：bytes 为线上字节，isFinal 标记收尾数据帧（BLE 收尾帧用放宽超时）。 */
+export class TransferFrame {
+  bytes: Uint8Array = new Uint8Array(0);
+  isFinal: boolean = false;
+}
+
+/**
+ * 发送侧分帧构建器：头帧（前缀 + JSON）+ ≤maxChunk 数据分片。
+ * 构建顺序与分片边界和抽离前的 BLE/WearEngine 实现逐字节一致。
+ */
+export class TransferFrameBuilder {
+  private readonly prefix: string;
+  private readonly maxChunk: number;
+
+  constructor(prefix: string, maxChunk: number) {
+    this.prefix = prefix;
+    this.maxChunk = maxChunk;
+  }
+
+  /** 头帧字节（独立导出供头帧与数据帧分开发送的通道使用） */
+  buildHeaderBytes(total: number, count: number, type: string): Uint8Array {
+    return utf8Encode(`${this.prefix}${JSON.stringify({ total: total, count: count, type: type })}`);
+  }
+
+  /** 完整帧序列：头帧 + 数据分片；payload 为空时仅有头帧（与原实现 while 循环边界一致） */
+  buildFrames(payload: Uint8Array, count: number, type: string): TransferFrame[] {
+    const total: number = payload.byteLength;
+    const frames: TransferFrame[] = [];
+    const header = new TransferFrame();
+    header.bytes = this.buildHeaderBytes(total, count, type);
+    frames.push(header);
+
+    let offset = 0;
+    while (offset < total) {
+      const end = Math.min(offset + this.maxChunk, total);
+      const chunk = new Uint8Array(end - offset);
+      chunk.set(payload.subarray(offset, end));
+      const frame = new TransferFrame();
+      frame.bytes = chunk;
+      frame.isFinal = offset + chunk.byteLength >= total;
+      frames.push(frame);
+      offset = end;
+    }
+    return frames;
+  }
+}
+
+/** 一次完整批次的快照（收齐 total 字节时生成，接收状态机随即复位）。 */
+export class TransferBatch {
+  total: number = 0;
+  count: number = 0;
+  type: string = '';
+  chunks: Array<Uint8Array> = [];
+  /** 实际收到的分片总字节（发送方 total 声明不符时的失败判定依据） */
+  receivedBytes: number = 0;
+}
+
+/** 帧事件类别 */
+export enum TransferFrameEventKind {
+  /** 有效头帧：新批次开始（含批次中途新头帧丢弃残留批次的场景） */
+  BATCH_STARTED = 0,
+  /** 数据帧已并入进行中批次，尚未收齐 */
+  CHUNK_ACCEPTED = 1,
+  /** 分片收齐，batch 携带快照，接收状态已自动复位 */
+  BATCH_COMPLETE = 2,
+  /** 头帧非法（解析失败/total ≤ 0/超上限）：批次状态保持不变 */
+  HEADER_INVALID = 3,
+  /** 数据帧到达但无进行中批次（旧实现静默忽略） */
+  ORPHAN_CHUNK = 4,
+  /** 缺省占位：新增事件种类未显式赋值时可被通道层识别为异常 */
+  UNKNOWN = 5,
+}
+
+/** 帧事件：kind + BATCH_STARTED 时的头帧明细（供日志）+ BATCH_COMPLETE 时的批次快照 */
+export class TransferFrameEvent {
+  kind: TransferFrameEventKind = TransferFrameEventKind.UNKNOWN;
+  header: TransferHeader | null = null;
+  batch: TransferBatch | null = null;
+}
+
+/** 接收侧配置（BLE 与 WearEngine 差异点） */
+export class TransferFrameOptions {
+  /** 头帧前缀；空串 = 无前缀模式（BLE：每帧都是头帧候选，数据帧解析必然失败） */
+  headerPrefix: string = '';
+  /** 头帧 total 上限（字节）；0 = 不设上限（WearEngine） */
+  maxTotal: number = 0;
+}
+
+/**
+ * 接收侧分片重组状态机。
+ *
+ * 与抽离前行为的等价性说明：
+ * - 任何有效头帧（含批次中途）都会丢弃残留分片并重启批次：BLE 的"手机端超时中断后
+ *   立即重试"与 WearEngine 的头前缀判定均依赖此语义；
+ * - HEADER_INVALID 保持当前批次不变。注意这是对 WearEngine 旧实现的有意收口：
+ *   旧代码对 total ≤ 0 的头帧静默忽略（批次保留），但对 JSON 解析抛错的头帧会落入
+ *   外层 catch 并重置批次（传输挂死）；此处统一为保留批次，解析抛错不再有副作用；
+ *   BLE 旧实现的解析失败路径（reset + FAILED + 失败应答）由 ORPHAN_CHUNK 映射保持不变；
+ * - 收齐判定为 received >= total（与原实现一致，交叠写入的精确性校验由
+ *   {@link concatenateChunks} 与通道层的 receivedBytes !== total 分支承担）；
+ * - BATCH_COMPLETE 后状态立即复位，收尾帧处理（解密/入库）期间新批次可立即开始。
+ */
+export class TransferFrameReceiver {
+  private readonly options: TransferFrameOptions;
+  private readonly prefixBytes: Uint8Array;
+  private batch: TransferBatch | null = null;
+
+  constructor(options: TransferFrameOptions) {
+    this.options = options;
+    this.prefixBytes = utf8Encode(options.headerPrefix);
+  }
+
+  /** 是否有进行中的批次 */
+  isInProgress(): boolean {
+    return this.batch !== null;
+  }
+
+  /** 丢弃进行中的批次（断连/失败路径复位） */
+  reset(): void {
+    this.batch = null;
+  }
+
+  /** 送入一帧，返回事件供通道层映射各自的状态上报与写应答 */
+  onFrame(bytes: Uint8Array): TransferFrameEvent {
+    const event = new TransferFrameEvent();
+    if (this.prefixBytes.length > 0) {
+      if (!this.startsWith(bytes, this.prefixBytes)) {
+        return this.acceptChunk(bytes, event);
+      }
+      const header = this.parseHeader(bytes.subarray(this.prefixBytes.length));
+      if (header === null) {
+        event.kind = TransferFrameEventKind.HEADER_INVALID;
+        return event;
+      }
+      this.startBatch(header);
+      event.kind = TransferFrameEventKind.BATCH_STARTED;
+      event.header = header;
+      return event;
+    }
+
+    // 无前缀模式：每帧都是头帧候选；解析成功即头帧（数据帧为加密随机字节，不可能解析出合法头）
+    const header = this.parseHeader(bytes);
+    if (header !== null) {
+      this.startBatch(header);
+      event.kind = TransferFrameEventKind.BATCH_STARTED;
+      event.header = header;
+      return event;
+    }
+    return this.acceptChunk(bytes, event);
+  }
+
+  /** 数据帧并入：无批次则孤儿帧；收齐则产出快照并复位 */
+  private acceptChunk(bytes: Uint8Array, event: TransferFrameEvent): TransferFrameEvent {
+    if (this.batch === null) {
+      event.kind = TransferFrameEventKind.ORPHAN_CHUNK;
+      return event;
+    }
+    this.batch.chunks.push(bytes);
+    this.batch.receivedBytes += bytes.byteLength;
+    if (this.batch.receivedBytes >= this.batch.total) {
+      event.kind = TransferFrameEventKind.BATCH_COMPLETE;
+      event.batch = this.batch;
+      this.batch = null;
+      return event;
+    }
+    event.kind = TransferFrameEventKind.CHUNK_ACCEPTED;
+    return event;
+  }
+
+  private startBatch(header: TransferHeader): void {
+    const batch = new TransferBatch();
+    batch.total = header.total;
+    batch.count = header.count;
+    batch.type = header.type !== undefined ? header.type : 'tokens';
+    this.batch = batch;
+  }
+
+  /** 头帧解析与校验：非 JSON/total 非有限正数/超上限返回 null */
+  private parseHeader(bytes: Uint8Array): TransferHeader | null {
+    let header: TransferHeader | null = null;
+    try {
+      header = JSON.parse(utf8Decode(bytes)) as TransferHeader;
+    } catch (err) {
+      return null;
+    }
+    if (header !== null && typeof header.total === 'number' && header.total > 0
+      && (this.options.maxTotal <= 0 || header.total <= this.options.maxTotal)) {
+      return header;
+    }
+    return null;
+  }
+
+  private startsWith(data: Uint8Array, prefix: Uint8Array): boolean {
+    if (data.length < prefix.length) {
+      return false;
+    }
+    for (let i = 0; i < prefix.length; i++) {
+      if (data[i] !== prefix[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+/**
+ * 按头帧 total 重组分片：与抽离前实现一致，缓冲区按 total 分配，
+ * 分片超出 total 时 set 越界抛异常（交叠写入的保护路径，由通道层捕获判失败）。
+ */
+export function concatenateChunks(total: number, chunks: Array<Uint8Array>): Uint8Array {
+  const full = new Uint8Array(total);
+  let offset = 0;
+  for (let i = 0; i < chunks.length; i++) {
+    full.set(chunks[i], offset);
+    offset += chunks[i].byteLength;
+  }
+  return full;
+}
+
+/**
+ * 令牌批次入库的 UUID 复用决策（P2P/BLE 两通道共享，纯函数）：
+ * 按 issuer+name 匹配本地已有令牌并复用其 UUID。
+ *
+ * 手机端与手表端令牌 UUID 不同(各端独立生成)，直接 updateToken 会按 UUID 判为
+ * 新增导致重复令牌；复用本地 UUID 同时维持排序/删除等引用的稳定性。
+ *
+ * @returns 复用本地 UUID 的令牌数（原位修改 incoming）
+ */
+export function reuseLocalTokenUuids(incoming: TokenConfig[], existing: TokenConfig[]): number {
+  let reused = 0;
+  for (let i = 0; i < incoming.length; i++) {
+    for (let j = 0; j < existing.length; j++) {
+      if (existing[j].TokenIssuer === incoming[i].TokenIssuer &&
+        existing[j].TokenName === incoming[i].TokenName) {
+        incoming[i].TokenUUID = existing[j].TokenUUID;
+        reused++;
+        break;
+      }
+    }
+  }
+  return reused;
+}

--- a/common/src/main/ets/utils/WearEngineTransfer.ets
+++ b/common/src/main/ets/utils/WearEngineTransfer.ets
@@ -8,6 +8,17 @@ import { TokenStore } from './TokenStore';
 import { AppPreference, PREF_KEYS, SettingValue } from './AppPreference';
 import { PermissionManager } from './PermissionManager';
 import { decryptBlePayload, encryptBlePayload } from './CryptoUtils';
+import {
+  TransferBatch,
+  TransferFrameBuilder,
+  TransferFrameEvent,
+  TransferFrameEventKind,
+  TransferFrameOptions,
+  TransferFrameReceiver,
+  concatenateChunks,
+  reuseLocalTokenUuids,
+  utf8Decode,
+} from './TransferProtocol';
 
 const TAG = 'WearEngineTransfer';
 const DOMAIN = 0xFF03;
@@ -23,18 +34,18 @@ const DOMAIN = 0xFF03;
  * - 传输信任链由华为账号/Wear Engine 背书
  * - 应用层 AES-256-GCM(encryptBlePayload/decryptBlePayload)纵深防御
  *
- * 消息协议(分片, 复用 BLE 分片思想):
+ * 消息协议(分片, 复用 BLE 分片思想, 协议纯类见 TransferProtocol):
  * - P2P 单条消息上限 4096 字节, 本实现每帧 ≤ P2P_FRAME_MAX(4000B) 留余量
- * - 首帧: JSON 头 {"total": 数据总字节数, "count": 消息数, "type": "tokens"|"settings"}
+ * - 首帧: JSON 头 {"total": 数据总字节数, "count": 消息数, "type": "tokens"|"settings"},
+ *   以 FRAME_HEADER_PREFIX 前缀与加密数据帧区分
  * - 后续帧: ≤ P2P_FRAME_MAX 的加密载荷分片
  * - 接收方按 total 重组, 解密后按 type 分发
  */
 
 /** P2P 单帧最大载荷(4096 上限留余量) */
 const P2P_FRAME_MAX = 4000;
-/** 首帧头与数据帧的区分: 数据帧以魔数字节开头, 头帧为纯 JSON */
+/** 首帧头与数据帧的区分: 数据帧以魔数字节开头, 头帧为前缀 + JSON */
 const FRAME_HEADER_PREFIX = 'OTPW';
-const FRAME_HEADER_PREFIX_BYTES: Uint8Array = new util.TextEncoder().encodeInto(FRAME_HEADER_PREFIX);
 
 /** 消息类型常量(与 BLE 方案一致) */
 const MSG_TYPE_TOKENS = 'tokens';
@@ -90,15 +101,7 @@ export interface SettingValuePair {
 export async function saveTokensBatch(tokens: TokenConfig[]): Promise<number> {
   const tkStore: TokenStore = TokenStore.getInstance();
   const existing = await tkStore.getTokens();
-  for (let i = 0; i < tokens.length; i++) {
-    for (let j = 0; j < existing.length; j++) {
-      if (existing[j].TokenIssuer === tokens[i].TokenIssuer &&
-        existing[j].TokenName === tokens[i].TokenName) {
-        tokens[i].TokenUUID = existing[j].TokenUUID;
-        break;
-      }
-    }
-  }
+  reuseLocalTokenUuids(tokens, existing);
   for (let i = 0; i < tokens.length; i++) {
     await tkStore.updateToken(tokens[i]);
   }
@@ -139,22 +142,7 @@ export enum BluetoothPermissionResult {
   DENIED = -1
 }
 
-/** 首帧头结构 */
-interface TransferHeader {
-  total: number;
-  count: number;
-  type?: string;
-}
-
-/** 分片接收状态 */
-interface ReceiveState {
-  inProgress: boolean;
-  total: number;
-  count: number;
-  type: string;
-  received: number;
-  chunks: Array<Uint8Array>;
-}
+/** 首帧头结构(协议定义见 TransferProtocol.TransferHeader) */
 
 /**
  * 手机端 Wear Engine P2P 客户端: 设备列表查询/拉起手表应用/分片发送令牌与设置.
@@ -353,28 +341,19 @@ export class WearEngineClient {
   /**
    * 分片发送公共实现: AES-256-GCM 加密 → 首帧头(JSON) → ≤P2P_FRAME_MAX 数据帧.
    * 帧格式: 头帧以 FRAME_HEADER_PREFIX 开头, 数据帧为原始字节, 接收方按首帧 total 重组.
+   * 帧构建委托 {@link TransferFrameBuilder}。
    */
   private async sendPayload(randomId: string, plain: Uint8Array, count: number, type: string): Promise<void> {
     await this.ensureAppParam();
     this.ensureClients();
     const encrypted: Uint8Array = await encryptBlePayload(plain);
-    const total: number = encrypted.byteLength;
 
-    // 首帧: 头 JSON
-    const headerBytes: Uint8Array = new util.TextEncoder().encodeInto(
-      `${FRAME_HEADER_PREFIX}${JSON.stringify({ total: total, count: count, type: type })}`);
-    await this.sendFrame(randomId, headerBytes);
-
-    // 数据分片(每帧 ≤ P2P_FRAME_MAX)
-    let offset: number = 0;
-    while (offset < total) {
-      const end: number = Math.min(offset + P2P_FRAME_MAX, total);
-      const chunk: Uint8Array = new Uint8Array(end - offset);
-      chunk.set(encrypted.subarray(offset, end));
-      await this.sendFrame(randomId, chunk);
-      offset = end;
+    const builder = new TransferFrameBuilder(FRAME_HEADER_PREFIX, P2P_FRAME_MAX);
+    const frames = builder.buildFrames(encrypted, count, type);
+    for (let i = 0; i < frames.length; i++) {
+      await this.sendFrame(randomId, frames[i].bytes);
     }
-    hilog.info(DOMAIN, TAG, `sendPayload done: type=${type}, count=${count}, ${total} bytes`);
+    hilog.info(DOMAIN, TAG, `sendPayload done: type=${type}, count=${count}, ${encrypted.byteLength} bytes`);
   }
 
   private async sendFrame(randomId: string, data: Uint8Array): Promise<void> {
@@ -389,9 +368,9 @@ export class WearEngineClient {
 export class WearEngineServer {
   private static instance: WearEngineServer;
   private p2pClient: wearEngine.P2pClient | null = null;
-  private receive: ReceiveState = {
-    inProgress: false, total: 0, count: 0, type: MSG_TYPE_TOKENS, received: 0, chunks: []
-  };
+  /** 分片协议接收状态机(Phase 3 抽至 TransferProtocol, OTPW 前缀模式 + 不设 total 上限) */
+  private receiver: TransferFrameReceiver =
+    new TransferFrameReceiver({ headerPrefix: FRAME_HEADER_PREFIX, maxTotal: 0 } as TransferFrameOptions);
   private onTokensSaved: ((count: number) => void) | undefined = undefined;
   private onSettingsApplied: (() => void) | undefined = undefined;
   /** 对端(手机)应用参数: bundleName/fingerprint 运行时从本应用签名信息动态获取 */
@@ -485,48 +464,37 @@ export class WearEngineServer {
     this.registeredRandomIds = [];
   }
 
-  /** 帧协议处理: 首帧头(FRAME_HEADER_PREFIX 前缀 JSON) → 数据帧累积 → total 齐后重组分发 */
+  /**
+   * 帧协议处理: 首帧头(前缀 JSON) → 数据帧累积 → total 齐后重组分发.
+   * 帧判定委托 {@link TransferFrameReceiver}: 非法头帧静默忽略且保留批次（有意收口:
+   * 旧实现 JSON 解析抛错会经外层 catch 重置批次致传输挂死, 现统一为无副作用忽略）,
+   * 孤儿数据帧静默忽略（与抽离前行为一致）, 收齐后异步分发.
+   */
   private handleMessage(message: wearEngine.P2pMessage): void {
     try {
-      const bytes: Uint8Array = message.content;
-      if (this.startsWith(bytes, FRAME_HEADER_PREFIX_BYTES)) {
-        // 首帧: 头 JSON {total, count, type}
-        const decoder = new util.TextDecoder('utf-8');
-        const headerText = decoder.decodeToString(bytes.subarray(FRAME_HEADER_PREFIX_BYTES.byteLength));
-        const header = JSON.parse(headerText) as TransferHeader;
-        if (header.total <= 0) {
-          hilog.error(DOMAIN, TAG, `invalid transfer header: ${headerText}`);
-          return;
-        }
-        this.receive = {
-          inProgress: true, total: header.total, count: header.count,
-          type: header.type ?? MSG_TYPE_TOKENS, received: 0, chunks: []
-        };
-        hilog.info(DOMAIN, TAG, `receive start: total=${header.total}, count=${header.count}, type=${this.receive.type}`);
-      } else if (this.receive.inProgress) {
-        this.receive.chunks.push(bytes);
-        this.receive.received += bytes.byteLength;
-        if (this.receive.received >= this.receive.total) {
-          this.assembleAndDispatch();
-        }
+      const event: TransferFrameEvent = this.receiver.onFrame(message.content);
+      if (event.kind === TransferFrameEventKind.BATCH_STARTED) {
+        hilog.info(DOMAIN, TAG,
+          `receive start: total=${event.header?.total}, count=${event.header?.count}, type=${event.header?.type}`);
+      } else if (event.kind === TransferFrameEventKind.BATCH_COMPLETE && event.batch !== null) {
+        this.assembleAndDispatch(event.batch);
       }
     } catch (err) {
       const e = err as BusinessError;
       hilog.error(e.code, TAG, `handleMessage failed: ${e.message}`);
-      this.receive = { inProgress: false, total: 0, count: 0, type: MSG_TYPE_TOKENS, received: 0, chunks: [] };
+      this.receiver.reset();
     }
   }
 
   /** 重组全部数据分片 → 解密 → 按 type 分发 */
-  private async assembleAndDispatch(): Promise<void> {
-    const full: Uint8Array = new Uint8Array(this.receive.total);
-    let offset: number = 0;
-    for (let i = 0; i < this.receive.chunks.length; i++) {
-      full.set(this.receive.chunks[i], offset);
-      offset += this.receive.chunks[i].byteLength;
+  private async assembleAndDispatch(batch: TransferBatch): Promise<void> {
+    if (batch.receivedBytes !== batch.total) {
+      // 分片总量与头不符(交叠写入/重复投递): 判失败并丢弃本批次, 不进入解密
+      hilog.error(DOMAIN, TAG, `chunk size mismatch: got ${batch.receivedBytes}, expect ${batch.total}, discarding`);
+      return;
     }
-    const msgType: string = this.receive.type;
-    this.receive = { inProgress: false, total: 0, count: 0, type: MSG_TYPE_TOKENS, received: 0, chunks: [] };
+    const full: Uint8Array = concatenateChunks(batch.total, batch.chunks);
+    const msgType: string = batch.type;
     try {
       // 应用层解密: 失败视为载荷被篡改或密钥版本不匹配, 丢弃且不入库
       const plain: Uint8Array | null = await decryptBlePayload(full);
@@ -538,8 +506,7 @@ export class WearEngineServer {
         await this.applySettings(plain);
         return;
       }
-      const decoder = new util.TextDecoder('utf-8');
-      const tokens = JSON.parse(decoder.decodeToString(plain)) as TokenConfig[];
+      const tokens = JSON.parse(utf8Decode(plain)) as TokenConfig[];
       hilog.info(DOMAIN, TAG, `received ${tokens.length} tokens, saving...`);
       // 共享入库: issuer+name 覆盖、updateToken(ASSET 双写)、sortTokens
       const saved = await saveTokensBatch(tokens);
@@ -553,25 +520,12 @@ export class WearEngineServer {
   /** 应用手机端下发的设置载荷(白名单过滤后写入手表 Preferences, 共享实现) */
   private async applySettings(plain: Uint8Array): Promise<void> {
     try {
-      const decoder = new util.TextDecoder('utf-8');
-      const pairs = JSON.parse(decoder.decodeToString(plain)) as Array<SettingValuePair>;
+      const pairs = JSON.parse(utf8Decode(plain)) as Array<SettingValuePair>;
       await applyWearSettings(pairs);
       this.onSettingsApplied?.();
     } catch (err) {
       const e = err as BusinessError;
       hilog.error(e.code, TAG, `applySettings failed: ${e.message}`);
     }
-  }
-
-  private startsWith(data: Uint8Array, prefix: Uint8Array): boolean {
-    if (data.length < prefix.length) {
-      return false;
-    }
-    for (let i = 0; i < prefix.length; i++) {
-      if (data[i] !== prefix[i]) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -9,17 +9,34 @@
 
 ## 1. 覆盖率基准
 
-### 当前基线（2026-09-11，Phase 1 快速赢面落地后）
+### 当前基线（2026-09-12，Phase 2 存储与密钥解耦落地后）
 
-| 指标 | Phase 1 前（2026-09-11 晨） | **Phase 1 后（当前）** |
+| 指标 | Phase 1 后（2026-09-11） | **Phase 2 后（当前）** |
 |---|---|---|
-| 全局行覆盖 | 27.11%（1772 / 6537） | **34.61%（2271 / 6561）** |
-| 全局分支覆盖 | 25.13%（349 / 1389） | **30.29%（422 / 1393）** |
-| **逻辑层行覆盖（可测基数口径）** | ≈27% | **50.92%（2195 / 4311）** |
-| **逻辑层分支覆盖（可测基数口径）** | ≈25% | **43.37%（396 / 913）** |
+| 全局行覆盖 | 34.61%（2271 / 6561） | **51.18%（3611 / 7056）** |
+| 全局分支覆盖 | 30.29%（422 / 1393） | **47.72%（721 / 1511）** |
+| **逻辑层行覆盖（可测基数口径）** | 50.92%（2195 / 4311） | **72.73%（3545 / 4874）** |
+| **逻辑层分支覆盖（可测基数口径）** | 43.37%（396 / 913） | **66.60%（696 / 1045）** |
 
-- 逻辑层口径冻结在 `scripts/check-coverage.mjs`（46 个文件：common 全部 + entry 的 crypto/steam/oath/utils，剔除真机 only 与 UI 胶水），数字随 `scripts/coverage-baseline.json` 入库，CI 禁止回退。
-- 测试规模：252 条 LocalUnit 用例（Phase 1 前 ≈200 条）。
+- 逻辑层口径冻结在 `scripts/check-coverage.mjs`（58 个文件：common 全部 + entry 的 crypto/steam/oath/utils，剔除真机 only 与 UI 胶水），数字随 `scripts/coverage-baseline.json` 入库，CI 禁止回退。Phase 2 起 `SteamSecretStore` 解耦后移出真机剔除清单（新增 StoragePorts/TokenKvBatch 使基数 55→58）。
+- 测试规模：387 条 LocalUnit 用例（Phase 1 后 252 条，新增 135 条）。
+
+### Phase 2 高风险清单去 0%（目标全部达成）
+
+| 文件 | Phase 2 前现状 | Phase 2 后 |
+|---|---|---|
+| TokenStore | 0% | **解耦（TokenKvStore+SecretStore 端口），迁移三重验证/降级/双写穷举覆盖** |
+| CloudBackupManager | 0% | **解耦（FsGateway+账号/设备/令牌/分组/图标包/同步端口），编排全测** |
+| CloudSyncTask | 无数据（豁免清单） | 纯助手（文件名/时间戳/日期）入 CommonUtils 覆盖；@Concurrent 胶水留真机 |
+| CryptoUtils | 0% | **解耦（CryptoEngine 端口），V2/V0/BLE 帧格式与错误分支全测** |
+| AssetSecretStore / SteamSecretStore | 均 0%（剔除口径） | SteamSecretStore **解耦（NamedSecretStore 端口）全测**并入口径；AssetSecretStore 尺寸判定（utf8ByteLength）覆盖，asset 胶水留真机 |
+| TokenBackup | 0% | **解耦（BackupTextIo 端口），明文/加密往返与校验全测** |
+| BackupRestoreHelper | 0% | **解耦（DeviceMigrationKv 端口），恢复成功才清空的决策全测** |
+| KvManager | 0%（剔除口径） | 事务分块提交 + 旧版本迁移抽至 TokenKvBatch（口径内）全测 |
+| TokenGroupStore | 55/59 | 保持（Phase 1 已测） |
+| OathApplet（快速赢面 11 号移交） | 无数据（豁免清单） | **解耦（OathCryptoPort+TagTransport 脚本化），SELECT/VALIDATE/CALCULATE ALL/61xx 分片全测，移出豁免清单** |
+
+附带解耦并覆盖：TokenCardStore（KeyValueStore 端口）、FileUtils（分块读取/哈希防重写入可测核心）、CloudSyncTask/CommonUtils 共享助手。IconPackCloudBackup（FsGateway+IconPackArchiver+设备端口）覆盖状态机互斥/备份流程/去抖/清理/状态查询/enabledPacks 合并纯函数——**恢复成功链路（解压→deletedPacks 清理→refreshIconPackState→合并应用）0 覆盖**（依赖 TokenIconPacks 磁盘加载，归 Phase 3 或真机 ohosTest）。`StoragePorts.ets` 的 FileIoFsGateway 生产适配器（0/77）有意留在分母：fileIo/cloudSync 真机行为归 ohosTest 责任区（与 Phase 3 登记表一致）。
 
 ### Phase 1 前分目录（历史存档，行覆盖 = covered/total 插桩行）
 
@@ -40,10 +57,14 @@
 - 报告共 65 个文件条目；entry 的 pages(29)/dialogs(7)/components(20)/oath(4)/shell(3) **完全不在报告中（无数据 ≠ 0%）**，uikit/wearable 亦无条目。这些文件未来若进入插桩基数，全局百分比会被稀释。
 - 因此**所有目标按「逻辑层可测基数」定义，不以全局插桩行定义**；全局数字仅作防基数漂移的参考，与 `coverage-baseline.json` 的 `globalReference` 一致。
 
-### LocalUnit 运行时限制（2026-09-11 实测新增）
+### LocalUnit 运行时限制（2026-09-11 实测新增；Phase 2 补充）
 
 - `util.Base64Helper`（@ohos.util）：**静默返回空数据**（encodeToStringSync 返回 ''、decodeSync 返回空数组，不抛异常）。CloudBackupCrypto 已加 `Base64Codec` 注入；Base64Util 的用例固化了该行为，若 LocalUnit 未来支持会主动失败提醒迁移。
-- `systemDateTime.getTime()` 与 `Date.now()`：被 stub、不与真实时钟对齐——时间差/耗时段言不可写，只能断言返回有限数值。
+- `systemDateTime.getTime()` 与 `Date.now()`：被 stub、不与真实时钟对齐——时间差/耗时段言不可写，只能断言返回有限数值。注意 `new Date()`（无参）走真实时钟：跨时钟的"是否今天"类断言不可写（Phase 2 的 auto_backup 用例因此只测确定性的"昨日时间戳"分支）。
+- `util.TextDecoder` 静默失效的连带影响（Phase 2 实测）：OathApplet 的凭据名解码经 `OathCryptoPort.utf8Decode` 注入后才可测；纯 TS UTF-8 编解码参考 `FakeCryptoEngine.utf8Encode/utf8Decode`。
+- `DeviceInfoHelper`（@ohos.deviceInfo）在 LocalUnit 抛异常：IconPackCloudBackup 备份流程经 `IconPackDevicePort` 注入后可测。
+- `@Concurrent`（TaskPool）函数**只能引用 import 进来的标识符**，同文件的模块级函数/常量不行（ArkTS lint 28079/variablesInFunctionCheck）：共享逻辑放 CommonUtils（其文件头注释即为此约定）再 import。
+- ArkTS 标称类型注意点：测试假实现 `implements` 的是哪个接口必须与注入点参数类型同族（接口继承链任一祖先即可）；跨族传参会触发 arkts-no-structural-typing 编译错误——这正是端口族（KeyValueStore ← TokenGroupKvBackend ← TokenKvStore）要设计成继承链的原因。
 - 其余已知限制见 AGENTS.md 第 10 节（cryptoFramework、generateRandomUUID、TextDecoder 等）。
 
 ---
@@ -87,7 +108,7 @@ PermissionManager、DlpAntiPeepManager、PhotoPickerUtils、IconThumbnailTask、
 |---|---|---|---|
 | **Phase 0 口径修正** | 固定基数 | 本文件剔除清单评审通过；无数据文件明确归入 UI 口径 | ✅ 完成 |
 | **Phase 1 快速赢面** | 行 27%→**40~45%**；分支 25%→**33~35%** | ✅ **完成（2026-09-11）**：行 **50.92%**、分支 **43.37%** 双双超额；清单 1~10、12 落地（11 号 OathApplet 移交 Phase 2 头）；CloudBackupCrypto/TokenGroupStore/AppPreference 脱离 0%；CI 门禁 `check-coverage.mjs` + `coverage-baseline.json` 已入 quality.yml。A 类纯函数路径全覆盖（TokenUtils 文件级 37.6% 因其余为真机 API 胶水，归 B/C 口径） | 实际 1 天 |
-| **Phase 2 存储与密钥解耦** | 行→**55~60%**；分支→**45%** | 建立四个接口：`KeyValueStore`、`SecretStore`、`CryptoEngine`、`FsGateway`；TokenStore 迁移决策（三重验证/降级/双写）穷举用例；高风险清单全部脱离 0%。候选入手点（当前 0% 的最大块）：CloudBackupManager(330)、IconPackCloudBackup(368)、CryptoUtils(159)、TokenStore(256)、FileUtils(77)、TokenCardStore(77)、BackupRestoreHelper(19)、OathApplet 协议层 | 3~6 周 |
+| **Phase 2 存储与密钥解耦** | 行→**55~60%**；分支→**45%** | ✅ **完成（2026-09-12）**：行 **72.73%**、分支 **66.60%** 双双大幅超额。四端口族落地于 `StoragePorts.ets`（`KeyValueStore`/`TokenKvStore`、`SecretStore`/`NamedSecretStore`、`CryptoEngine`、`FsGateway`，另有 `TokenGroupKvBackend` 并入、`BackupTextIo`/`TransactionalKv`/`LegacyTokenKv`/`IconPackArchiver`/`DeviceMigrationKv`/`OathCryptoPort` 等伴生端口）；TokenStore 迁移决策（三重验证三分支/超限降级/双写/KV 失败回滚）穷举用例；高风险清单全部脱离 0%（见第 1 节表）；快速赢面 11 号 OathApplet 落地并移出豁免清单。实际工作量 1 天（计划 3~6 周为含评审/真机回归的保守估计；AES/PBKDF2/GCM 数值正确性仍归真机 ohosTest） | 实际 1 天 |
 | **Phase 3 备份与传输协议** | 行→**70~75%**；分支→**55~60%**（逻辑层基本到顶） | CloudBackupManager/CloudSyncTask/TokenBackup/IconPackCloudBackup 打包解析与状态机全测；BleFrameCodec/WearEngine 消息编解码纯类分支 ≥70%；ohosTest 补齐备份 round-trip、换机迁移、BLE/WearEngine 冒烟各 ≥3 条 | 4~8 周 |
 
 **天花板**：75%/60%（行/分支）之后剩余基本是 API 调用胶水（await kvStore.put、asset.add、ble.write…），LocalUnit 永远测不了，强行 mock 只会产生"测 mock"的假覆盖。折算到当前全量 6,537 行口径约为 55~58% 行。
@@ -104,7 +125,7 @@ PermissionManager、DlpAntiPeepManager、PhotoPickerUtils、IconThumbnailTask、
 8. ✅ SnackBar 注入点（注入记录函数验证分发与默认参数）
 9. ✅ Base64Util（**实测结论：util.Base64Helper 在 LocalUnit 静默返回空**——用例固化该行为并注释迁移路径；纯 TS base64 语义由 SteamCrypto 套件覆盖）
 10. ✅ UiUtils.throttle 窗口、TokenBatchProgress 观察者协议（含观察者抛异常不回滚）、CommonUtils（delay resolve、nowUnixSeconds 契约、padZero）
-11. ⬜ oath/OathApplet 协议层（519 行 TLV/指令构造；cryptoFramework 换 PureHash 注入后全测）— Phase 1 末或 Phase 2 头
+11. ✅ oath/OathApplet 协议层（**Phase 2 头落地 2026-09-12**：OathCryptoPort 注入 + 脚本化 TagTransport；SELECT 解析/锁定、VALIDATE 三分支、CALCULATE ALL 凭据分类（默认周期/HOTP 重算/非默认周期/touch 跳过）、61xx 分片链、TLV 边界与状态字映射全测；PBKDF2/HMAC-SHA1 数值归真机）
 12. ✅ ResponsiveLayoutPolicy（新增 `resolveVp(widthVp, heightVp)` 纯数值入口，`resolve` 委托换算；断点/宽高比边界全测）
 
 ### UI 层（pages/dialogs/components/shell/widget/uikit/wearable，约 1.76 万行）
@@ -140,7 +161,7 @@ node scripts/check-coverage.mjs
 
 ### 门禁盲区登记（2026-09-11 红方评审后加固）
 
-- **分母逃逸**：coverageReport.json 只含测试导入图可达的文件，未加载的口径内文件对覆盖率完全不可见。`check-coverage.mjs` 现将磁盘口径文件与报告路径求差集，豁免清单冻结于 `coverage-baseline.json` 的 `expectedAbsentFromReport`（当前 9 个，只允许缩小）：common 的 AppWindowInfo/AppFonts/CloudSyncTask/CommonConstants，entry 的 oath/NfcSessionTokens、oath/OathApplet、oath/TagTransport、utils/BackupImportOperation、utils/TokenBatchOperation。给文件补导入触达用例后应移除对应条目；OathApplet 随快速赢面 11 号（Phase 2 头）自然消除。
+- **分母逃逸**：coverageReport.json 只含测试导入图可达的文件，未加载的口径内文件对覆盖率完全不可见。`check-coverage.mjs` 现将磁盘口径文件与报告路径求差集，豁免清单冻结于 `coverage-baseline.json` 的 `expectedAbsentFromReport`（当前 8 个，只允许缩小）：common 的 AppWindowInfo/AppFonts/CloudSyncTask/CommonConstants，entry 的 oath/NfcSessionTokens、oath/TagTransport、utils/BackupImportOperation、utils/TokenBatchOperation。给文件补导入触达用例后应移除对应条目；OathApplet 已随 Phase 2 落地移出。
 - **baseline 防篡改**：baseline 含 `fileCount`（磁盘口径文件数），门禁对「删文件缩分母」「报告缺文件」双重拦截；覆盖率提升后重新生成 baseline 并随代码提交（同一提交内下调 baseline 属违反流程，review 时应拒绝）。
 - **未守护目录**（三分法有意排除，写入即不受门禁约束）：entry 的 pages/dialogs/components/shell/widget、entryability/entryformability 系、uikit/wearable 模块。gate 每次运行都会打印此提示。
 
@@ -150,5 +171,5 @@ node scripts/check-coverage.mjs
 
 1. 合理终点：**逻辑层（可测基数 ≈5,000 行）三阶段 40% → 60% → 75% 行覆盖，分支 33% → 45% → 60%**；全局口径终态约 55%。UI 层不设行覆盖目标。
 2. 分 Phase 0 + 3 个实施阶段；UI 前两阶段零投入，Phase 3 可选黑盒冒烟。
-3. 最高优先级是高风险清单（TokenStore/CloudBackupCrypto/各 SecretStore/备份恢复路径）；Phase 3 前，真机备份 round-trip 用例必须存在。
-4. 解耦成本低：PureHash、HttpTransport、Sleeper、TagTransport、setSnackBarImpl 五个先例证明 B 类解耦是沿用既有模式；BLE/WearEngine/NFC/cloudSync/asset 真机部分明确剔除，交给 ohosTest。
+3. 最高优先级是高风险清单（TokenStore/CloudBackupCrypto/各 SecretStore/备份恢复路径）；Phase 3 前，真机备份 round-trip 用例必须存在。**Phase 2（2026-09-12）已把高风险清单的 LocalUnit 可测部分全部落地并大幅超额达标（72.63%/66.22%）；Phase 3 的重点因此收敛为：备份/恢复协议状态机（CloudBackupManager/TokenBackup/IconPackCloudBackup 深分支）、BLE/WearEngine 消息编解码纯类，以及真机 ohosTest 补齐备份 round-trip、换机迁移、BLE/WearEngine 冒烟各 ≥3 条。**
+4. 解耦成本低：PureHash、HttpTransport、Sleeper、TagTransport、setSnackBarImpl 五个先例证明 B 类解耦是沿用既有模式；Phase 2 的 StoragePorts 端口族延续该模式并已沉淀为标准做法（新增 B 类文件先抽端口再写实现）；BLE/WearEngine/NFC/cloudSync/asset 真机部分明确剔除，交给 ohosTest。

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -9,17 +9,17 @@
 
 ## 1. 覆盖率基准
 
-### 当前基线（2026-09-12，Phase 2 存储与密钥解耦落地后）
+### 当前基线（2026-09-12，Phase 3 备份与传输协议落地后）
 
-| 指标 | Phase 1 后（2026-09-11） | **Phase 2 后（当前）** |
+| 指标 | Phase 2 后（2026-09-12 早） | **Phase 3 后（当前）** |
 |---|---|---|
-| 全局行覆盖 | 34.61%（2271 / 6561） | **51.18%（3611 / 7056）** |
-| 全局分支覆盖 | 30.29%（422 / 1393） | **47.72%（721 / 1511）** |
-| **逻辑层行覆盖（可测基数口径）** | 50.92%（2195 / 4311） | **72.73%（3545 / 4874）** |
-| **逻辑层分支覆盖（可测基数口径）** | 43.37%（396 / 913） | **66.60%（696 / 1045）** |
+| 全局行覆盖 | 51.29%（3626 / 7070） | **54.14%（3890 / 7185）** |
+| 全局分支覆盖 | 47.98%（725 / 1511） | **51.71%（802 / 1551）** |
+| **逻辑层行覆盖（可测基数口径）** | 72.73%（3545 / 4874） | **75.10%（3800 / 5060）** |
+| **逻辑层分支覆盖（可测基数口径）** | 66.60%（696 / 1045） | **70.28%（771 / 1097）** |
 
-- 逻辑层口径冻结在 `scripts/check-coverage.mjs`（58 个文件：common 全部 + entry 的 crypto/steam/oath/utils，剔除真机 only 与 UI 胶水），数字随 `scripts/coverage-baseline.json` 入库，CI 禁止回退。Phase 2 起 `SteamSecretStore` 解耦后移出真机剔除清单（新增 StoragePorts/TokenKvBatch 使基数 55→58）。
-- 测试规模：387 条 LocalUnit 用例（Phase 1 后 252 条，新增 135 条）。
+- 逻辑层口径冻结在 `scripts/check-coverage.mjs`（59 个文件：common 全部 + entry 的 crypto/steam/oath/utils，剔除真机 only 与 UI 胶水），数字随 `scripts/coverage-baseline.json` 入库，CI 禁止回退。Phase 3 新增 `TransferProtocol.ets`（手机↔手表传输协议纯类，行 100%、分支 97.7%）使基数 58→59。
+- 测试规模：420 条 LocalUnit 用例（Phase 2 后 387 条，新增 33 条）。ohosTest 新增 4 套件 16 条真机用例（见第 4 节 Phase 3 出口记录）。
 
 ### Phase 2 高风险清单去 0%（目标全部达成）
 
@@ -36,7 +36,7 @@
 | TokenGroupStore | 55/59 | 保持（Phase 1 已测） |
 | OathApplet（快速赢面 11 号移交） | 无数据（豁免清单） | **解耦（OathCryptoPort+TagTransport 脚本化），SELECT/VALIDATE/CALCULATE ALL/61xx 分片全测，移出豁免清单** |
 
-附带解耦并覆盖：TokenCardStore（KeyValueStore 端口）、FileUtils（分块读取/哈希防重写入可测核心）、CloudSyncTask/CommonUtils 共享助手。IconPackCloudBackup（FsGateway+IconPackArchiver+设备端口）覆盖状态机互斥/备份流程/去抖/清理/状态查询/enabledPacks 合并纯函数——**恢复成功链路（解压→deletedPacks 清理→refreshIconPackState→合并应用）0 覆盖**（依赖 TokenIconPacks 磁盘加载，归 Phase 3 或真机 ohosTest）。`StoragePorts.ets` 的 FileIoFsGateway 生产适配器（0/77）有意留在分母：fileIo/cloudSync 真机行为归 ohosTest 责任区（与 Phase 3 登记表一致）。
+附带解耦并覆盖：TokenCardStore（KeyValueStore 端口）、FileUtils（分块读取/哈希防重写入可测核心）、CloudSyncTask/CommonUtils 共享助手。IconPackCloudBackup（FsGateway+IconPackArchiver+设备端口）覆盖状态机互斥/备份流程/去抖/清理/状态查询/enabledPacks 合并纯函数——**恢复成功链路（解压→deletedPacks 清理→refreshIconPackState→合并应用）已在 Phase 3 经 `IconPackRegistry` 端口补齐覆盖**（deletedPacks 清理/未知 uuid 跳过/损坏包不中断/无 meta 降级/冷启动 auto-restore 门禁与整链路）。`StoragePorts.ets` 的 FileIoFsGateway 生产适配器（0/77）有意留在分母：fileIo/cloudSync 真机行为归 ohosTest 责任区（与 Phase 3 登记表一致）。
 
 ### Phase 1 前分目录（历史存档，行覆盖 = covered/total 插桩行）
 
@@ -64,6 +64,8 @@
 - `util.TextDecoder` 静默失效的连带影响（Phase 2 实测）：OathApplet 的凭据名解码经 `OathCryptoPort.utf8Decode` 注入后才可测；纯 TS UTF-8 编解码参考 `FakeCryptoEngine.utf8Encode/utf8Decode`。
 - `DeviceInfoHelper`（@ohos.deviceInfo）在 LocalUnit 抛异常：IconPackCloudBackup 备份流程经 `IconPackDevicePort` 注入后可测。
 - `@Concurrent`（TaskPool）函数**只能引用 import 进来的标识符**，同文件的模块级函数/常量不行（ArkTS lint 28079/variablesInFunctionCheck）：共享逻辑放 CommonUtils（其文件头注释即为此约定）再 import。
+- 管理器类 `useDepsForTest` 为**整体替换语义**（Phase 3 实测）：`testDeps` 是一个对象，只传单个端口会把其余端口打回生产适配器（真机 API → LocalUnit 下失败）。局部替换时必须传完整端口集（CloudBackupManager.test 的 Flaky 用例为此踩坑）。
+- hypium `Assert` 无 `assertNotNull`（有 `assertNull`）：非空断言用 `expect(x !== null).assertTrue()`。
 - ArkTS 标称类型注意点：测试假实现 `implements` 的是哪个接口必须与注入点参数类型同族（接口继承链任一祖先即可）；跨族传参会触发 arkts-no-structural-typing 编译错误——这正是端口族（KeyValueStore ← TokenGroupKvBackend ← TokenKvStore）要设计成继承链的原因。
 - 其余已知限制见 AGENTS.md 第 10 节（cryptoFramework、generateRandomUUID、TextDecoder 等）。
 
@@ -109,7 +111,7 @@ PermissionManager、DlpAntiPeepManager、PhotoPickerUtils、IconThumbnailTask、
 | **Phase 0 口径修正** | 固定基数 | 本文件剔除清单评审通过；无数据文件明确归入 UI 口径 | ✅ 完成 |
 | **Phase 1 快速赢面** | 行 27%→**40~45%**；分支 25%→**33~35%** | ✅ **完成（2026-09-11）**：行 **50.92%**、分支 **43.37%** 双双超额；清单 1~10、12 落地（11 号 OathApplet 移交 Phase 2 头）；CloudBackupCrypto/TokenGroupStore/AppPreference 脱离 0%；CI 门禁 `check-coverage.mjs` + `coverage-baseline.json` 已入 quality.yml。A 类纯函数路径全覆盖（TokenUtils 文件级 37.6% 因其余为真机 API 胶水，归 B/C 口径） | 实际 1 天 |
 | **Phase 2 存储与密钥解耦** | 行→**55~60%**；分支→**45%** | ✅ **完成（2026-09-12）**：行 **72.73%**、分支 **66.60%** 双双大幅超额。四端口族落地于 `StoragePorts.ets`（`KeyValueStore`/`TokenKvStore`、`SecretStore`/`NamedSecretStore`、`CryptoEngine`、`FsGateway`，另有 `TokenGroupKvBackend` 并入、`BackupTextIo`/`TransactionalKv`/`LegacyTokenKv`/`IconPackArchiver`/`DeviceMigrationKv`/`OathCryptoPort` 等伴生端口）；TokenStore 迁移决策（三重验证三分支/超限降级/双写/KV 失败回滚）穷举用例；高风险清单全部脱离 0%（见第 1 节表）；快速赢面 11 号 OathApplet 落地并移出豁免清单。实际工作量 1 天（计划 3~6 周为含评审/真机回归的保守估计；AES/PBKDF2/GCM 数值正确性仍归真机 ohosTest） | 实际 1 天 |
-| **Phase 3 备份与传输协议** | 行→**70~75%**；分支→**55~60%**（逻辑层基本到顶） | CloudBackupManager/CloudSyncTask/TokenBackup/IconPackCloudBackup 打包解析与状态机全测；BleFrameCodec/WearEngine 消息编解码纯类分支 ≥70%；ohosTest 补齐备份 round-trip、换机迁移、BLE/WearEngine 冒烟各 ≥3 条 | 4~8 周 |
+| **Phase 3 备份与传输协议** | 行→**70~75%**；分支→**55~60%**（逻辑层基本到顶） | ✅ **完成（2026-09-12）**：行 **75.10%**、分支 **70.28%** 双双超额（Phase 2 已提前越过全局目标，Phase 3 按出口清单收尾）。① 传输协议纯类 `TransferProtocol.ets` 落地（分帧构建/头解析/双模式接收状态机/纯 TS UTF-8/UUID 复用决策），BleTokenTransfer/WearEngineTransfer 生产类改委托，**行 161/163、分支 49/50（98%）**（目标 ≥70%）；② IconPackCloudBackup 恢复成功链路经 `IconPackRegistry` 端口补齐；③ CloudBackupManager 深分支（CloudBackupTokenError 路径/单文件 stat 失败隔离/同步故障容忍/清理粒度边界）补测；④ ohosTest 新增 4 套件 16 条真机用例（BackupRoundTrip 4 / DeviceMigration 4 / BleTransferSmoke 4 / WearEngineSmoke 4，已编译通过，待真机执行——设备当前不在线）。红方评审两路 P0 均为零；随评审落地的两处有意行为收口：WearEngine 非法头帧统一为"保留批次无副作用忽略"（旧实现 JSON 抛错会重置批次致传输挂死）、Wear 通道重组前增加 receivedBytes !== total 显式判失败（旧实现走越界异常）。待真机验证项：KvManager 换机迁移用 getEntries('^') 键前缀扫描，而令牌键以 _token_uuid_ 开头，若分布式 KV 内部键形态不含 '^' 前缀则迁移会静默空转——DeviceMigration 冒烟已加 backupCount > 0 硬护栏，真机执行即可暴露。实际工作量 1 天 | 实际 1 天 |
 
 **天花板**：75%/60%（行/分支）之后剩余基本是 API 调用胶水（await kvStore.put、asset.add、ble.write…），LocalUnit 永远测不了，强行 mock 只会产生"测 mock"的假覆盖。折算到当前全量 6,537 行口径约为 55~58% 行。
 
@@ -171,5 +173,5 @@ node scripts/check-coverage.mjs
 
 1. 合理终点：**逻辑层（可测基数 ≈5,000 行）三阶段 40% → 60% → 75% 行覆盖，分支 33% → 45% → 60%**；全局口径终态约 55%。UI 层不设行覆盖目标。
 2. 分 Phase 0 + 3 个实施阶段；UI 前两阶段零投入，Phase 3 可选黑盒冒烟。
-3. 最高优先级是高风险清单（TokenStore/CloudBackupCrypto/各 SecretStore/备份恢复路径）；Phase 3 前，真机备份 round-trip 用例必须存在。**Phase 2（2026-09-12）已把高风险清单的 LocalUnit 可测部分全部落地并大幅超额达标（72.63%/66.22%）；Phase 3 的重点因此收敛为：备份/恢复协议状态机（CloudBackupManager/TokenBackup/IconPackCloudBackup 深分支）、BLE/WearEngine 消息编解码纯类，以及真机 ohosTest 补齐备份 round-trip、换机迁移、BLE/WearEngine 冒烟各 ≥3 条。**
+3. 最高优先级是高风险清单（TokenStore/CloudBackupCrypto/各 SecretStore/备份恢复路径）。**三阶段已全部完成（2026-09-12）：逻辑层行 75.10%、分支 70.28%，接近 75%/60% 天花板口径的行上限；剩余基本是 API 调用胶水。后续重点转为真机回归：ohosTest 已备好备份 round-trip（4）/换机迁移（4）/BLE（4）/WearEngine（4）冒烟用例，待设备在线执行并纳入发版前检查清单（换机迁移用例自带 getEntries('^') 风险探测护栏）。**
 4. 解耦成本低：PureHash、HttpTransport、Sleeper、TagTransport、setSnackBarImpl 五个先例证明 B 类解耦是沿用既有模式；Phase 2 的 StoragePorts 端口族延续该模式并已沉淀为标准做法（新增 B 类文件先抽端口再写实现）；BLE/WearEngine/NFC/cloudSync/asset 真机部分明确剔除，交给 ohosTest。

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,154 @@
+# 测试用例与代码覆盖率计划
+
+> 创建日期：2026-09-11
+> 基准来源：DevEco Studio「Local Test with Coverage」官方覆盖率报告（`hvigorw test` 亦会重新生成）
+> 基准报告：`entry/.test/default/outputs/test/reports/index.html`（coverageReport.json）
+> Instrument Test 覆盖率当前 IDE 不可用，本计划仅以 LocalUnit 覆盖率为量化基准；真机部分用 ohosTest 用例数/冒烟清单管理。
+
+---
+
+## 1. 覆盖率基准
+
+### 当前基线（2026-09-11，Phase 1 快速赢面落地后）
+
+| 指标 | Phase 1 前（2026-09-11 晨） | **Phase 1 后（当前）** |
+|---|---|---|
+| 全局行覆盖 | 27.11%（1772 / 6537） | **34.61%（2271 / 6561）** |
+| 全局分支覆盖 | 25.13%（349 / 1389） | **30.29%（422 / 1393）** |
+| **逻辑层行覆盖（可测基数口径）** | ≈27% | **50.92%（2195 / 4311）** |
+| **逻辑层分支覆盖（可测基数口径）** | ≈25% | **43.37%（396 / 913）** |
+
+- 逻辑层口径冻结在 `scripts/check-coverage.mjs`（46 个文件：common 全部 + entry 的 crypto/steam/oath/utils，剔除真机 only 与 UI 胶水），数字随 `scripts/coverage-baseline.json` 入库，CI 禁止回退。
+- 测试规模：252 条 LocalUnit 用例（Phase 1 前 ≈200 条）。
+
+### Phase 1 前分目录（历史存档，行覆盖 = covered/total 插桩行）
+
+| 区域 | Phase 1 前 | Phase 1 后 |
+|---|---|---|
+| entry/ets/crypto（PureHash） | 93.7%（224/239） | 不变（已饱和） |
+| common/ets/utils/proto | 89.8%（141/157） | 不变 |
+| entry/ets/steam + proto | 72.5% / 83.5% | SteamClient **97.4%（223/229）** |
+| common/ets/utils/importers | 38.9%（35/90） | TokenImporter 17/18；TwoFA 语义已有 Node 套件 |
+| common/ets/utils（39 文件） | 15.1%（639/4225） | 大幅提升：TokenGroupStore 55/59、AppPreference 128/163、CloudBackupCrypto 98/161、Base64Util 19/22、SnackBar 8/22、TokenBatchProgress 8/9、CommonUtils 6/7 |
+| entry/ets/utils | 4.3%（8/188） | ResponsiveLayoutPolicy 9/11（common 侧） |
+| CloudBackupCrypto / TokenGroupStore / AppPreference | **均 0%** | **全部脱离 0%** |
+| entry pages/dialogs/components/shell/widget、entryability 系 | 无数据 | 无数据（归 UI 口径） |
+| uikit、wearable 模块 | 无数据 | 无数据（纯 UI） |
+
+### 口径说明（重要）
+
+- 报告共 65 个文件条目；entry 的 pages(29)/dialogs(7)/components(20)/oath(4)/shell(3) **完全不在报告中（无数据 ≠ 0%）**，uikit/wearable 亦无条目。这些文件未来若进入插桩基数，全局百分比会被稀释。
+- 因此**所有目标按「逻辑层可测基数」定义，不以全局插桩行定义**；全局数字仅作防基数漂移的参考，与 `coverage-baseline.json` 的 `globalReference` 一致。
+
+### LocalUnit 运行时限制（2026-09-11 实测新增）
+
+- `util.Base64Helper`（@ohos.util）：**静默返回空数据**（encodeToStringSync 返回 ''、decodeSync 返回空数组，不抛异常）。CloudBackupCrypto 已加 `Base64Codec` 注入；Base64Util 的用例固化了该行为，若 LocalUnit 未来支持会主动失败提醒迁移。
+- `systemDateTime.getTime()` 与 `Date.now()`：被 stub、不与真实时钟对齐——时间差/耗时段言不可写，只能断言返回有限数值。
+- 其余已知限制见 AGENTS.md 第 10 节（cryptoFramework、generateRandomUUID、TextDecoder 等）。
+
+---
+
+## 2. 代码分类结论（三分法）
+
+- **A 类（纯逻辑，LocalUnit 现在就能测）**：common 的 proto/importers/TokenUtils 纯函数部分、TokenConfig、GoogleAuthMigration、OtpAuthParser、SteamAuth、entry 的 crypto/steam（除 NetworkHttpTransport）、ResponsiveLayoutPolicy（改签名后）等。项目已有成熟注入先例：PureHash、HttpTransport、Sleeper、TagTransport、setSnackBarImpl。
+- **B 类（业务逻辑但耦合系统 API，需解耦后可测）**：TokenStore（KvManager/RdbManager/Asset/SteamSecretStore）、CloudBackupCrypto（cryptoFramework）、CryptoUtils、AppPreference（preferences）、KvManager（distributedKVStore）、BleTokenTransfer（ble）、WearEngineTransfer（wearEngine）、CloudBackupManager（fileIo/cloudSync）、各 SecretStore（asset）等。
+- **C 类（UI，LocalUnit 永远测不了）**：entry pages/dialogs/components/shell/widget/pages、uikit 全部（1167 行 @Component）、wearable 全部（955 行）。
+
+### 真机 only（从可测基数剔除，归 ohosTest 责任区）
+
+PermissionManager、DlpAntiPeepManager、PhotoPickerUtils、IconThumbnailTask、RdbManager、HuaweiAccountManager 登录流程、BleTokenTransfer 的 GATT/scan 部分（~280/403 行）、WearEngineTransfer 的 P2P/权限部分（~180/262 行）、KvManager 的 distributedKVStore 调用、AssetSecretStore 的 asset 调用、NfcOathReader/NfcTagTransport、NetworkHttpTransport、TokenSwitchPerf、EntryAbility 系。
+估算剔除后**逻辑层可测基数 ≈ 4,900~5,000 插桩行**。
+
+---
+
+## 3. 高风险清单（数据丢失/密钥安全，必须优先脱离 0%）
+
+| 文件 | 风险 | 现状 |
+|---|---|---|
+| TokenStore | 令牌主存储，KV+ASSET 双写、迁移三重验证、900 字节降级——出错即用户全部令牌丢失 | 0% |
+| CloudBackupCrypto | 云备份加密格式，加密有 bug 即备份不可恢复 | 0% |
+| CloudBackupManager / CloudSyncTask | 备份/恢复编排与记录解析 | 0% / 无数据 |
+| AssetSecretStore / SteamSecretStore | TEE 密钥读写与分片，丢失不可再生 | 均 0% |
+| CryptoUtils | 本地备份 + BLE 传输加密 | 0% |
+| TokenBackup | 本地文件备份管线（magic/version/加密） | 0% |
+| BackupRestoreHelper + BackupExtension | 换机迁移明文 KV 中转窗口 | 0% |
+| KvManager | 持久化底层 + 旧版本数据迁移 | 0% |
+| TokenGroupStore | merge/reconcile 可能破坏用户分组 | 1.8% |
+
+以上合计约 1,400 插桩行，其中约 60% 可经接口抽取后在 LocalUnit 覆盖；其余由 ohosTest 真机回归覆盖（现有 AssetConcurrency/TokenBatch 雏形需扩展为备份/恢复/迁移套件）。
+
+---
+
+## 4. 阶段计划
+
+### 逻辑层（common 全部 + entry 的 crypto/steam/oath/utils）
+
+| 阶段 | 目标（对可测基数） | 出口条件 | 工作量 |
+|---|---|---|---|
+| **Phase 0 口径修正** | 固定基数 | 本文件剔除清单评审通过；无数据文件明确归入 UI 口径 | ✅ 完成 |
+| **Phase 1 快速赢面** | 行 27%→**40~45%**；分支 25%→**33~35%** | ✅ **完成（2026-09-11）**：行 **50.92%**、分支 **43.37%** 双双超额；清单 1~10、12 落地（11 号 OathApplet 移交 Phase 2 头）；CloudBackupCrypto/TokenGroupStore/AppPreference 脱离 0%；CI 门禁 `check-coverage.mjs` + `coverage-baseline.json` 已入 quality.yml。A 类纯函数路径全覆盖（TokenUtils 文件级 37.6% 因其余为真机 API 胶水，归 B/C 口径） | 实际 1 天 |
+| **Phase 2 存储与密钥解耦** | 行→**55~60%**；分支→**45%** | 建立四个接口：`KeyValueStore`、`SecretStore`、`CryptoEngine`、`FsGateway`；TokenStore 迁移决策（三重验证/降级/双写）穷举用例；高风险清单全部脱离 0%。候选入手点（当前 0% 的最大块）：CloudBackupManager(330)、IconPackCloudBackup(368)、CryptoUtils(159)、TokenStore(256)、FileUtils(77)、TokenCardStore(77)、BackupRestoreHelper(19)、OathApplet 协议层 | 3~6 周 |
+| **Phase 3 备份与传输协议** | 行→**70~75%**；分支→**55~60%**（逻辑层基本到顶） | CloudBackupManager/CloudSyncTask/TokenBackup/IconPackCloudBackup 打包解析与状态机全测；BleFrameCodec/WearEngine 消息编解码纯类分支 ≥70%；ohosTest 补齐备份 round-trip、换机迁移、BLE/WearEngine 冒烟各 ≥3 条 | 4~8 周 |
+
+**天花板**：75%/60%（行/分支）之后剩余基本是 API 调用胶水（await kvStore.put、asset.add、ble.write…），LocalUnit 永远测不了，强行 mock 只会产生"测 mock"的假覆盖。折算到当前全量 6,537 行口径约为 55~58% 行。
+
+### 快速赢面清单（Phase 1，按行数×风险排序；✅ = 已落地 2026-09-11）
+
+1. ✅ CloudBackupCrypto（0%→61% 行，加密引擎经 `BackupCryptoEngine`/`Base64Codec` 注入）：getMode/isMockFormat/parseTokenHeader/verifyToken/错误分支/三段式 round-trip 全测（XOR 假引擎 + PureHash 真 SHA-256）；AES/PBKDF2 数值归真机
+2. ✅ TokenUtils.OTPDefaultIconPack：查表映射 + 数据完整性（无重复/小写归一/路径集合一致）
+3. ✅ TokenUtils 其余纯函数（convertToken2URI、stringToIntArray、counterToBytes64 大数值边界；base32 变体此前已覆盖）
+4. ✅ TokenGroupStore 纯逻辑（isValidName/rename/remove/move/merge/reconcile/写失败回退；`useKvBackendForTest` 注入内存 KV）
+5. ✅ AppPreference 纯部分（默认值缓存/枚举稳定值/选项数组一致性/PREF_KEYS 无冲突/路由与外链常量/loadSettings 默认值流入 TokenPreference）
+6. ✅ SteamClient 58%→**97.4%**（RSA 解析、BeginAuth float interval、newClientId 迁移、迁移/撤销/状态全链路、请求体 protobuf 回读）
+7. ✅ TokenImporterRegistry 分发 + URIImporter 空实现契约（init 幂等/同 id 覆盖）
+8. ✅ SnackBar 注入点（注入记录函数验证分发与默认参数）
+9. ✅ Base64Util（**实测结论：util.Base64Helper 在 LocalUnit 静默返回空**——用例固化该行为并注释迁移路径；纯 TS base64 语义由 SteamCrypto 套件覆盖）
+10. ✅ UiUtils.throttle 窗口、TokenBatchProgress 观察者协议（含观察者抛异常不回滚）、CommonUtils（delay resolve、nowUnixSeconds 契约、padZero）
+11. ⬜ oath/OathApplet 协议层（519 行 TLV/指令构造；cryptoFramework 换 PureHash 注入后全测）— Phase 1 末或 Phase 2 头
+12. ✅ ResponsiveLayoutPolicy（新增 `resolveVp(widthVp, heightVp)` 纯数值入口，`resolve` 委托换算；断点/宽高比边界全测）
+
+### UI 层（pages/dialogs/components/shell/widget/uikit/wearable，约 1.76 万行）
+
+| 阶段 | 策略 |
+|---|---|
+| Phase 1~2 | **不上 UI 自动化**。只做两件事：(a) UI 文件里零星纯函数（TokenListPage.toVMs、颜色换算、describeError 等 <300 行）顺手抽走归入逻辑层；(b) 真机手工冒烟清单文档化（加令牌/编辑/删除/备份恢复/卡片刷新 5 条主路径） |
+| Phase 3（可选） | ArkUITest 黑盒冒烟 10~20 条关键路径（列表渲染/搜索/排序/添加三类型/应用锁），**不做 UI 覆盖率门禁**；若需要数字，行覆盖 15~25% 仅为参考值 |
+| widget | CardOTPUtils 已 100%，FormExtension 生命周期留真机；不设目标 |
+| wearable | 不设 LocalUnit 目标，列入真机 ohosTest/手工冒烟清单 |
+
+UI 层度量方式：关键路径 ohosTest/ArkUITest 用例通过率 + 手工冒烟清单勾选，**不用行覆盖率**（信噪比低，深挖性价比远低于逻辑层分支覆盖）。
+
+---
+
+## 5. 度量与复现
+
+```powershell
+# 重新生成基准（二选一）：
+# 1) DevEco Studio：右键 entry/src/test → Run 'Tests in 'test'' with Coverage
+# 2) CLI（无需特殊参数，test 任务默认重写覆盖率报告）：
+./hvigorw test -p module=entry@default --no-daemon
+# 报告输出：entry/.test/default/outputs/test/reports/index.html + coverageReport.json
+
+# 逻辑层覆盖率门禁（CI quality.yml localunit job 亦执行）：
+node scripts/check-coverage.mjs
+# 口径冻结于脚本内 INCLUDES/EXCLUDES；数字对比 scripts/coverage-baseline.json，
+# 有意提升覆盖率后重新生成 baseline 随代码提交（只进不退）。
+```
+
+- CI 门禁：quality.yml 解析 test_result.txt 的现有逻辑不变，其后追加 `node scripts/check-coverage.mjs`——逻辑层行/分支覆盖低于基线（0.1pp 容差）即失败。
+- 每阶段合入后更新本文件第 1 节的基准数字与日期。
+
+### 门禁盲区登记（2026-09-11 红方评审后加固）
+
+- **分母逃逸**：coverageReport.json 只含测试导入图可达的文件，未加载的口径内文件对覆盖率完全不可见。`check-coverage.mjs` 现将磁盘口径文件与报告路径求差集，豁免清单冻结于 `coverage-baseline.json` 的 `expectedAbsentFromReport`（当前 9 个，只允许缩小）：common 的 AppWindowInfo/AppFonts/CloudSyncTask/CommonConstants，entry 的 oath/NfcSessionTokens、oath/OathApplet、oath/TagTransport、utils/BackupImportOperation、utils/TokenBatchOperation。给文件补导入触达用例后应移除对应条目；OathApplet 随快速赢面 11 号（Phase 2 头）自然消除。
+- **baseline 防篡改**：baseline 含 `fileCount`（磁盘口径文件数），门禁对「删文件缩分母」「报告缺文件」双重拦截；覆盖率提升后重新生成 baseline 并随代码提交（同一提交内下调 baseline 属违反流程，review 时应拒绝）。
+- **未守护目录**（三分法有意排除，写入即不受门禁约束）：entry 的 pages/dialogs/components/shell/widget、entryability/entryformability 系、uikit/wearable 模块。gate 每次运行都会打印此提示。
+
+---
+
+## 6. 结论摘要
+
+1. 合理终点：**逻辑层（可测基数 ≈5,000 行）三阶段 40% → 60% → 75% 行覆盖，分支 33% → 45% → 60%**；全局口径终态约 55%。UI 层不设行覆盖目标。
+2. 分 Phase 0 + 3 个实施阶段；UI 前两阶段零投入，Phase 3 可选黑盒冒烟。
+3. 最高优先级是高风险清单（TokenStore/CloudBackupCrypto/各 SecretStore/备份恢复路径）；Phase 3 前，真机备份 round-trip 用例必须存在。
+4. 解耦成本低：PureHash、HttpTransport、Sleeper、TagTransport、setSnackBarImpl 五个先例证明 B 类解耦是沿用既有模式；BLE/WearEngine/NFC/cloudSync/asset 真机部分明确剔除，交给 ohosTest。

--- a/entry/src/main/ets/oath/OathApplet.ets
+++ b/entry/src/main/ets/oath/OathApplet.ets
@@ -1,6 +1,5 @@
 import { cryptoFramework } from '@kit.CryptoArchitectureKit';
 import { util } from '@kit.ArkTS';
-import { BusinessError } from '@kit.BasicServicesKit';
 import { Logger } from 'common';
 import { TagTransport } from './TagTransport';
 
@@ -39,6 +38,57 @@ const SW1_MORE_DATA = 0x61;
 const SW_SECURITY_CONDITION_NOT_SATISFIED = 0x6982;
 
 let logger = Logger;
+
+// ---------- 密码学端口 ----------
+
+/**
+ * OATH 会话所需密码学端口（Phase 2 解耦）。
+ * 生产实现走 cryptoFramework（LocalUnit 不可用）；测试注入确定性实现，
+ * 仅验证协议编排（挑战/响应一致性由同一实现两侧计算保证）。
+ * PBKDF2/HMAC-SHA1 数值正确性由真机 ohosTest 的 RFC 向量保证。
+ */
+export interface OathCryptoPort {
+  pbkdf2Sha1Derive(password: string, salt: Uint8Array, iterations: number, keySize: number): Promise<Uint8Array>;
+  hmacSha1(key: Uint8Array, message: Uint8Array): Promise<Uint8Array>;
+  randomBytes(len: number): Uint8Array;
+  /** UTF-8 解码（util.TextDecoder 在 LocalUnit 下静默失效，经端口注入） */
+  utf8Decode(data: Uint8Array): string;
+}
+
+class CryptoFrameworkOathCrypto implements OathCryptoPort {
+  async pbkdf2Sha1Derive(password: string, salt: Uint8Array, iterations: number, keySize: number): Promise<Uint8Array> {
+    const spec: cryptoFramework.PBKDF2Spec = {
+      algName: 'PBKDF2',
+      password: password,
+      salt: salt,
+      iterations: iterations,
+      keySize: keySize
+    };
+    const kdf = cryptoFramework.createKdf('PBKDF2|SHA1');
+    const secret = await kdf.generateSecret(spec);
+    return secret.data;
+  }
+
+  async hmacSha1(key: Uint8Array, message: Uint8Array): Promise<Uint8Array> {
+    const keyBlob: cryptoFramework.DataBlob = { data: key };
+    const symKeyGenerator = cryptoFramework.createSymKeyGenerator('HMAC');
+    const symKey = symKeyGenerator.convertKeySync(keyBlob);
+    const mac = cryptoFramework.createMac('SHA1');
+    mac.initSync(symKey);
+    mac.updateSync({ data: message });
+    const macResult = mac.doFinalSync();
+    return macResult.data;
+  }
+
+  randomBytes(len: number): Uint8Array {
+    const random = cryptoFramework.createRandom();
+    return random.generateRandomSync(len).data;
+  }
+
+  utf8Decode(data: Uint8Array): string {
+    return textDecoder.decodeToString(data);
+  }
+}
 
 // ---------- 数据类型 ----------
 
@@ -142,12 +192,7 @@ function getResponseData(response: number[]): number[] {
 
 // ---------- 编解码工具 ----------
 
-const textEncoder = new util.TextEncoder();
 const textDecoder = util.TextDecoder.create('utf-8');
-
-function utf8BytesToString(bytes: Uint8Array): string {
-  return textDecoder.decodeToString(bytes);
-}
 
 /** 大端字节序列（用于 8 字节 challenge 时间步） */
 function bigEndianBytes(value: number, len: number): number[] {
@@ -184,8 +229,7 @@ interface ParsedCredId {
  * TOTP 用正则 ^((\d+)/)?(([^:]+):)?(.+)$ 提取 period/issuer/name；
  * HOTP 以首个 ':' 分割 issuer/name（无 issuer 则为空串）。
  */
-function parseCredId(credIdBytes: Uint8Array, oathType: OathType): ParsedCredId {
-  const data = utf8BytesToString(credIdBytes);
+function parseCredId(data: string, oathType: OathType): ParsedCredId {
   if (oathType === 'TOTP') {
     const pattern = new RegExp('^((\\d+)/)?(([^:]+):)?(.+)$');
     const match = pattern.exec(data);
@@ -248,14 +292,16 @@ interface CalcResult {
  */
 export class OathSession {
   private transport: TagTransport;
+  private crypto: OathCryptoPort;
   private version: string = '';
   private salt: Uint8Array = new Uint8Array(0);
   /** SELECT 响应中的 challenge，存在即锁定（需 VALIDATE 解锁） */
   private challenge: Uint8Array | undefined = undefined;
   private closed: boolean = false;
 
-  constructor(transport: TagTransport) {
+  constructor(transport: TagTransport, crypto?: OathCryptoPort) {
     this.transport = transport;
+    this.crypto = crypto !== undefined ? crypto : new CryptoFrameworkOathCrypto();
   }
 
   /** 是否锁定（存在 challenge 即需认证） */
@@ -335,7 +381,6 @@ export class OathSession {
     this.challenge = undefined;
     logger.info('VALIDATE ok');
   }
-
   /**
    * CALCULATE ALL：APDU 00 A4 00 01 0A 74 08 <8字节大端 timestamp//30>。
    * 解析 [0x71 name, 响应TLV] 列表；61xx 分片经 SEND REMAINING（00 A5 00 00 00）循环取回。
@@ -370,14 +415,14 @@ export class OathSession {
         continue;
       }
       const oathType: OathType = respTlv.tag === TAG_HOTP ? 'HOTP' : 'TOTP';
-      const parsed = parseCredId(nameTlv.value, oathType);
+      const parsed = parseCredId(this.utf8BytesToString(nameTlv.value), oathType);
       // touch 凭据：免交互流程无法取码，跳过（FR-016）
       if (respTlv.tag === TAG_TOUCH) {
         logger.info(`skip touch credential: ${parsed.name}`);
         continue;
       }
       const credential: OathCredential = {
-        credentialId: utf8BytesToString(nameTlv.value),
+        credentialId: this.utf8BytesToString(nameTlv.value),
         rawId: nameTlv.value,
         issuer: parsed.issuer,
         name: parsed.name,
@@ -485,35 +530,23 @@ export class OathSession {
     return buf;
   }
 
+  /** 凭据名等 UTF-8 解码（经 OathCryptoPort，LocalUnit 可注入） */
+  private utf8BytesToString(bytes: Uint8Array): string {
+    return this.crypto.utf8Decode(bytes);
+  }
+
   /** PBKDF2-HMAC-SHA1 派生 16 字节访问密钥（与 ykman _derive_key 等价） */
   private async deriveKey(password: string): Promise<Uint8Array> {
-    const spec: cryptoFramework.PBKDF2Spec = {
-      algName: 'PBKDF2',
-      password: password,
-      salt: this.salt,
-      iterations: 1000,
-      keySize: 16
-    };
-    const kdf = cryptoFramework.createKdf('PBKDF2|SHA1');
-    const secret = await kdf.generateSecret(spec);
-    return secret.data;
+    return this.crypto.pbkdf2Sha1Derive(password, this.salt, 1000, 16);
   }
 
-  /** HMAC-SHA1 计算（参照 TokenUtils.ets 的 genSymKeyByData/doHmacBySync 写法） */
+  /** HMAC-SHA1 计算（经 OathCryptoPort，生产为 cryptoFramework） */
   private async hmacSha1(key: Uint8Array, message: Uint8Array): Promise<Uint8Array> {
-    const keyBlob: cryptoFramework.DataBlob = { data: key };
-    const symKeyGenerator = cryptoFramework.createSymKeyGenerator('HMAC');
-    const symKey = symKeyGenerator.convertKeySync(keyBlob);
-    const mac = cryptoFramework.createMac('SHA1');
-    mac.initSync(symKey);
-    mac.updateSync({ data: message });
-    const macResult = mac.doFinalSync();
-    return macResult.data;
+    return this.crypto.hmacSha1(key, message);
   }
 
-  /** 生成 len 字节系统随机数 */
+  /** 生成 len 字节系统随机数（经 OathCryptoPort） */
   private randomBytes(len: number): Uint8Array {
-    const random = cryptoFramework.createRandom();
-    return random.generateRandomSync(len).data;
+    return this.crypto.randomBytes(len);
   }
 }

--- a/entry/src/ohosTest/ets/test/BackupRoundTrip.test.ets
+++ b/entry/src/ohosTest/ets/test/BackupRoundTrip.test.ets
@@ -1,0 +1,136 @@
+import { describe, beforeAll, it, expect } from '@ohos/hypium';
+import { abilityDelegatorRegistry } from '@kit.TestKit';
+import { common } from '@kit.AbilityKit';
+import { fileIo as fs } from '@kit.CoreFileKit';
+import {
+  AppPreference,
+  CloudBackupCrypto,
+  TokenBackup,
+  restoreFromBackup,
+  saveBackupToFile,
+  TokenConfig,
+  otpType,
+} from 'common';
+
+/**
+ * 真机备份 round-trip 冒烟（Phase 3，docs/TEST_PLAN.md 第 4 节出口条件）。
+ *
+ * LocalUnit 无法验证 cryptoFramework/base32/文件 IO 的数值正确性；
+ * 本套件在真机用生产实现做完整的 备份→恢复 回路，验证密文可解、
+ * 头部元信息可读、令牌数据无损、错误密码被拒绝。
+ * 用例只写临时文件并自清理，不清库、不触碰用户数据。
+ */
+export default function backupRoundTripTest(): void {
+  describe('BackupRoundTripDeviceTest', () => {
+    let context: common.UIAbilityContext;
+    let tempDir: string;
+
+    const makeToken = (uuid: string, name: string): TokenConfig => {
+      const token = new TokenConfig('JBSWY3DPEHPK3PXP', otpType.TOTP, name, 'RoundTripIssuer');
+      token.TokenUUID = uuid;
+      return token;
+    };
+
+    const cleanupFile = (filePath: string): void => {
+      try {
+        fs.unlinkSync(filePath);
+      } catch (_) {
+        // 清理失败不影响用例结果
+      }
+    };
+
+    beforeAll(async () => {
+      const delegator = abilityDelegatorRegistry.getAbilityDelegator();
+      const monitor: abilityDelegatorRegistry.AbilityMonitor = { abilityName: 'EntryAbility' };
+      await delegator.addAbilityMonitor(monitor);
+      await delegator.startAbility({
+        bundleName: abilityDelegatorRegistry.getArguments().bundleName,
+        abilityName: 'EntryAbility'
+      });
+      const ability = await delegator.waitAbilityMonitor(monitor, 20000);
+      context = ability.context as common.UIAbilityContext;
+      await delegator.removeAbilityMonitor(monitor);
+      AppStorage.setOrCreate('appContext', context);
+      await AppPreference.loadSettings();
+      tempDir = context.filesDir + '/test_backup_roundtrip';
+      try {
+        fs.mkdirSync(tempDir, true);
+      } catch (_) {
+        // 目录已存在
+      }
+    });
+
+    it('plaintext_backup_file_roundtrip_preserves_tokens', 0, async () => {
+      const token = makeToken('rt-plain-1', 'PlainRoundTrip');
+      const backup = new TokenBackup(1, [token]);
+      const filePath = `${tempDir}/plain.bak`;
+
+      try {
+        await saveBackupToFile(filePath, backup, false, '');
+        const restored = await restoreFromBackup(filePath, false, '');
+
+        expect(restored.magic).assertEqual(backup.magic);
+        expect(restored.configs.length).assertEqual(1);
+        expect(restored.configs[0].TokenUUID).assertEqual('rt-plain-1');
+        expect(restored.configs[0].TokenSecret).assertEqual('JBSWY3DPEHPK3PXP');
+      } finally {
+        cleanupFile(filePath);
+      }
+    });
+
+    it('encrypted_backup_file_roundtrip_with_password', 0, async () => {
+      const token = makeToken('rt-enc-1', 'EncRoundTrip');
+      const backup = new TokenBackup(1, [token]);
+      const filePath = `${tempDir}/enc.bak`;
+      const password = 'round-trip-pass-0';
+
+      try {
+        // 生产 encryptFile（cryptoFramework AES + PBKDF2）→ base32 落盘
+        await saveBackupToFile(filePath, backup, true, password);
+        expect(fs.accessSync(filePath)).assertTrue();
+
+        const restored = await restoreFromBackup(filePath, true, password);
+        expect(restored.configs.length).assertEqual(1);
+        expect(restored.configs[0].TokenUUID).assertEqual('rt-enc-1');
+      } finally {
+        cleanupFile(filePath);
+      }
+    });
+
+    it('encrypted_backup_rejects_wrong_password', 0, async () => {
+      const token = makeToken('rt-enc-2', 'EncRoundTrip2');
+      const backup = new TokenBackup(1, [token]);
+      const filePath = `${tempDir}/enc2.bak`;
+
+      try {
+        await saveBackupToFile(filePath, backup, true, 'correct-pass');
+        let threw = false;
+        try {
+          await restoreFromBackup(filePath, true, 'wrong-pass');
+        } catch (err) {
+          threw = true;
+        }
+        expect(threw).assertTrue();
+      } finally {
+        cleanupFile(filePath);
+      }
+    });
+
+    it('cloud_backup_crypto_roundtrip_preserves_header_and_payload', 0, async () => {
+      const crypto = CloudBackupCrypto.getInstance();
+      const mode = crypto.getMode(true);
+      const payload = '{"tokens":[{"TokenUUID":"rt-cloud-1","TokenSecret":"S"}],"groups":[]}';
+      const sealed = await crypto.encrypt(payload, mode, 'union-device-test', 2, 1726000000000, 'odid-rt', 'Mate60RT');
+
+      // 头部元信息可独立解析（云端列表页依赖，不解密载荷）
+      const header = crypto.parseTokenHeader(sealed);
+      expect(header.tokenCount).assertEqual(2);
+      expect(header.deviceId).assertEqual('odid-rt');
+      expect(header.deviceName).assertEqual('Mate60RT');
+
+      // 完整解密还原
+      const decrypted = await crypto.decrypt(sealed, mode, 'union-device-test');
+      expect(decrypted).assertEqual(payload);
+    });
+  });
+}

--- a/entry/src/ohosTest/ets/test/BleTransferSmoke.test.ets
+++ b/entry/src/ohosTest/ets/test/BleTransferSmoke.test.ets
@@ -1,0 +1,106 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { util } from '@kit.ArkTS';
+import {
+  decryptBlePayload,
+  encryptBlePayload,
+  TransferFrameBuilder,
+  TransferFrameEventKind,
+  TransferFrameOptions,
+  TransferFrameReceiver,
+  concatenateChunks,
+  utf8Decode,
+  utf8Encode,
+} from 'common';
+
+/**
+ * 真机 BLE 传输通道冒烟（Phase 3，docs/TEST_PLAN.md 第 4 节出口条件）。
+ *
+ * GATT 扫描/配对/写入部分归手工与页面联调；本套件在真机验证通道两端都依赖的
+ * 生产密码学与协议纯类：AES-256-GCM 载荷加解密回路、篡改载荷被拒、
+ * 分帧→重组回路在真机字节序下无损、纯 TS UTF-8 与系统 TextEncoder 一致。
+ */
+
+const BLE_MAX_CHUNK = 480;
+
+function bleReceiver(): TransferFrameReceiver {
+  return new TransferFrameReceiver({ headerPrefix: '', maxTotal: 512 * 1024 } as TransferFrameOptions);
+}
+
+export default function bleTransferSmokeTest(): void {
+  describe('BleTransferSmokeDeviceTest', () => {
+    it('ble_payload_encrypt_decrypt_roundtrip', 0, async () => {
+      // 生产 AES-256-GCM（[MAGIC][iv][tag][ciphertext]）加解密回路
+      const plain = utf8Encode('{"total":1,"tokens":[{"TokenSecret":"device-secret"}]}');
+      const sealed = await encryptBlePayload(plain);
+      // 密文比明文长（MAGIC+iv+tag 开销）
+      expect(sealed.byteLength > plain.byteLength).assertTrue();
+
+      const opened = await decryptBlePayload(sealed);
+      expect(opened !== null).assertTrue();
+      expect(utf8Decode(opened!)).assertEqual('{"total":1,"tokens":[{"TokenSecret":"device-secret"}]}');
+    });
+
+    it('ble_payload_tamper_is_rejected_by_gcm_tag', 0, async () => {
+      const plain = utf8Encode('tamper-detection-payload');
+      const sealed = await encryptBlePayload(plain);
+      // 翻转密文尾部一个字节 → GCM tag 校验必须失败（返回 null，丢弃且不入库）
+      const tampered = sealed.slice();
+      tampered[tampered.length - 1] = (tampered[tampered.length - 1] ^ 0x01) & 0xFF;
+      const opened = await decryptBlePayload(tampered);
+      expect(opened === null).assertTrue();
+    });
+
+    it('ble_frame_protocol_roundtrip_on_device', 0, async () => {
+      // 分帧→重组回路：1000 字节载荷跨三片，验证真机字节序下协议无损
+      const cipher = new Uint8Array(1000);
+      for (let i = 0; i < cipher.length; i++) {
+        cipher[i] = (i * 31 + 7) % 256;
+      }
+      const frames = new TransferFrameBuilder('', BLE_MAX_CHUNK).buildFrames(cipher, 5, 'tokens');
+      const receiver = bleReceiver();
+      let done = false;
+      let batchTotal = -1;
+      let byteIdentical = true;
+      const chunks: Array<Uint8Array> = [];
+      for (let i = 0; i < frames.length; i++) {
+        const event = receiver.onFrame(frames[i].bytes);
+        if (event.kind === TransferFrameEventKind.BATCH_COMPLETE) {
+          done = true;
+          batchTotal = event.batch!.total;
+          for (let j = 0; j < event.batch!.chunks.length; j++) {
+            chunks.push(event.batch!.chunks[j]);
+          }
+        }
+      }
+      const reassembled = done ? concatenateChunks(batchTotal, chunks) : new Uint8Array(0);
+      for (let i = 0; i < cipher.length; i++) {
+        if (reassembled[i] !== cipher[i]) {
+          byteIdentical = false;
+          break;
+        }
+      }
+      expect(done).assertTrue();
+      expect(batchTotal).assertEqual(1000);
+      expect(byteIdentical).assertTrue();
+    });
+
+    it('pure_ts_utf8_matches_system_text_encoder', 0, () => {
+      // 纯 TS UTF-8 与系统 util.TextEncoder 字节级一致（含多字节）
+      const samples = ['OHOTP', '中文令牌抽象', 'emoji 😀'];
+      const encoder = new util.TextEncoder();
+      for (const s of samples) {
+        const sys = encoder.encodeInto(s);
+        const own = utf8Encode(s);
+        expect(own.length).assertEqual(sys.length);
+        let same = true;
+        for (let i = 0; i < own.length; i++) {
+          if (own[i] !== sys[i]) {
+            same = false;
+            break;
+          }
+        }
+        expect(same).assertTrue();
+      }
+    });
+  });
+}

--- a/entry/src/ohosTest/ets/test/DeviceMigration.test.ets
+++ b/entry/src/ohosTest/ets/test/DeviceMigration.test.ets
@@ -1,0 +1,158 @@
+import { describe, beforeAll, it, expect } from '@ohos/hypium';
+import { abilityDelegatorRegistry } from '@kit.TestKit';
+import { common } from '@kit.AbilityKit';
+import {
+  AppPreference,
+  DeviceMigrationKv,
+  performBackup,
+  performRestore,
+  TokenConfig,
+  TokenStore,
+  otpType,
+} from 'common';
+
+/**
+ * 真机换机迁移冒烟（Phase 3，docs/TEST_PLAN.md 第 4 节出口条件）。
+ *
+ * performBackup/performRestore 的编排决策（成功才清空明文中转 KV、错误向上传播）
+ * 已在 LocalUnit 用内存端口穷举；本套件在真机验证默认 KvManager 生产适配器
+ * （distributedKVStore 加密 KV ↔ 非加密 KV）可初始化、可同步往返、返回计数合理。
+ *
+ * 已知风险（红方评审标记，待真机核实）：生产扫描用 getEntries('^')（键前缀语义），
+ * 而令牌键以 _token_uuid_ 开头——若分布式 KV 内部键形态不含 '^' 前缀，迁移会静默
+ * 空转。roundtrip 用例用自种令牌 + backupCount > 0 硬护栏暴露该风险。
+ */
+
+/** 注入用假实现：copyToEncrypt 失败，验证恢复失败时不清理明文中转 */
+class FailingRestoreKv implements DeviceMigrationKv {
+  calls: string[] = [];
+
+  initForBackup(_ctx: common.Context): Promise<void> {
+    this.calls.push('init');
+    return Promise.resolve();
+  }
+
+  copyToNoEncrypt(): Promise<number> {
+    this.calls.push('backup');
+    return Promise.resolve(3);
+  }
+
+  copyToEncrypt(): Promise<number> {
+    this.calls.push('restore');
+    return Promise.reject(new Error('restore boom'));
+  }
+
+  clearNoEncrypt(): Promise<void> {
+    this.calls.push('clear');
+    return Promise.resolve();
+  }
+}
+
+/** 注入用假实现：init 即失败，验证 BackupExtension 依赖的错误传播契约 */
+class FailingInitKv implements DeviceMigrationKv {
+  initForBackup(_ctx: common.Context): Promise<void> {
+    return Promise.reject(new Error('kv init boom'));
+  }
+
+  copyToNoEncrypt(): Promise<number> {
+    return Promise.resolve(0);
+  }
+
+  copyToEncrypt(): Promise<number> {
+    return Promise.resolve(0);
+  }
+
+  clearNoEncrypt(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+export default function deviceMigrationTest(): void {
+  describe('DeviceMigrationDeviceTest', () => {
+    let context: common.UIAbilityContext;
+    let seedToken: TokenConfig;
+    const ownedIds: string[] = [];
+
+    beforeAll(async () => {
+      const delegator = abilityDelegatorRegistry.getAbilityDelegator();
+      const monitor: abilityDelegatorRegistry.AbilityMonitor = { abilityName: 'EntryAbility' };
+      await delegator.addAbilityMonitor(monitor);
+      await delegator.startAbility({
+        bundleName: abilityDelegatorRegistry.getArguments().bundleName,
+        abilityName: 'EntryAbility'
+      });
+      const ability = await delegator.waitAbilityMonitor(monitor, 20000);
+      context = ability.context as common.UIAbilityContext;
+      await delegator.removeAbilityMonitor(monitor);
+      AppStorage.setOrCreate('appContext', context);
+      await AppPreference.loadSettings();
+      await TokenStore.getInstance().initTokenStore();
+      await TokenStore.getInstance().LoadTokenByDataBase();
+    });
+
+    afterEach(async () => {
+      // 兜底清理测试令牌（断言失败中断也不留脏数据）
+      const store = TokenStore.getInstance();
+      for (const uuid of ownedIds) {
+        try {
+          await store.deleteToken(uuid);
+        } catch (_) {
+          // 清理失败不掩盖用例结果
+        }
+      }
+    });
+
+    it('perform_backup_syncs_to_non_encrypt_kv', 0, async () => {
+      // 生产适配器直通：加密 KV → 非加密 KV。自种令牌保证库非空，护栏 count > 0
+      const store = TokenStore.getInstance();
+      seedToken = new TokenConfig('JBSWY3DPEHPK3PXP', otpType.TOTP, 'MigrationSeed', 'MigrationSmokeIssuer');
+      ownedIds.push(seedToken.TokenUUID);
+      await store.updateToken(seedToken);
+
+      const count = await performBackup(context);
+      expect(Number.isFinite(count)).assertTrue();
+      expect(count > 0).assertTrue();
+    });
+
+    it('perform_restore_roundtrip_returns_matching_count', 0, async () => {
+      // 备份 → 恢复往返：单机无对端传输时，恢复读到的正是刚备份写入的条目；
+      // 恢复成功（count>0）后明文中转被清空（生产编排决策）。
+      // backupCount > 0 护栏防止 0==0 空转通过（getEntries('^') 风险探测）
+      const store = TokenStore.getInstance();
+      seedToken = new TokenConfig('JBSWY3DPEHPK3PXP', otpType.TOTP, 'MigrationRoundTrip', 'MigrationSmokeIssuer');
+      ownedIds.push(seedToken.TokenUUID);
+      await store.updateToken(seedToken);
+
+      const backupCount = await performBackup(context);
+      expect(backupCount > 0).assertTrue();
+      const restoreCount = await performRestore(context);
+      expect(Number.isFinite(restoreCount)).assertTrue();
+      expect(restoreCount).assertEqual(backupCount);
+    });
+
+    it('restore_failure_does_not_clear_staging_kv', 0, async () => {
+      // 设备侧固化编排契约：copyToEncrypt 抛错时向上传播，且不走 clearNoEncrypt
+      const failingKv = new FailingRestoreKv();
+      let threw = false;
+      try {
+        await performRestore(context, failingKv);
+      } catch (err) {
+        threw = true;
+      }
+      expect(threw).assertTrue();
+      expect(failingKv.calls.join(',')).assertEqual('init,restore');
+    });
+
+    it('backup_failure_propagates_error_to_extension', 0, async () => {
+      // BackupExtension 依赖 performBackup 抛错感知失败：错误必须穿透而非被吞
+      const failingKv = new FailingInitKv();
+      let threw = false;
+      try {
+        await performBackup(context, failingKv);
+      } catch (err) {
+        threw = true;
+      }
+      expect(threw).assertTrue();
+    });
+  });
+}

--- a/entry/src/ohosTest/ets/test/List.test.ets
+++ b/entry/src/ohosTest/ets/test/List.test.ets
@@ -4,6 +4,10 @@ import tokenBatchTest from './TokenBatch.test';
 import assetConcurrencyTest from './AssetConcurrency.test';
 import tokenProgressDialogTest from './TokenProgressDialog.test';
 import steamSecretStoreTest from './SteamSecretStore.test';
+import backupRoundTripTest from './BackupRoundTrip.test';
+import deviceMigrationTest from './DeviceMigration.test';
+import bleTransferSmokeTest from './BleTransferSmoke.test';
+import wearEngineSmokeTest from './WearEngineSmoke.test';
 
 export default function testsuite() {
   abilityTest();
@@ -12,4 +16,8 @@ export default function testsuite() {
   assetConcurrencyTest();
   tokenProgressDialogTest();
   steamSecretStoreTest();
+  backupRoundTripTest();
+  deviceMigrationTest();
+  bleTransferSmokeTest();
+  wearEngineSmokeTest();
 }

--- a/entry/src/ohosTest/ets/test/WearEngineSmoke.test.ets
+++ b/entry/src/ohosTest/ets/test/WearEngineSmoke.test.ets
@@ -1,0 +1,159 @@
+import { describe, beforeAll, it, expect } from '@ohos/hypium';
+import { abilityDelegatorRegistry } from '@kit.TestKit';
+import { common } from '@kit.AbilityKit';
+import {
+  AppPreference,
+  PREF_KEYS,
+  SettingValuePair,
+  TokenConfig,
+  TokenStore,
+  WEAR_SYNC_PREF_KEYS,
+  applyWearSettings,
+  saveTokensBatch,
+  TransferFrameBuilder,
+  TransferFrameEventKind,
+  TransferFrameOptions,
+  TransferFrameReceiver,
+  concatenateChunks,
+  otpType,
+} from 'common';
+
+/**
+ * 真机 WearEngine 通道冒烟（Phase 3，docs/TEST_PLAN.md 第 4 节出口条件）。
+ *
+ * P2P 设备发现/拉起手表应用/消息收发归真机手工与页面联调（需真实手表）；
+ * 本套件在真机验证手机/手表两端共享的入库与应用逻辑：
+ * 设置白名单过滤写入真实 preferences、令牌批次 issuer+name UUID 复用防重复、
+ * OTPW 分帧协议重组回路。
+ */
+
+const WEAR_PREFIX = 'OTPW';
+
+function wearReceiver(): TransferFrameReceiver {
+  return new TransferFrameReceiver({ headerPrefix: WEAR_PREFIX, maxTotal: 0 } as TransferFrameOptions);
+}
+
+export default function wearEngineSmokeTest(): void {
+  describe('WearEngineSmokeDeviceTest', () => {
+    let context: common.UIAbilityContext;
+    const ownedIds: string[] = [];
+
+    const makeToken = (secret: string, name: string): TokenConfig => {
+      const token = new TokenConfig(secret, otpType.TOTP, name, 'WearSmokeIssuer');
+      ownedIds.push(token.TokenUUID);
+      return token;
+    };
+
+    beforeAll(async () => {
+      const delegator = abilityDelegatorRegistry.getAbilityDelegator();
+      const monitor: abilityDelegatorRegistry.AbilityMonitor = { abilityName: 'EntryAbility' };
+      await delegator.addAbilityMonitor(monitor);
+      await delegator.startAbility({
+        bundleName: abilityDelegatorRegistry.getArguments().bundleName,
+        abilityName: 'EntryAbility'
+      });
+      const ability = await delegator.waitAbilityMonitor(monitor, 20000);
+      context = ability.context as common.UIAbilityContext;
+      await delegator.removeAbilityMonitor(monitor);
+      AppStorage.setOrCreate('appContext', context);
+      await AppPreference.loadSettings();
+      await TokenStore.getInstance().initTokenStore();
+      await TokenStore.getInstance().LoadTokenByDataBase();
+    });
+
+    it('wear_settings_whitelist_filters_and_applies', 0, async () => {
+      // 白名单键真实写入 preferences；白名单外键被拒。偏好改动在 finally 还原
+      const keepKey = PREF_KEYS.APPEARANCE_SHOW_NEXT_TOKEN_ENABLE;
+      const original = AppPreference.getPreference(keepKey);
+      try {
+        const pairs: Array<SettingValuePair> = [
+          { key: keepKey, value: true },
+          { key: 'NOT_IN_WHITELIST', value: 'should-be-ignored' },
+        ];
+        const applied = await applyWearSettings(pairs);
+        expect(applied).assertEqual(1);
+        expect(AppPreference.getPreference(keepKey)).assertEqual(true);
+      } finally {
+        AppPreference.setPreference(keepKey, original);
+      }
+    });
+
+    it('wear_sync_pref_keys_unique_and_nonempty', 0, () => {
+      // 白名单键非空且无重复（手表端按这些键刷新 UI；键与 TokenPreference 字段的一致性由代码评审保证）
+      expect(WEAR_SYNC_PREF_KEYS.length > 0).assertTrue();
+      const seen: Set<string> = new Set();
+      for (const key of WEAR_SYNC_PREF_KEYS) {
+        expect(key.length > 0).assertTrue();
+        seen.add(key);
+      }
+      expect(seen.size).assertEqual(WEAR_SYNC_PREF_KEYS.length);
+    });
+
+    it('wear_token_batch_reuses_local_uuid_no_duplicates', 0, async () => {
+      // 本地已有 A 令牌；批次携带同 issuer+name、不同 UUID 的 B 令牌。
+      // 真实写入 TokenStore/ASSET，清理放 finally 保证断言失败也不留测试数据
+      const store = TokenStore.getInstance();
+
+      const local = makeToken('JBSWY3DPEHPK3PXP', 'WearSmokeA');
+      try {
+        await store.updateToken(local);
+
+        const incoming = new TokenConfig('JBSWY3DPEHPK3PXP', otpType.TOTP, 'WearSmokeA', 'WearSmokeIssuer');
+        incoming.TokenUUID = 'wear-side-generated-uuid';
+        const saved = await saveTokensBatch([incoming]);
+
+        expect(saved).assertEqual(1);
+        const after = await store.getTokens();
+        const matches = after.filter(t => t.TokenIssuer === 'WearSmokeIssuer' && t.TokenName === 'WearSmokeA');
+        // UUID 复用：同名令牌只有一条，且保留本地 UUID（防手机/手表双 UUID 重复）
+        expect(matches.length).assertEqual(1);
+        expect(matches[0].TokenUUID).assertEqual(local.TokenUUID);
+      } finally {
+        for (const uuid of ownedIds) {
+          try {
+            await store.deleteToken(uuid);
+          } catch (_) {
+            // 清理失败不掩盖用例结果（TokenBatch 套件同约定）
+          }
+        }
+      }
+    });
+
+    it('wear_frame_protocol_roundtrip_with_prefix', 0, () => {
+      // OTPW 分帧协议（首帧前缀 + 4000B 分片）真机重组回路
+      const cipher = new Uint8Array(5200);
+      for (let i = 0; i < cipher.length; i++) {
+        cipher[i] = (i * 17) % 256;
+      }
+      const frames = new TransferFrameBuilder(WEAR_PREFIX, 4000).buildFrames(cipher, 26, 'settings');
+      const receiver = wearReceiver();
+      let done = false;
+      let batchTotal = -1;
+      let batchType = '';
+      const chunks: Array<Uint8Array> = [];
+      for (let i = 0; i < frames.length; i++) {
+        const event = receiver.onFrame(frames[i].bytes);
+        if (event.kind === TransferFrameEventKind.BATCH_COMPLETE) {
+          done = true;
+          batchTotal = event.batch!.total;
+          batchType = event.batch!.type;
+          for (let j = 0; j < event.batch!.chunks.length; j++) {
+            chunks.push(event.batch!.chunks[j]);
+          }
+        }
+      }
+      expect(done).assertTrue();
+      expect(batchTotal).assertEqual(5200);
+      expect(batchType).assertEqual('settings');
+      const reassembled = concatenateChunks(batchTotal, chunks);
+      let identical = true;
+      for (let i = 0; i < cipher.length; i++) {
+        if (reassembled[i] !== cipher[i]) {
+          identical = false;
+          break;
+        }
+      }
+      expect(identical).assertTrue();
+    });
+  });
+}

--- a/entry/src/test/AppPreference.test.ets
+++ b/entry/src/test/AppPreference.test.ets
@@ -1,0 +1,193 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { AppStorageV2 } from '@kit.ArkUI';
+import {
+  AppPreference,
+  AVAILABLE_BOTTOM_TABS_TYPES,
+  AVAILABLE_HIDDEN_TOKEN_TYPES,
+  AVAILABLE_IMMERSIVE_STYLES,
+  AVAILABLE_TOKEN_PROGRESS_TYPES,
+  AVAILABLE_TOKEN_SEPARATORS,
+  AVAILABLE_TOP_EFFECT_TYPES,
+  BUILTIN_DEFAULT_PACK_ID,
+  EVENT_NAMES,
+  EXTERNAL_URLS,
+  PREF_KEYS,
+  ROUTE_NAMES,
+  SettingBottomTabsType,
+  SettingColorMode,
+  SettingHiddenTokenType,
+  SettingImmersiveStyle,
+  SettingTokenProgressType,
+  SettingTokenSeparator,
+  SettingTopEffectType,
+  TokenPreference,
+} from 'common';
+
+/**
+ * AppPreference 纯部分测试：默认值缓存、枚举/选项数组一致性、路由与外链常量。
+ *
+ * LocalUnit 下 PreferenceManager 未初始化（无 appContext），
+ * getValueSync 恒返回 null——因此仅默认值 Map 内的键可离线读取，
+ * 走 setPreference 的用例必须留给真机（会触发 preferences API）。
+ */
+export default function appPreferenceTest() {
+  describe('appPreferenceTest', () => {
+    it('enum_numeric_values_are_stable_contract', 0, () => {
+      // 这些值会持久化到 preferences，变化等于用户设置错乱
+      expect(SettingColorMode.System).assertEqual(0);
+      expect(SettingColorMode.Dark).assertEqual(1);
+      expect(SettingColorMode.Light).assertEqual(2);
+
+      expect(SettingTokenSeparator.NONE).assertEqual(0);
+      expect(SettingTokenSeparator.SPACE).assertEqual(1);
+      expect(SettingTokenSeparator.DOT).assertEqual(2);
+
+      expect(SettingHiddenTokenType.COMPACT).assertEqual(0);
+      expect(SettingHiddenTokenType.STANDARD).assertEqual(1);
+
+      expect(SettingTokenProgressType.LINEAR).assertEqual(0);
+      expect(SettingTokenProgressType.RING).assertEqual(1);
+      expect(SettingTokenProgressType.SCALE_RING).assertEqual(3);
+
+      expect(SettingTopEffectType.DISABLE).assertEqual(0);
+      expect(SettingTopEffectType.IMMERSIVE_GRADIENT_BLUR).assertEqual(4);
+
+      expect(SettingBottomTabsType.FLATTEN).assertEqual(0);
+      expect(SettingBottomTabsType.SUSPENSION).assertEqual(1);
+
+      expect(SettingImmersiveStyle.ULTRA_THIN).assertEqual(0);
+      expect(SettingImmersiveStyle.THICK).assertEqual(3);
+      expect(SettingImmersiveStyle.ULTRA_THICK).assertEqual(4);
+    });
+
+    it('get_preference_returns_defaults_from_cache', 0, () => {
+      expect(AppPreference.getPreference(PREF_KEYS.SAFETY_PRIVACY_ENABLE) as boolean).assertFalse();
+      expect(AppPreference.getPreference(PREF_KEYS.SAFETY_LOCK_ENABLE) as boolean).assertFalse();
+      expect(AppPreference.getPreference(PREF_KEYS.SAFETY_BACKGROUND_BLUR_ENABLE) as boolean).assertFalse();
+      expect(AppPreference.getPreference(PREF_KEYS.SHOW_GUIDE_TIPS) as boolean).assertTrue();
+      expect(AppPreference.getPreference(PREF_KEYS.DEBUG_MODE_ON) as boolean).assertFalse();
+      expect(AppPreference.getPreference(PREF_KEYS.WANT_URI) as string).assertEqual('');
+      expect(AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME) as string).assertEqual('0');
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_COLOR_MODE) as number)
+        .assertEqual(SettingColorMode.System);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_IMMERSIVE_ENABLE) as boolean).assertTrue();
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_IMMERSIVE_STYLE) as number)
+        .assertEqual(SettingImmersiveStyle.THICK);
+    });
+
+    it('appearance_defaults_match_design_baseline', 0, () => {
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_ITEM_HEIGHT) as number).assertEqual(60);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_ITEM_SPACE) as number).assertEqual(10);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_ITEM_RADIUS) as number).assertEqual(16);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_ITEM_MAX_WIDTH) as number).assertEqual(800);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_FONT_SIZE) as number).assertEqual(30);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_LONG_PRESS_DURATION) as number).assertEqual(300);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_COLOR) as number).assertEqual(0xFF254ff7);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_COLOR_DARK) as number).assertEqual(0xFF638FF6);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_SEPARATOR) as number)
+        .assertEqual(SettingTokenSeparator.NONE);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_HIDDEN_TOKEN_TYPE) as number)
+        .assertEqual(SettingHiddenTokenType.STANDARD);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOKEN_PROGRESS_TYPE) as number)
+        .assertEqual(SettingTokenProgressType.LINEAR);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_TOP_EFFECT_TYPE) as number)
+        .assertEqual(SettingTopEffectType.IMMERSIVE_GRADIENT_BLUR);
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_BOTTOM_TABS_TYPE) as number)
+        .assertEqual(SettingBottomTabsType.SUSPENSION);
+    });
+
+    it('option_arrays_cover_their_enums_exactly', 0, () => {
+      expect(AVAILABLE_TOKEN_SEPARATORS.map(o => o.value).join(',')).assertEqual(
+        [SettingTokenSeparator.NONE, SettingTokenSeparator.SPACE, SettingTokenSeparator.DOT].join(','));
+      expect(AVAILABLE_HIDDEN_TOKEN_TYPES.map(o => o.value).join(',')).assertEqual(
+        [SettingHiddenTokenType.COMPACT, SettingHiddenTokenType.STANDARD].join(','));
+      expect(AVAILABLE_TOKEN_PROGRESS_TYPES.map(o => o.value).join(',')).assertEqual(
+        [SettingTokenProgressType.LINEAR, SettingTokenProgressType.RING,
+          SettingTokenProgressType.SCALE_RING].join(','));
+      expect(AVAILABLE_BOTTOM_TABS_TYPES.map(o => o.value).join(',')).assertEqual(
+        [SettingBottomTabsType.FLATTEN, SettingBottomTabsType.SUSPENSION].join(','));
+      expect(AVAILABLE_IMMERSIVE_STYLES.map(o => o.value).join(',')).assertEqual(
+        [SettingImmersiveStyle.ULTRA_THIN, SettingImmersiveStyle.THIN, SettingImmersiveStyle.REGULAR,
+          SettingImmersiveStyle.THICK, SettingImmersiveStyle.ULTRA_THICK].join(','));
+      // 顶部模糊当前只暴露 4 项（DISABLE 不进设置列表）
+      expect(AVAILABLE_TOP_EFFECT_TYPES.map(o => o.value).join(',')).assertEqual(
+        [SettingTopEffectType.COMMON_BLUR, SettingTopEffectType.GRADUAL_BLUR,
+          SettingTopEffectType.GRADIENT_BLUR, SettingTopEffectType.IMMERSIVE_GRADIENT_BLUR].join(','));
+      // 每个选项必须带非空文案
+      for (const option of AVAILABLE_TOKEN_SEPARATORS.concat(AVAILABLE_HIDDEN_TOKEN_TYPES)
+        .concat(AVAILABLE_TOKEN_PROGRESS_TYPES).concat(AVAILABLE_TOP_EFFECT_TYPES)
+        .concat(AVAILABLE_BOTTOM_TABS_TYPES).concat(AVAILABLE_IMMERSIVE_STYLES)) {
+        expect(option.label !== undefined && option.label !== '').assertTrue();
+      }
+    });
+
+    it('pref_keys_have_no_value_collisions', 0, () => {
+      // 键名冲突会让两个设置共享同一存储槽
+      const keys = [
+        PREF_KEYS.DEBUG_MODE_ON, PREF_KEYS.SAFETY_LOCK_ENABLE, PREF_KEYS.SAFETY_PRIVACY_ENABLE,
+        PREF_KEYS.APPEARANCE_COLOR_MODE, PREF_KEYS.APPEARANCE_ITEM_HEIGHT, PREF_KEYS.WANT_URI,
+        PREF_KEYS.DB_RDS_SYNC_ENABLE, PREF_KEYS.CLOUD_SYNC_LAST_TIME, PREF_KEYS.SHOW_GUIDE_TIPS,
+        PREF_KEYS.APPEARANCE_IMMERSIVE_ENABLE, PREF_KEYS.APPEARANCE_IMMERSIVE_STYLE,
+        PREF_KEYS.MASTER_KEY_DEPRECATION_ACKNOWLEDGED, PREF_KEYS.ASSET_MIGRATION_DONE,
+      ];
+      const unique = new Set<string>(keys);
+      expect(unique.size).assertEqual(keys.length);
+      for (const key of keys) {
+        expect(key.startsWith('app_')).assertTrue();
+      }
+    });
+
+    it('event_names_are_unique_snake_actions', 0, () => {
+      const names = [
+        EVENT_NAMES.TOKEN_CHANGED, EVENT_NAMES.KV_STORE_SYNC_COMPLETE, EVENT_NAMES.FILE_DROP,
+        EVENT_NAMES.ICON_PACK_CHANGED, EVENT_NAMES.OPEN_STEAM_CONFIRMATIONS,
+        EVENT_NAMES.HUAWEI_ACCOUNT_STATE_CHANGED, EVENT_NAMES.DEBUG_MODE_CHANGED,
+      ];
+      const unique = new Set<string>(names);
+      expect(unique.size).assertEqual(names.length);
+    });
+
+    it('route_names_and_external_urls_are_well_formed', 0, () => {
+      expect(ROUTE_NAMES.AppearancePage.length > 0).assertTrue();
+      expect(ROUTE_NAMES.IndexPage).assertEqual('pages/Index');
+      expect(ROUTE_NAMES.SettingBackup).assertEqual('setting/backup');
+      expect(ROUTE_NAMES.AddSteamTokenPage).assertEqual('AddSteamTokenPage');
+
+      expect(EXTERNAL_URLS.FEEDBACK_GITHUB.startsWith('https://github.com/OHOTP/')).assertTrue();
+      expect(EXTERNAL_URLS.REPO_HOME.startsWith('https://')).assertTrue();
+      expect(EXTERNAL_URLS.OSS_LIBCOTP.startsWith('https://')).assertTrue();
+    });
+
+    it('enabled_packs_default_to_builtin_without_migration', 0, () => {
+      // LocalUnit 下未持久化过图标包键 → 默认仅内置包
+      expect(AppPreference.loadEnabledPacks().join(',')).assertEqual(BUILTIN_DEFAULT_PACK_ID);
+      expect(AppPreference.hasEnabledPacksMigrated()).assertFalse();
+      expect(AppPreference.getLegacySelectedPack()).assertEqual(0);
+    });
+
+    it('unknown_key_without_default_reads_empty_in_localunit', 0, () => {
+      // APPEARANCE_ICON_PACK_ENABLED 不在默认值 Map 中：
+      // 生产走 preferences 读取；LocalUnit 下 PreferenceManager 未初始化，返回空串
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_ICON_PACK_ENABLED) as string).assertEqual('');
+    });
+
+    it('load_settings_pushes_defaults_into_token_preference_state', 0, async () => {
+      // LocalUnit 无持久化偏好：loadSettings 等价于“全新安装”，
+      // 默认值 Map 应原样流入 AppStorageV2 的 TokenPreference（UI 绑定源）。
+      await AppPreference.loadSettings();
+
+      const appearance = AppStorageV2.connect(TokenPreference, () => new TokenPreference())!;
+      expect(appearance.app_appearance_item_height).assertEqual(60);
+      expect(appearance.app_appearance_item_radius).assertEqual(16);
+      expect(appearance.app_appearance_token_font_size).assertEqual(30);
+      expect(appearance.app_appearance_issuer_font_size).assertEqual(18);
+      expect(appearance.app_appearance_token_separator).assertEqual(SettingTokenSeparator.NONE);
+      expect(appearance.app_appearance_hidden_token_type).assertEqual(SettingHiddenTokenType.STANDARD);
+      expect(appearance.app_appearance_token_progress_type).assertEqual(SettingTokenProgressType.LINEAR);
+      expect(appearance.app_appearance_token_color).assertEqual(0xFF254ff7);
+      expect(appearance.app_appearance_chain_animation_enable).assertTrue();
+      // 长按时长夹取到 [200, 1000]
+      expect(appearance.app_appearance_long_press_duration).assertEqual(300);
+    });
+  });
+}

--- a/entry/src/test/BackupRestoreHelper.test.ets
+++ b/entry/src/test/BackupRestoreHelper.test.ets
@@ -1,0 +1,104 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { common } from '@kit.AbilityKit';
+import { DeviceMigrationKv, performBackup, performRestore } from 'common';
+
+/**
+ * 换机备份/恢复编排测试（Phase 2 DeviceMigrationKv 端口注入）。
+ *
+ * 核心决策：恢复仅在成功（count > 0）时清理非加密 KV 中转数据，
+ * 失败路径保留唯一数据副本；错误向上传播由 BackupExtension 感知。
+ */
+
+class FakeMigrationKv implements DeviceMigrationKv {
+  initCalls: number = 0;
+  copyToNoEncryptResult: number = 0;
+  copyToEncryptResult: number = 0;
+  failCopyToNoEncrypt: boolean = false;
+  failCopyToEncrypt: boolean = false;
+  clearCalls: number = 0;
+
+  initForBackup(_ctx: common.Context): Promise<void> {
+    this.initCalls++;
+    return Promise.resolve();
+  }
+
+  copyToNoEncrypt(): Promise<number> {
+    if (this.failCopyToNoEncrypt) {
+      return Promise.reject(new Error('backup copy failed'));
+    }
+    return Promise.resolve(this.copyToNoEncryptResult);
+  }
+
+  copyToEncrypt(): Promise<number> {
+    if (this.failCopyToEncrypt) {
+      return Promise.reject(new Error('restore copy failed'));
+    }
+    return Promise.resolve(this.copyToEncryptResult);
+  }
+
+  clearNoEncrypt(): Promise<void> {
+    this.clearCalls++;
+    return Promise.resolve();
+  }
+}
+
+// 编排层不对 ctx 解引用（生产语义：透传给 KvManager 初始化），假上下文即可。
+const FAKE_CTX = new Object() as common.Context;
+
+export default function backupRestoreHelperTest() {
+  describe('backupRestoreHelperTest', () => {
+    it('perform_backup_returns_count_and_initializes', 0, async () => {
+      const kv = new FakeMigrationKv();
+      kv.copyToNoEncryptResult = 42;
+
+      const count = await performBackup(FAKE_CTX, kv);
+      expect(count).assertEqual(42);
+      expect(kv.initCalls).assertEqual(1);
+      // 备份后不清空非加密 KV：系统还要传输该文件
+      expect(kv.clearCalls).assertEqual(0);
+    });
+
+    it('perform_backup_error_propagates', 0, async () => {
+      const kv = new FakeMigrationKv();
+      kv.failCopyToNoEncrypt = true;
+
+      let threw = false;
+      try {
+        await performBackup(FAKE_CTX, kv);
+      } catch (e) {
+        threw = (e as Error).message === 'backup copy failed';
+      }
+      expect(threw).assertTrue();
+    });
+
+    it('perform_restore_clears_staging_only_on_success', 0, async () => {
+      const kv = new FakeMigrationKv();
+      kv.copyToEncryptResult = 7;
+
+      const count = await performRestore(FAKE_CTX, kv);
+      expect(count).assertEqual(7);
+      expect(kv.clearCalls).assertEqual(1);
+
+      // count == 0：保留唯一数据副本，不清空
+      const empty = new FakeMigrationKv();
+      empty.copyToEncryptResult = 0;
+      const zero = await performRestore(FAKE_CTX, empty);
+      expect(zero).assertEqual(0);
+      expect(empty.clearCalls).assertEqual(0);
+    });
+
+    it('perform_restore_error_propagates_without_clear', 0, async () => {
+      const kv = new FakeMigrationKv();
+      kv.failCopyToEncrypt = true;
+
+      let threw = false;
+      try {
+        await performRestore(FAKE_CTX, kv);
+      } catch (e) {
+        threw = true;
+      }
+      expect(threw).assertTrue();
+      expect(kv.clearCalls).assertEqual(0);
+    });
+  });
+}

--- a/entry/src/test/Base64Util.test.ets
+++ b/entry/src/test/Base64Util.test.ets
@@ -1,0 +1,51 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { Base64Util } from 'common';
+import { utf8ToBytes } from '../main/ets/steam/SteamCrypto';
+
+/**
+ * Base64Util 测试——同时固化一项 LocalUnit 运行时实测结论：
+ *
+ * `util.Base64Helper`（@ohos.util）在 LocalUnit / Previewer 运行时下
+ * **静默返回空数据**（不抛异常）：encodeToStringSync 返回 ''、decodeSync 返回空数组。
+ *
+ * 结论（2026-09-11 实测）：
+ * - CloudBackupCrypto 的 base64 已改为注入 Base64Codec，测试注入纯 TS 实现；
+ * - 纯 TS base64 语义由 SteamCrypto（base64Encode/base64Decode）的用例覆盖；
+ * - Base64Helper 的真实编解码行为归 ohosTest 真机回归。
+ *
+ * 若未来 LocalUnit 支持了 Base64Helper，本套件中的
+ * localunit_stub_* 用例会开始失败——届时应移除 stub 断言并补上真实向量。
+ */
+export default function base64UtilTest() {
+  describe('base64UtilTest', () => {
+    it('localunit_stub_encode_returns_empty_string', 0, () => {
+      // LocalUnit 下 Base64Helper.encodeToStringSync 静默返回空
+      expect(Base64Util.encodeToStrSync(utf8ToBytes('foobar'))).assertEqual('');
+    });
+
+    it('localunit_stub_decode_returns_empty_bytes', 0, () => {
+      const decoded = Base64Util.decodeSync('Zm9vYmFy');
+      expect(decoded.length).assertEqual(0);
+    });
+
+    it('null_and_undefined_encode_to_empty_string', 0, () => {
+      // 空值守卫在触碰 Base64Helper 之前返回，真机/LocalUnit 行为一致
+      expect(Base64Util.encodeToStrSync(null)).assertEqual('');
+      expect(Base64Util.encodeToStrSync(undefined)).assertEqual('');
+    });
+
+    it('empty_string_decode_is_safe', 0, () => {
+      expect(Base64Util.decodeSync('').length).assertEqual(0);
+    });
+
+    it('async_entrypoints_resolve_without_throwing', 0, async () => {
+      // LocalUnit 下异步包装同样静默返回空；契约是 Promise 正常 resolve 不抛异常
+      const encoded = await Base64Util.encode(utf8ToBytes('data'));
+      const text = await Base64Util.encodeToStr(utf8ToBytes('data'));
+      const decoded = await Base64Util.decode('Zm9vYmFy');
+      expect(encoded.length).assertEqual(0);
+      expect(text).assertEqual('');
+      expect(decoded.length).assertEqual(0);
+    });
+  });
+}

--- a/entry/src/test/CloudBackupCrypto.test.ets
+++ b/entry/src/test/CloudBackupCrypto.test.ets
@@ -1,0 +1,271 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { buffer } from '@kit.ArkTS';
+import {
+  BackupCryptoEngine,
+  Base64Codec,
+  CloudBackupCrypto,
+  CloudBackupCryptoMode,
+  CloudBackupTokenError,
+  CloudBackupTokenHeader,
+} from 'common';
+import { sha256 } from '../main/ets/crypto/PureHash';
+import { base64Decode, base64Encode, utf8ToBytes } from '../main/ets/steam/SteamCrypto';
+
+/**
+ * 云备份加密编排逻辑测试（注入纯 TS 引擎与编解码器，无 cryptoFramework/Base64Helper）。
+ *
+ * cryptoFramework 与 util.Base64Helper 在 LocalUnit 下都静默返回空数据，
+ * 因此 AES/PBKDF2 数值正确性归 ohosTest 真机回归；这里用可逆 XOR 引擎覆盖
+ * 三段式格式、签名校验、mock 旧格式兼容与错误分支。签名段用 PureHash 的真实 SHA-256。
+ */
+
+function bytesToHex(data: Uint8Array): string {
+  let hex = '';
+  for (let i = 0; i < data.length; i++) {
+    hex += data[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+/** 纯 TS base64 编解码（SteamCrypto），绕开 LocalUnit 下静默失效的 util.Base64Helper */
+class PureTsCodec implements Base64Codec {
+  encodeText(text: string): string {
+    return base64Encode(utf8ToBytes(text));
+  }
+
+  decodeText(base64Str: string): string {
+    return buffer.from(base64Decode(base64Str)).toString('utf-8');
+  }
+
+  encodeBytes(data: Uint8Array): string {
+    return base64Encode(data);
+  }
+
+  decodeBytes(base64Str: string): Uint8Array {
+    return base64Decode(base64Str);
+  }
+}
+
+class XorBackupEngine implements BackupCryptoEngine {
+  round: number = 0;
+
+  randomBytes(length: number): Uint8Array {
+    // 确定性伪随机：每次调用递增轮次，保证两次加密的 salt/iv 不同且可复现
+    const out = new Uint8Array(length);
+    for (let i = 0; i < length; i++) {
+      out[i] = (this.round * 37 + i * 13 + 5) & 0xff;
+    }
+    this.round++;
+    return out;
+  }
+
+  async sha256Hex(data: string): Promise<string> {
+    return bytesToHex(sha256(utf8ToBytes(data)));
+  }
+
+  async aesCbcEncrypt(plaintext: Uint8Array, password: string, salt: Uint8Array,
+    iv: Uint8Array): Promise<Uint8Array> {
+    return this.xor(plaintext, password, salt, iv);
+  }
+
+  async aesCbcDecrypt(ciphertext: Uint8Array, password: string, salt: Uint8Array,
+    iv: Uint8Array): Promise<Uint8Array> {
+    return this.xor(ciphertext, password, salt, iv);
+  }
+
+  /** 可逆 XOR：密钥流由 password+salt+iv 派生，错误密钥必然产生不同明文 */
+  private xor(data: Uint8Array, password: string, salt: Uint8Array, iv: Uint8Array): Uint8Array {
+    const material = utf8ToBytes(password + ':' + bytesToHex(salt) + bytesToHex(iv));
+    const pad = sha256(material);
+    const out = new Uint8Array(data.length);
+    for (let i = 0; i < data.length; i++) {
+      out[i] = data[i] ^ pad[i % pad.length];
+    }
+    return out;
+  }
+}
+
+function b64(text: string): string {
+  return base64Encode(utf8ToBytes(text));
+}
+
+/** 手工拼装三段式 token（用于 mock 旧格式与篡改用例） */
+function buildToken(headerObj: CloudBackupTokenHeader, payloadText: string, signature: string): string {
+  return b64(JSON.stringify(headerObj)) + '.' + b64(payloadText) + '.' + signature;
+}
+
+export default function cloudBackupCryptoTest() {
+  describe('cloudBackupCryptoTest', () => {
+    it('get_mode_follows_huawei_login_state', 0, () => {
+      const crypto = CloudBackupCrypto.useEngineForTest(new XorBackupEngine(), new PureTsCodec());
+      expect(crypto.getMode(true)).assertEqual(CloudBackupCryptoMode.HUAWEI_ACCOUNT);
+      expect(crypto.getMode(false)).assertEqual(CloudBackupCryptoMode.NONE);
+      expect(CloudBackupCryptoMode.HUAWEI_ACCOUNT).assertEqual(1);
+      expect(CloudBackupCryptoMode.NONE).assertEqual(0);
+    });
+
+    it('encrypt_rejects_none_mode_with_code_3', 0, async () => {
+      const crypto = CloudBackupCrypto.useEngineForTest(new XorBackupEngine(), new PureTsCodec());
+      let threw = false;
+      let code = 0;
+      try {
+        await crypto.encrypt('{}', CloudBackupCryptoMode.NONE, 'k', 0, 0, 'dev', 'name');
+      } catch (e) {
+        threw = true;
+        code = (e as CloudBackupTokenError).code;
+      }
+      expect(threw).assertTrue();
+      expect(code).assertEqual(3);
+    });
+
+    it('roundtrip_preserves_plaintext_and_header_metadata', 0, async () => {
+      const crypto = CloudBackupCrypto.useEngineForTest(new XorBackupEngine(), new PureTsCodec());
+      const plaintext = '{"tokens":[{"issuer":"GitHub","name":"alice"}]}';
+      const token = await crypto.encrypt(plaintext, CloudBackupCryptoMode.HUAWEI_ACCOUNT, 'key-1',
+        3, 1788953926000, 'odid-123', 'Mate 60');
+
+      expect(token.split('.').length).assertEqual(3);
+      expect(await crypto.decrypt(token, CloudBackupCryptoMode.HUAWEI_ACCOUNT, 'key-1'))
+        .assertEqual(plaintext);
+
+      const header = crypto.parseTokenHeader(token);
+      expect(header.version).assertEqual(2);
+      expect(header.mode).assertEqual(CloudBackupCryptoMode.HUAWEI_ACCOUNT);
+      expect(header.tokenCount).assertEqual(3);
+      expect(header.size).assertEqual(plaintext.length);
+      expect(header.timestamp).assertEqual(1788953926000);
+      expect(header.deviceId).assertEqual('odid-123');
+      expect(header.deviceName).assertEqual('Mate 60');
+      expect(header.salt.startsWith('mock_salt_')).assertFalse();
+    });
+
+    it('encrypt_is_non_deterministic_across_calls', 0, async () => {
+      const crypto = CloudBackupCrypto.useEngineForTest(new XorBackupEngine(), new PureTsCodec());
+      const first = await crypto.encrypt('same-plaintext', CloudBackupCryptoMode.HUAWEI_ACCOUNT,
+        'k', 1, 1, 'd', 'n');
+      const second = await crypto.encrypt('same-plaintext', CloudBackupCryptoMode.HUAWEI_ACCOUNT,
+        'k', 1, 1, 'd', 'n');
+      // salt/iv 每次重新生成：header 与密文段都必须不同（否则 salt/iv 可预测）
+      expect(first.split('.')[0] !== second.split('.')[0]).assertTrue();
+      expect(first.split('.')[1] !== second.split('.')[1]).assertTrue();
+      // 两次的 salt 也要互不相同（engine.round 递增保证）
+      const h1 = crypto.parseTokenHeader(first);
+      const h2 = crypto.parseTokenHeader(second);
+      expect(h1.salt === h2.salt).assertFalse();
+      expect(h1.iv === h2.iv).assertFalse();
+      // 错误密钥不会抛异常（XOR 引擎无填充校验），但明文必须是乱码而非原文
+      const wrong = await crypto.decrypt(first, CloudBackupCryptoMode.HUAWEI_ACCOUNT, 'other-key');
+      expect(wrong === 'same-plaintext').assertFalse();
+    });
+
+    it('decrypt_tampered_signature_fails_integrity_with_code_2', 0, async () => {
+      const crypto = CloudBackupCrypto.useEngineForTest(new XorBackupEngine(), new PureTsCodec());
+      const token = await crypto.encrypt('data', CloudBackupCryptoMode.HUAWEI_ACCOUNT, 'k',
+        1, 1, 'd', 'n');
+      const segments = token.split('.');
+      const tampered = `${segments[0]}.${segments[1]}.${'0'.repeat(segments[2].length)}`;
+      let threw = false;
+      let code = 0;
+      try {
+        await crypto.decrypt(tampered, CloudBackupCryptoMode.HUAWEI_ACCOUNT, 'k');
+      } catch (e) {
+        threw = true;
+        code = (e as CloudBackupTokenError).code;
+      }
+      expect(threw).assertTrue();
+      expect(code).assertEqual(2);
+    });
+
+    it('decrypt_and_parse_reject_wrong_segment_count_with_code_1', 0, async () => {
+      const crypto = CloudBackupCrypto.useEngineForTest(new XorBackupEngine(), new PureTsCodec());
+      for (const bad of ['a.b', 'a.b.c.d']) {
+        let threw = false;
+        let code = 0;
+        try {
+          await crypto.decrypt(bad, CloudBackupCryptoMode.HUAWEI_ACCOUNT, 'k');
+        } catch (e) {
+          threw = true;
+          code = (e as CloudBackupTokenError).code;
+        }
+        expect(threw).assertTrue();
+        expect(code).assertEqual(1);
+
+        let parseThrew = false;
+        try {
+          crypto.parseTokenHeader(bad);
+        } catch (e) {
+          parseThrew = true;
+          code = (e as CloudBackupTokenError).code;
+        }
+        expect(parseThrew).assertTrue();
+        expect(code).assertEqual(1);
+      }
+    });
+
+    it('verify_token_checks_signature_without_decrypting', 0, async () => {
+      const crypto = CloudBackupCrypto.useEngineForTest(new XorBackupEngine(), new PureTsCodec());
+      const token = await crypto.encrypt('payload', CloudBackupCryptoMode.HUAWEI_ACCOUNT, 'k',
+        1, 1, 'd', 'n');
+      expect(await crypto.verifyToken(token)).assertTrue();
+
+      const segments = token.split('.');
+      const forged = `${segments[0]}.${segments[1]}.deadbeef`;
+      expect(await crypto.verifyToken(forged)).assertFalse();
+      expect(await crypto.verifyToken('only.two')).assertFalse();
+    });
+
+    it('mock_legacy_format_returns_plaintext_without_decrypting', 0, async () => {
+      const engine = new XorBackupEngine();
+      const crypto = CloudBackupCrypto.useEngineForTest(engine, new PureTsCodec());
+      const legacyHeader: CloudBackupTokenHeader = {
+        version: 1,
+        mode: CloudBackupCryptoMode.NONE,
+        salt: 'mock_salt_legacy',
+        iv: b64('legacy-iv'),
+        tokenCount: 2,
+        size: 13,
+        timestamp: 1700000000000,
+        deviceId: 'old-device',
+        deviceName: 'old-name',
+      };
+      const payloadText = '{"tokens":[1,2]}';
+      const headerB64 = b64(JSON.stringify(legacyHeader));
+      const payloadB64 = b64(payloadText);
+      // mock 旧格式同样先过签名校验（decrypt 先验签后判 mock），再跳过 AES 直接返回明文
+      const signature = await engine.sha256Hex(`${headerB64}.${payloadB64}`);
+      const token = `${headerB64}.${payloadB64}.${signature}`;
+
+      expect(crypto.isMockFormat(token)).assertTrue();
+      expect(await crypto.decrypt(token, CloudBackupCryptoMode.HUAWEI_ACCOUNT, 'any-key'))
+        .assertEqual(payloadText);
+      expect(await crypto.verifyToken(token)).assertTrue();
+    });
+
+    it('is_mock_format_returns_false_for_invalid_or_normal_tokens', 0, async () => {
+      const crypto = CloudBackupCrypto.useEngineForTest(new XorBackupEngine(), new PureTsCodec());
+      expect(crypto.isMockFormat('not-a-token')).assertFalse();
+
+      const normalHeader: CloudBackupTokenHeader = {
+        version: 2,
+        mode: CloudBackupCryptoMode.HUAWEI_ACCOUNT,
+        salt: b64('0123456789abcdef'),
+        iv: b64('0123456789abcdef'),
+        tokenCount: 1,
+        size: 4,
+        timestamp: 0,
+        deviceId: 'd',
+        deviceName: 'n',
+      };
+      const token = buildToken(normalHeader, 'data', 'ff');
+      expect(crypto.isMockFormat(token)).assertFalse();
+      const header = crypto.parseTokenHeader(token);
+      expect(header.salt.startsWith('mock_salt_')).assertFalse();
+    });
+
+    it('singleton_returns_same_instance', 0, () => {
+      const a = CloudBackupCrypto.getInstance();
+      const b = CloudBackupCrypto.getInstance();
+      expect(a === b).assertTrue();
+    });
+  });
+}

--- a/entry/src/test/CloudBackupManager.test.ets
+++ b/entry/src/test/CloudBackupManager.test.ets
@@ -1,0 +1,491 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { buffer } from '@kit.ArkTS';
+import {
+  AppPreference,
+  BackupCryptoEngine,
+  Base64Codec,
+  CloudBackupAccountPort,
+  CloudBackupCrypto,
+  CloudBackupDevicePort,
+  CloudBackupGroupPort,
+  CloudBackupIconPort,
+  CloudBackupManager,
+  CloudBackupTokenPort,
+  CloudSyncStarter,
+  PREF_KEYS,
+  TokenConfig,
+  TokenGroup,
+  otpType,
+} from 'common';
+import { sha256 } from '../main/ets/crypto/PureHash';
+import { base64Decode, base64Encode, utf8ToBytes } from '../main/ets/steam/SteamCrypto';
+import { MemoryFs } from './fakes/BackupFakes';
+
+/**
+ * 云备份编排逻辑测试（Phase 2 端口注入：FsGateway + 账号/设备/令牌/分组/图标包/同步）。
+ *
+ * 覆盖：登录门禁、备份写文件与失败回退、MAX_BACKUP_COUNT 最旧清理、
+ * 记录扫描（过滤/排序/头部解析降级）、新旧载荷恢复、三种清理粒度、
+ * 自动备份门禁。加密数值由注入引擎保证可逆，不测 AES 本身。
+ */
+
+function bytesToHex(data: Uint8Array): string {
+  let hex = '';
+  for (let i = 0; i < data.length; i++) {
+    hex += data[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+class PureTsCodec implements Base64Codec {
+  encodeText(text: string): string {
+    return base64Encode(utf8ToBytes(text));
+  }
+
+  decodeText(base64Str: string): string {
+    return buffer.from(base64Decode(base64Str)).toString('utf-8');
+  }
+
+  encodeBytes(data: Uint8Array): string {
+    return base64Encode(data);
+  }
+
+  decodeBytes(base64Str: string): Uint8Array {
+    return base64Decode(base64Str);
+  }
+}
+
+/** 可逆 XOR 备份引擎（密钥流由 PureHash SHA-256 派生） */
+class XorBackupEngine implements BackupCryptoEngine {
+  round: number = 0;
+
+  randomBytes(length: number): Uint8Array {
+    const out = new Uint8Array(length);
+    for (let i = 0; i < length; i++) {
+      out[i] = (this.round * 37 + i * 13 + 5) & 0xff;
+    }
+    this.round++;
+    return out;
+  }
+
+  async sha256Hex(data: string): Promise<string> {
+    return bytesToHex(sha256(utf8ToBytes(data)));
+  }
+
+  async aesCbcEncrypt(plaintext: Uint8Array, password: string, salt: Uint8Array, iv: Uint8Array): Promise<Uint8Array> {
+    return this.xor(plaintext, password, salt, iv);
+  }
+
+  async aesCbcDecrypt(ciphertext: Uint8Array, password: string, salt: Uint8Array, iv: Uint8Array): Promise<Uint8Array> {
+    return this.xor(ciphertext, password, salt, iv);
+  }
+
+  private xor(data: Uint8Array, password: string, salt: Uint8Array, iv: Uint8Array): Uint8Array {
+    const material = utf8ToBytes(password + ':' + bytesToHex(salt) + bytesToHex(iv));
+    const pad = sha256(material);
+    const out = new Uint8Array(data.length);
+    for (let i = 0; i < data.length; i++) {
+      out[i] = data[i] ^ pad[i % pad.length];
+    }
+    return out;
+  }
+}
+
+class FakeAccount implements CloudBackupAccountPort {
+  login: boolean = true;
+  union: string = 'union-1';
+
+  isUserLogin(): boolean {
+    return this.login;
+  }
+
+  unionId(): string {
+    return this.union;
+  }
+}
+
+class FakeDevice implements CloudBackupDevicePort {
+  id: string = 'odid-A';
+  name: string = 'Mate60';
+
+  deviceId(): string {
+    return this.id;
+  }
+
+  deviceName(): string {
+    return this.name;
+  }
+}
+
+class FakeTokens implements CloudBackupTokenPort {
+  list: TokenConfig[] = [];
+  updated: TokenConfig[] = [];
+
+  getTokens(): Promise<TokenConfig[]> {
+    return Promise.resolve(this.list);
+  }
+
+  updateToken(token: TokenConfig): Promise<void> {
+    this.updated.push(token);
+    return Promise.resolve();
+  }
+}
+
+class FakeGroups implements CloudBackupGroupPort {
+  groups: TokenGroup[] = [];
+  mergedGroups: TokenGroup[] | null = null;
+
+  currentGroups(): TokenGroup[] {
+    return this.groups;
+  }
+
+  merge(groups: TokenGroup[] | undefined): Promise<void> {
+    this.mergedGroups = groups !== undefined ? groups : null;
+    return Promise.resolve();
+  }
+}
+
+class FakeIcons implements CloudBackupIconPort {
+  backupCalls: number = 0;
+  clearCalls: number = 0;
+
+  backupIconPacks(): Promise<boolean> {
+    this.backupCalls++;
+    return Promise.resolve(true);
+  }
+
+  clearCloudBackup(): Promise<boolean> {
+    this.clearCalls++;
+    return Promise.resolve(true);
+  }
+}
+
+class FakeSync implements CloudSyncStarter {
+  startCalls: number = 0;
+
+  start(): Promise<void> {
+    this.startCalls++;
+    return Promise.resolve();
+  }
+}
+
+function makeToken(uuid: string, secret: string): TokenConfig {
+  const token = new TokenConfig(secret, otpType.TOTP);
+  token.TokenUUID = uuid;
+  token.RankScore = 0;
+  return token;
+}
+
+interface TestRig {
+  fs: MemoryFs;
+  account: FakeAccount;
+  device: FakeDevice;
+  tokens: FakeTokens;
+  groups: FakeGroups;
+  icons: FakeIcons;
+  sync: FakeSync;
+}
+
+function freshRig(): TestRig {
+  CloudBackupCrypto.useEngineForTest(new XorBackupEngine(), new PureTsCodec());
+  AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, '');
+  // 复位静态偏好与单例，隔离套件间污染
+  AppPreference.setPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, false);
+  AppPreference.setPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME, '');
+  CloudBackupManager.getInstance().resetForTest();
+
+  const rig: TestRig = {
+    fs: new MemoryFs(),
+    account: new FakeAccount(),
+    device: new FakeDevice(),
+    tokens: new FakeTokens(),
+    groups: new FakeGroups(),
+    icons: new FakeIcons(),
+    sync: new FakeSync(),
+  };
+  CloudBackupManager.getInstance().useDepsForTest({
+    fs: rig.fs,
+    account: rig.account,
+    device: rig.device,
+    tokens: rig.tokens,
+    groups: rig.groups,
+    icons: rig.icons,
+    sync: rig.sync,
+    cloudDir: '/cloud',
+  });
+  return rig;
+}
+
+function backupFileName(ts: number): string {
+  return `otp_backup_${ts}.enc`;
+}
+
+/** 直接向假文件系统写入一份合法加密备份 */
+async function seedBackup(rig: TestRig, ts: number, plaintext: string, deviceId: string,
+  deviceName: string = 'Mate60'): Promise<void> {
+  const crypto = CloudBackupCrypto.getInstance();
+  const content = await crypto.encrypt(plaintext, crypto.getMode(true), 'union-1', 1, ts, deviceId, deviceName);
+  rig.fs.files.set(`/cloud/${backupFileName(ts)}`, content);
+}
+
+async function flushMicrotasks(): Promise<void> {
+  // fire-and-forget promise（图标包备份）需要一次事件循环轮转
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+export default function cloudBackupManagerTest() {
+  describe('cloudBackupManagerTest', () => {
+    it('backup_aborts_when_not_logged_in', 0, async () => {
+      const rig = freshRig();
+      rig.account.login = false;
+
+      const result = await CloudBackupManager.getInstance().backupToCloud();
+      expect(result).assertFalse();
+      expect(rig.fs.files.size).assertEqual(0);
+      expect(rig.sync.startCalls).assertEqual(0);
+    });
+
+    it('backup_success_writes_file_sets_pref_and_triggers_sync_icons', 0, async () => {
+      const rig = freshRig();
+      rig.tokens.list = [makeToken('u1', 'secret1')];
+
+      const result = await CloudBackupManager.getInstance().backupToCloud();
+      expect(result).assertTrue();
+      // 文件名规则 otp_backup_{ts}.enc
+      let backupFiles: string[] = [];
+      rig.fs.files.forEach((_: string, name: string) => {
+        backupFiles.push(name.substring(name.lastIndexOf('/') + 1));
+      });
+      expect(backupFiles.length).assertEqual(1);
+      expect(backupFiles[0].startsWith('otp_backup_')).assertTrue();
+      expect(backupFiles[0].endsWith('.enc')).assertTrue();
+      // 同步触发一次；图标包备份 fire-and-forget 已排队
+      expect(rig.sync.startCalls).assertEqual(1);
+      await flushMicrotasks();
+      expect(rig.icons.backupCalls).assertEqual(1);
+      // last time 已记录（同步内存缓存）
+      const lastTime = AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME) as string;
+      expect(lastTime.length > 0).assertTrue();
+    });
+
+    it('backup_write_failure_returns_false', 0, async () => {
+      const rig = freshRig();
+      rig.fs.failWrite = true;
+
+      const result = await CloudBackupManager.getInstance().backupToCloud();
+      expect(result).assertFalse();
+      expect(rig.sync.startCalls).assertEqual(0);
+    });
+
+    it('backup_prunes_oldest_only_beyond_max_count', 0, async () => {
+      const rig = freshRig();
+      // 预置 5 份旧备份（相对 stub 时钟递减），上限为 5 → 写入后应删除最旧一份
+      const stubNow = Date.now();
+      for (let i = 1; i <= 5; i++) {
+        await seedBackup(rig, stubNow - 1000 * i, '{"tokens":[]}', 'odid-A');
+      }
+
+      const result = await CloudBackupManager.getInstance().backupToCloud();
+      expect(result).assertTrue();
+
+      let backupFiles: string[] = [];
+      rig.fs.files.forEach((_: string, name: string) => {
+        const base = name.substring(name.lastIndexOf('/') + 1);
+        if (base.startsWith('otp_backup_')) {
+          backupFiles.push(base);
+        }
+      });
+      expect(backupFiles.length).assertEqual(5);
+      // 最旧的一份（stubNow-5000）被删除（其余保留）
+      let deletedOldest = false;
+      for (const path of rig.fs.deletedPaths) {
+        if (path.endsWith(`otp_backup_${stubNow - 5000}.enc`)) {
+          deletedOldest = true;
+        }
+      }
+      expect(deletedOldest).assertTrue();
+    });
+
+    it('list_history_filters_suffix_and_nan_and_sorts_desc', 0, async () => {
+      const rig = freshRig();
+      await seedBackup(rig, 2000, '{"tokens":[]}', 'odid-A');
+      await seedBackup(rig, 3000, '{"tokens":[]}', 'odid-B');
+      rig.fs.files.set('/cloud/otp_backup_notanumber.enc', 'junk');
+      rig.fs.files.set('/cloud/unrelated.txt', 'junk');
+
+      const records = await CloudBackupManager.getInstance().listBackupHistory();
+      expect(records.length).assertEqual(2);
+      // 时间戳降序
+      expect(records[0].timestamp).assertEqual(3000);
+      expect(records[1].timestamp).assertEqual(2000);
+      // 头部解析成功：deviceId/设备名来自加密头
+      expect(records[0].deviceId).assertEqual('odid-B');
+      expect(records[0].deviceName).assertEqual('Mate60');
+    });
+
+    it('list_history_header_parse_failure_falls_back_to_stat', 0, async () => {
+      const rig = freshRig();
+      // 非 JWT 三段式内容 → 头部解析失败，回退 stat
+      rig.fs.files.set('/cloud/otp_backup_4000.enc', 'not-a-jwt');
+
+      const records = await CloudBackupManager.getInstance().listBackupHistory();
+      expect(records.length).assertEqual(1);
+      expect(records[0].tokenCount).assertEqual(0);
+      expect(records[0].deviceId).assertEqual('');
+      expect(records[0].size).assertEqual(9);
+    });
+
+    it('restore_from_cloud_false_when_no_records', 0, async () => {
+      const rig = freshRig();
+      const result = await CloudBackupManager.getInstance().restoreFromCloud();
+      expect(result).assertFalse();
+      expect(rig.tokens.updated.length).assertEqual(0);
+    });
+
+    it('restore_new_payload_restores_tokens_groups_and_packs', 0, async () => {
+      const rig = freshRig();
+      const tokenJson = JSON.stringify(makeToken('u1', 'restored_secret'));
+      const payload = `{"tokens":[${tokenJson}],"groups":[{"id":"g1","name":"Work"}],"enabledPacks":["pack-x"],"packMeta":[]}`;
+      await seedBackup(rig, 5000, payload, 'odid-A');
+      await seedBackup(rig, 6000, payload, 'odid-A');
+
+      // 恢复最新（6000）
+      const result = await CloudBackupManager.getInstance().restoreFromCloud();
+      expect(result).assertTrue();
+      expect(rig.tokens.updated.length).assertEqual(1);
+      expect(rig.tokens.updated[0].TokenUUID).assertEqual('u1');
+      expect(rig.tokens.updated[0].TokenSecret).assertEqual('restored_secret');
+      expect(rig.groups.mergedGroups !== null && rig.groups.mergedGroups!.length === 1).assertTrue();
+    });
+
+    it('restore_legacy_array_payload_skips_group_merge', 0, async () => {
+      const rig = freshRig();
+      const tokenJson = JSON.stringify(makeToken('legacy', 'legacy_secret'));
+      await seedBackup(rig, 7000, `[${tokenJson}]`, 'odid-A');
+
+      const result = await CloudBackupManager.getInstance().restoreFromBackupRecord(backupFileName(7000));
+      expect(result).assertTrue();
+      expect(rig.tokens.updated.length).assertEqual(1);
+      expect(rig.tokens.updated[0].TokenUUID).assertEqual('legacy');
+      expect(rig.groups.mergedGroups).assertNull();
+    });
+
+    it('restore_cloud_only_file_location2_still_restores', 0, async () => {
+      const rig = freshRig();
+      const tokenJson = JSON.stringify(makeToken('cloud', 'cloud_secret'));
+      await seedBackup(rig, 8600, `{"tokens":[${tokenJson}]}`, 'odid-A');
+      // 标记为云端文件（location=2）：注入模式下 cacheFile 跳过，读取与恢复不中断
+      rig.fs.locationOverride.set('/cloud/otp_backup_8600.enc', 2);
+
+      const result = await CloudBackupManager.getInstance().restoreFromBackupRecord(backupFileName(8600));
+      expect(result).assertTrue();
+      expect(rig.tokens.updated.length).assertEqual(1);
+      expect(rig.tokens.updated[0].TokenSecret).assertEqual('cloud_secret');
+    });
+
+    it('restore_missing_record_returns_false', 0, async () => {
+      freshRig();
+      const result = await CloudBackupManager.getInstance().restoreFromBackupRecord('otp_backup_9999.enc');
+      expect(result).assertFalse();
+    });
+
+    it('restore_aborts_when_not_logged_in', 0, async () => {
+      const rig = freshRig();
+      await seedBackup(rig, 8000, '{"tokens":[]}', 'odid-A');
+      rig.account.login = false;
+
+      const result = await CloudBackupManager.getInstance().restoreFromBackupRecord(backupFileName(8000));
+      expect(result).assertFalse();
+      expect(rig.tokens.updated.length).assertEqual(0);
+    });
+
+    it('clear_storage_deletes_all_and_resets_last_time', 0, async () => {
+      const rig = freshRig();
+      await seedBackup(rig, 9100, '{"tokens":[]}', 'odid-A');
+      await seedBackup(rig, 9200, '{"tokens":[]}', 'odid-B');
+
+      const result = await CloudBackupManager.getInstance().clearCloudStorage();
+      expect(result).assertTrue();
+      expect(rig.fs.files.size).assertEqual(0);
+      expect(rig.icons.clearCalls).assertEqual(1);
+      expect(AppPreference.getPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME)).assertEqual('0');
+    });
+
+    it('clear_device_storage_deletes_only_matching_odid', 0, async () => {
+      const rig = freshRig();
+      await seedBackup(rig, 9300, '{"tokens":[]}', 'odid-A');
+      await seedBackup(rig, 9400, '{"tokens":[]}', 'odid-B');
+
+      const result = await CloudBackupManager.getInstance().clearDeviceCloudStorage();
+      expect(result).assertTrue();
+      expect(rig.fs.files.size).assertEqual(1);
+      expect(rig.fs.files.has('/cloud/otp_backup_9400.enc')).assertTrue();
+      expect(rig.icons.clearCalls).assertEqual(1);
+    });
+
+    it('clear_device_name_storage_deletes_stale_install_only', 0, async () => {
+      const rig = freshRig();
+      // 同名设备、不同 ODID（卸载重装遗留）
+      await seedBackup(rig, 9500, '{"tokens":[]}', 'odid-OLD');
+      // 当前 ODID：保留；其他名称：保留
+      await seedBackup(rig, 9600, '{"tokens":[]}', 'odid-A');
+      await seedBackup(rig, 9700, '{"tokens":[]}', 'odid-B', 'OtherDev');
+
+      const result = await CloudBackupManager.getInstance().clearDeviceNameCloudStorage();
+      expect(result).assertTrue();
+      expect(rig.fs.files.size).assertEqual(2);
+      expect(rig.fs.files.has('/cloud/otp_backup_9600.enc')).assertTrue();
+      expect(rig.fs.files.has('/cloud/otp_backup_9700.enc')).assertTrue();
+      // 有实际删除才清理图标包
+      expect(rig.icons.clearCalls).assertEqual(1);
+
+      // 无遗留：不触发图标包清理
+      const iconsBefore = rig.icons.clearCalls;
+      const again = await CloudBackupManager.getInstance().clearDeviceNameCloudStorage();
+      expect(again).assertTrue();
+      expect(rig.icons.clearCalls).assertEqual(iconsBefore);
+    });
+
+    it('delete_record_syncs_only_on_success', 0, async () => {
+      const rig = freshRig();
+      await seedBackup(rig, 9800, '{"tokens":[]}', 'odid-A');
+
+      const missing = await CloudBackupManager.getInstance().deleteBackupRecord('otp_backup_1111.enc');
+      expect(missing).assertFalse();
+      expect(rig.sync.startCalls).assertEqual(0);
+
+      const ok = await CloudBackupManager.getInstance().deleteBackupRecord(backupFileName(9800));
+      expect(ok).assertTrue();
+      expect(rig.sync.startCalls).assertEqual(1);
+    });
+
+    it('auto_backup_skips_when_disabled', 0, async () => {
+      const rig = freshRig();
+      AppPreference.setPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, false);
+
+      await CloudBackupManager.getInstance().checkAndAutoBackup();
+      expect(rig.sync.startCalls).assertEqual(0);
+    });
+
+    it('auto_backup_runs_when_last_backup_is_stale', 0, async () => {
+      const rig = freshRig();
+      AppPreference.setPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, true);
+      // 上次备份相对 stub 时钟在一天前 → 不命中"今日已备份"跳过分支
+      AppPreference.setPreference(PREF_KEYS.CLOUD_SYNC_LAST_TIME, `${Date.now() - 86400000}`);
+
+      await CloudBackupManager.getInstance().checkAndAutoBackup();
+      expect(rig.fs.written.size).assertEqual(1);
+      expect(rig.sync.startCalls).assertEqual(1);
+    });
+
+    it('auto_backup_skips_when_logged_out', 0, async () => {
+      const rig = freshRig();
+      AppPreference.setPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, true);
+      rig.account.login = false;
+
+      await CloudBackupManager.getInstance().checkAndAutoBackup();
+      expect(rig.fs.written.size).assertEqual(0);
+    });
+  });
+}

--- a/entry/src/test/CloudBackupManager.test.ets
+++ b/entry/src/test/CloudBackupManager.test.ets
@@ -12,6 +12,7 @@ import {
   CloudBackupManager,
   CloudBackupTokenPort,
   CloudSyncStarter,
+  FsStatInfo,
   PREF_KEYS,
   TokenConfig,
   TokenGroup,
@@ -166,6 +167,39 @@ class FakeSync implements CloudSyncStarter {
   start(): Promise<void> {
     this.startCalls++;
     return Promise.resolve();
+  }
+}
+
+/** 同步触发可失败：验证备份主流程对同步故障的容忍 */
+class FlakySync implements CloudSyncStarter {
+  fail: boolean = false;
+  startCalls: number = 0;
+
+  async start(): Promise<void> {
+    this.startCalls++;
+    if (this.fail) {
+      throw new Error('sync down');
+    }
+  }
+}
+
+/** 可注入单点故障的文件系统：验证记录扫描/清理对单文件 IO 异常的隔离 */
+class FlakyFs extends MemoryFs {
+  failStatFor: Set<string> = new Set();
+  failDeleteFor: Set<string> = new Set();
+
+  stat(path: string): Promise<FsStatInfo> {
+    if (this.failStatFor.has(path)) {
+      return Promise.reject(new Error('stat flake'));
+    }
+    return super.stat(path);
+  }
+
+  async deleteFile(path: string): Promise<void> {
+    if (this.failDeleteFor.has(path)) {
+      throw new Error('delete flake');
+    }
+    await super.deleteFile(path);
   }
 }
 
@@ -486,6 +520,111 @@ export default function cloudBackupManagerTest() {
 
       await CloudBackupManager.getInstance().checkAndAutoBackup();
       expect(rig.fs.written.size).assertEqual(0);
+    });
+
+    it('restore_invalid_record_returns_false_without_writes', 0, async () => {
+      const rig = freshRig();
+      // 非 3 段格式 → decrypt 抛 CloudBackupTokenError → 恢复失败且异常被吞、零写入
+      rig.fs.files.set(`/cloud/${backupFileName(9500)}`, 'garbage-not-a-token');
+
+      const ok = await CloudBackupManager.getInstance().restoreFromCloud();
+      expect(ok).assertFalse();
+      expect(rig.tokens.updated.length).assertEqual(0);
+    });
+
+    it('backup_succeeds_even_when_cloud_sync_start_fails', 0, async () => {
+      const rig = freshRig();
+      const flakySync = new FlakySync();
+      flakySync.fail = true;
+      // useDepsForTest 为整体替换语义：必须传完整端口集，否则其余端口回退生产实现
+      CloudBackupManager.getInstance().useDepsForTest({
+        fs: rig.fs, account: rig.account, device: rig.device, tokens: rig.tokens,
+        groups: rig.groups, icons: rig.icons, sync: flakySync, cloudDir: '/cloud',
+      });
+      rig.tokens.list.push(makeToken('u1', 'SECRET'));
+
+      const ok = await CloudBackupManager.getInstance().backupToCloud();
+      // 同步触发失败不回滚备份结果（下次冷启动 FileSync 会补同步）
+      expect(ok).assertTrue();
+      expect(rig.fs.written.size).assertEqual(1);
+      expect(flakySync.startCalls).assertEqual(1);
+    });
+
+    it('clear_cloud_storage_tolerates_individual_delete_failures', 0, async () => {
+      const rig = freshRig();
+      const flaky = new FlakyFs();
+      // useDepsForTest 为整体替换语义：先注入再向同一个假文件系统种子备份
+      CloudBackupManager.getInstance().useDepsForTest({
+        fs: flaky, account: rig.account, device: rig.device, tokens: rig.tokens,
+        groups: rig.groups, icons: rig.icons, sync: rig.sync, cloudDir: '/cloud',
+      });
+      const crypto = CloudBackupCrypto.getInstance();
+      const content = await crypto.encrypt('{}', crypto.getMode(true), 'union-1', 1, 9100, 'odid-A', 'Mate60');
+      flaky.files.set(`/cloud/${backupFileName(9100)}`, content);
+      flaky.failDeleteFor.add(`/cloud/${backupFileName(9100)}`);
+
+      const ok = await CloudBackupManager.getInstance().clearCloudStorage();
+      // 现网行为：deleteBackupFile 内部吞错，单个文件删除失败不中断整体清理
+      // （红方评审关注点：清理"成功"反馈与云端实际状态可能不一致，归产品决策）
+      expect(ok).assertTrue();
+      expect(rig.icons.clearCalls).assertEqual(1);
+    });
+
+    it('clear_device_name_storage_noop_does_not_clear_icons', 0, async () => {
+      const rig = freshRig();
+      // 只有"同名不同 ODID"才算遗留备份；异名设备备份不受影响、不触发图标包清理
+      await seedBackup(rig, 9200, '{}', 'odid-B', 'Pixel8');
+
+      const ok = await CloudBackupManager.getInstance().clearDeviceNameCloudStorage();
+      expect(ok).assertTrue();
+      expect(rig.icons.clearCalls).assertEqual(0);
+      expect(rig.fs.deletedPaths.length).assertEqual(0);
+    });
+
+    it('list_records_skip_files_that_fail_stat_and_continue', 0, async () => {
+      const rig = freshRig();
+      const flaky = new FlakyFs();
+      CloudBackupManager.getInstance().useDepsForTest({
+        fs: flaky, account: rig.account, device: rig.device, tokens: rig.tokens,
+        groups: rig.groups, icons: rig.icons, sync: rig.sync, cloudDir: '/cloud',
+      });
+      const crypto = CloudBackupCrypto.getInstance();
+      const content1 = await crypto.encrypt('{"tokens":[]}', crypto.getMode(true), 'union-1', 1, 9300, 'odid-A', 'Mate60');
+      const content2 = await crypto.encrypt('{"tokens":[]}', crypto.getMode(true), 'union-1', 1, 9400, 'odid-A', 'Mate60');
+      flaky.files.set(`/cloud/${backupFileName(9300)}`, content1);
+      flaky.files.set(`/cloud/${backupFileName(9400)}`, content2);
+      flaky.failStatFor.add(`/cloud/${backupFileName(9300)}`);
+
+      const records = await CloudBackupManager.getInstance().listBackupHistory();
+      // 单文件 stat 失败只跳过该文件，其余记录正常返回（降序）
+      expect(records.length).assertEqual(1);
+      expect(records[0].timestamp).assertEqual(9400);
+    });
+
+    it('restore_new_payload_without_enabled_packs_keeps_current_setting', 0, async () => {
+      const rig = freshRig();
+      AppPreference.setPreference(PREF_KEYS.APPEARANCE_ICON_PACK_ENABLED, '["keep"]');
+      const payload = '{"tokens":[{"TokenUUID":"t1"}],"groups":[]}';
+      await seedBackup(rig, 9600, payload, 'odid-A');
+
+      const ok = await CloudBackupManager.getInstance().restoreFromCloud();
+      expect(ok).assertTrue();
+      // 载荷无 enabledPacks 字段 → 保留本地当前启用列表
+      expect(AppPreference.getPreference(PREF_KEYS.APPEARANCE_ICON_PACK_ENABLED) as string).assertEqual('["keep"]');
+      expect(rig.tokens.updated.length).assertEqual(1);
+      expect(rig.groups.mergedGroups !== null).assertTrue();
+    });
+
+    it('clear_methods_abort_when_not_logged_in', 0, async () => {
+      const rig = freshRig();
+      rig.account.login = false;
+      await seedBackup(rig, 9700, '{}', 'odid-A');
+
+      expect(await CloudBackupManager.getInstance().clearCloudStorage()).assertFalse();
+      expect(await CloudBackupManager.getInstance().clearDeviceCloudStorage()).assertFalse();
+      expect(await CloudBackupManager.getInstance().clearDeviceNameCloudStorage()).assertFalse();
+      expect(rig.fs.deletedPaths.length).assertEqual(0);
+      expect(rig.icons.clearCalls).assertEqual(0);
     });
   });
 }

--- a/entry/src/test/CryptoUtils.test.ets
+++ b/entry/src/test/CryptoUtils.test.ets
@@ -1,0 +1,242 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  decryptBlePayload,
+  decryptFile,
+  decryptStringData,
+  decryptUint8ArrayData,
+  encryptBlePayload,
+  encryptFile,
+  encryptStringData,
+  encryptUint8ArrayData,
+  randomBytes,
+  resetCryptoEngineForTest,
+  useCryptoEngineForTest,
+} from 'common';
+import { cryptoFramework } from '@kit.CryptoArchitectureKit';
+import { FakeCryptoEngine } from './fakes/BackupFakes';
+
+/**
+ * CryptoUtils 格式/协议层测试（Phase 2 CryptoEngine 端口注入）。
+ *
+ * 覆盖：V2 文件格式帧（MAGIC+salt+iv）、V0 legacy 派生参数、
+ * MAGIC_U8 对称帧、BLE GCM 帧与防篡改失败路径。
+ * AES/PBKDF2/GCM 数值正确性由生产引擎在真机 ohosTest 保证。
+ */
+
+const FILE_MAGIC: number[] = [0x4F, 0x54, 0x50, 0x02];
+const U8_MAGIC: number[] = [0x4F, 0x54, 0x50, 0x03];
+const BLE_MAGIC: number[] = [0x4F, 0x54, 0x50, 0x05];
+const LEGACY_IV_STR = 'ohtotptokenaesiv';
+
+/** 每个用例重新绑定干净假引擎，并清除模块级缓存（引擎单例 + BLE 派生密钥） */
+function freshEngine(): FakeCryptoEngine {
+  resetCryptoEngineForTest();
+  const engine = new FakeCryptoEngine();
+  useCryptoEngineForTest(engine);
+  return engine;
+}
+
+function bytesToNumbers(data: Uint8Array): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < data.length; i++) {
+    out.push(data[i]);
+  }
+  return out;
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export default function cryptoUtilsTest() {
+  describe('cryptoUtilsTest', () => {
+    it('encryptFile_builds_v2_framing_and_roundtrips', 0, async () => {
+      const engine = freshEngine();
+      const plain = '{"configs":["hello world"]}';
+      // 契约：随机源确定性（同种子同输出），不绑定引擎内部伪随机公式
+      engine.randomSeed = 42;
+      const encrypted = await encryptFile(plain, 'pass-123');
+      engine.randomSeed = 42;
+      const again = await encryptFile(plain, 'pass-123');
+      expect(bytesEqual(encrypted, again)).assertTrue();
+
+      // MAGIC(4) + salt(16) + iv(16) + ciphertext
+      const numbers = bytesToNumbers(encrypted);
+      expect(numbers.length).assertEqual(36 + engine.utf8Encode(plain).length);
+      for (let i = 0; i < 4; i++) {
+        expect(numbers[i]).assertEqual(FILE_MAGIC[i]);
+      }
+      // salt 与 iv 均来自引擎随机源（非零且互不相同）
+      let saltZero = true;
+      for (let i = 4; i < 20; i++) {
+        if (numbers[i] !== 0) {
+          saltZero = false;
+        }
+      }
+      expect(saltZero).assertFalse();
+      let saltEqualsIv = true;
+      for (let i = 0; i < 16; i++) {
+        if (numbers[4 + i] !== numbers[20 + i]) {
+          saltEqualsIv = false;
+        }
+      }
+      expect(saltEqualsIv).assertFalse();
+
+      const decrypted = await decryptFile(encrypted, 'pass-123');
+      expect(decrypted).assertEqual(plain);
+      // 密钥变化 → 同明文不同密文
+      const otherKey = await encryptFile(plain, 'pass-456');
+      expect(bytesEqual(encrypted, otherKey)).assertFalse();
+    });
+
+    it('decryptFile_v2_uses_pbkdf2_600k_iterations_with_file_salt', 0, async () => {
+      const engine = freshEngine();
+      const encrypted = await encryptFile('data', 'key1');
+      engine.lastPbkdf2Iterations = -1;
+      engine.lastPbkdf2Password = '';
+
+      await decryptFile(encrypted, 'key1');
+      expect(engine.lastPbkdf2Password).assertEqual('key1');
+      expect(engine.lastPbkdf2Iterations).assertEqual(600000);
+      expect(engine.lastPbkdf2KeySize).assertEqual(16);
+      // salt 取自文件头 [4..20)
+      expect(engine.lastPbkdf2Salt.length).assertEqual(16);
+      expect(engine.lastPbkdf2Salt[0]).assertEqual(encrypted[4]);
+    });
+
+    it('decryptFile_legacy_path_uses_zero_salt_and_fixed_iv', 0, async () => {
+      const engine = freshEngine();
+      // 构造 V0 数据：任意非 MAGIC 前缀的"密文"（假引擎 XOR 可逆）
+      const keyBytes = await engine.pbkdf2Derive('legacy_key', new Uint8Array(16), 10000, 16);
+      const legacyIv = engine.utf8Encode(LEGACY_IV_STR);
+      const plainBytes = engine.utf8Encode('legacy secret text');
+      const cipher = await engine.aesCbcEncrypt(plainBytes, keyBytes, legacyIv);
+
+      const decrypted = await decryptFile(cipher, 'legacy_key');
+      expect(decrypted).assertEqual('legacy secret text');
+      // legacy 派生参数：零盐 + 10000 轮
+      expect(engine.lastPbkdf2Iterations).assertEqual(10000);
+      let saltAllZero = engine.lastPbkdf2Salt.length === 16;
+      for (let i = 0; i < engine.lastPbkdf2Salt.length; i++) {
+        if (engine.lastPbkdf2Salt[i] !== 0) {
+          saltAllZero = false;
+        }
+      }
+      expect(saltAllZero).assertTrue();
+      // 解密使用硬编码 legacy IV
+      expect(bytesEqual(engine.lastCbcDecryptIv, legacyIv)).assertTrue();
+    });
+
+    it('encryptUint8ArrayData_framing_and_roundtrip', 0, async () => {
+      const engine = freshEngine();
+      const keyBlob: cryptoFramework.DataBlob = { data: engine.utf8Encode('sym-key-bytes!!!!') };
+      const plain = engine.utf8Encode('binary payload');
+      const encrypted = await encryptUint8ArrayData(plain, keyBlob);
+
+      const numbers = bytesToNumbers(encrypted);
+      expect(numbers.length).assertEqual(20 + plain.length);
+      for (let i = 0; i < 4; i++) {
+        expect(numbers[i]).assertEqual(U8_MAGIC[i]);
+      }
+
+      const decrypted = await decryptUint8ArrayData(encrypted, keyBlob);
+      expect(decrypted !== null).assertTrue();
+      expect(bytesEqual(decrypted!, plain)).assertTrue();
+    });
+
+    it('decryptUint8ArrayData_legacy_fallback_uses_hardcoded_iv', 0, async () => {
+      const engine = freshEngine();
+      const keyBlob: cryptoFramework.DataBlob = { data: engine.utf8Encode('sym-key-bytes!!!!') };
+      const legacyIv = engine.utf8Encode(LEGACY_IV_STR);
+      const plain = engine.utf8Encode('old data');
+      const cipher = await engine.aesCbcEncrypt(plain, new Uint8Array(keyBlob.data), legacyIv);
+
+      const decrypted = await decryptUint8ArrayData(cipher, keyBlob);
+      expect(decrypted !== null).assertTrue();
+      expect(bytesEqual(decrypted!, plain)).assertTrue();
+      expect(bytesEqual(engine.lastCbcDecryptIv, legacyIv)).assertTrue();
+    });
+
+    it('decryptUint8ArrayData_returns_null_on_decrypt_error', 0, async () => {
+      const engine = freshEngine();
+      const keyBlob: cryptoFramework.DataBlob = { data: engine.utf8Encode('sym-key-bytes!!!!') };
+      const encrypted = await encryptUint8ArrayData(engine.utf8Encode('x'), keyBlob);
+      engine.failNextCbcDecrypt = true;
+      const result = await decryptUint8ArrayData(encrypted, keyBlob);
+      expect(result).assertNull();
+    });
+
+    it('encryptStringData_roundtrip_utf8_and_null_on_failure', 0, async () => {
+      const engine = freshEngine();
+      const keyBlob: cryptoFramework.DataBlob = { data: engine.utf8Encode('another-sym-key!') };
+      const text = 'issuer:GitHub,name=octocat';
+      const encrypted = await encryptStringData(text, keyBlob);
+      const decrypted = await decryptStringData(encrypted, keyBlob);
+      expect(decrypted !== null).assertTrue();
+      expect(decrypted!).assertEqual(text);
+
+      // 解密失败（如填充错误）→ null
+      engine.failNextCbcDecrypt = true;
+      const failed = await decryptStringData(encrypted, keyBlob);
+      expect(failed).assertNull();
+    });
+
+    it('randomBytes_delegates_to_engine', 0, async () => {
+      const engine = freshEngine();
+      // 同一种子下两次采样一致，证明 randomBytes 委托当前注入引擎
+      engine.randomSeed = 12345;
+      const actual = randomBytes(8);
+      engine.randomSeed = 12345;
+      const expected = engine.randomBytes(8);
+      expect(bytesEqual(actual, expected)).assertTrue();
+    });
+
+    it('encryptBlePayload_framing_iv_and_tag_layout', 0, async () => {
+      const engine = freshEngine();
+      const plain = engine.utf8Encode('ble frame body');
+      const payload = await encryptBlePayload(plain);
+
+      const numbers = bytesToNumbers(payload);
+      // MAGIC(4) + iv(12) + tag(16) + ciphertext
+      expect(numbers.length).assertEqual(32 + plain.length);
+      for (let i = 0; i < 4; i++) {
+        expect(numbers[i]).assertEqual(BLE_MAGIC[i]);
+      }
+      // tag 区 16 字节且非全零（真实 tag 来自引擎 seal）
+      let tagAllZero = true;
+      for (let i = 16; i < 32; i++) {
+        if (numbers[i] !== 0) {
+          tagAllZero = false;
+        }
+      }
+      expect(tagAllZero).assertFalse();
+
+      const decrypted = await decryptBlePayload(payload);
+      expect(decrypted !== null).assertTrue();
+      expect(bytesEqual(decrypted!, plain)).assertTrue();
+    });
+
+    it('decryptBlePayload_rejects_short_wrong_magic_and_tampered', 0, async () => {
+      freshEngine();
+      expect(await decryptBlePayload(new Uint8Array(10))).assertNull();
+
+      const wrongMagic = new Uint8Array(40);
+      wrongMagic[0] = 0x00;
+      expect(await decryptBlePayload(wrongMagic)).assertNull();
+
+      // tag 校验失败（GCM open 抛错）→ null，调用方必须丢弃
+      const engine = freshEngine();
+      const payload = await encryptBlePayload(engine.utf8Encode('body'));
+      engine.failGcmOpen = true;
+      expect(await decryptBlePayload(payload)).assertNull();
+    });
+  });
+}

--- a/entry/src/test/FileUtils.test.ets
+++ b/entry/src/test/FileUtils.test.ets
@@ -1,0 +1,151 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  ChunkedTextReader,
+  constantTimeCompare,
+  HashCompareWriteIo,
+  readTextViaChunks,
+  writeTextIfHashDiffers,
+} from 'common';
+
+/**
+ * FileUtils 可测核心测试（Phase 2 抽出的分块读取与哈希防重写入）。
+ * fs/cryptoFramework 真机部分不在 LocalUnit 覆盖范围。
+ */
+
+const BUFFER_SIZE = 4096;
+
+/** 按预定块大小依次返回内容的假读取器（写入真实字节，供拼接契约断言） */
+class ScriptedReader implements ChunkedTextReader {
+  private chunks: number[] = [];
+  private content: string;
+  private callIndex: number = 0;
+  private buffer: ArrayBuffer = new ArrayBuffer(BUFFER_SIZE);
+  closed: boolean = false;
+  readCalls: number = 0;
+
+  constructor(content: string, chunks: number[]) {
+    this.content = content;
+    this.chunks = chunks;
+  }
+
+  readChunk(offset: number): number {
+    const size = this.chunks[this.callIndex];
+    this.callIndex++;
+    this.readCalls++;
+    const view = new Uint8Array(this.buffer);
+    for (let i = 0; i < size && i < view.length; i++) {
+      view[i] = this.content.charCodeAt(offset + i) & 0xFF;
+    }
+    return size;
+  }
+
+  chunkBuffer(): ArrayBuffer {
+    return this.buffer;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+class MemoryHashIo implements HashCompareWriteIo {
+  files: Map<string, string> = new Map();
+  writeCalls: string[] = [];
+
+  fileExists(uri: string): Promise<boolean> {
+    return Promise.resolve(this.files.has(uri));
+  }
+
+  readText(uri: string): Promise<string> {
+    const content = this.files.get(uri);
+    if (content === undefined) {
+      return Promise.reject(new Error('missing'));
+    }
+    return Promise.resolve(content);
+  }
+
+  writeText(uri: string, content: string): Promise<void> {
+    this.writeCalls.push(uri);
+    this.files.set(uri, content);
+    return Promise.resolve();
+  }
+}
+
+/** 确定性假哈希：字节和（区分度足够触发同/异分支） */
+async function fakeHash(content: string): Promise<Uint8Array> {
+  let sum = 0;
+  for (let i = 0; i < content.length; i++) {
+    sum = (sum + content.charCodeAt(i)) % 65536;
+  }
+  const out = new Uint8Array(2);
+  out[0] = sum >> 8;
+  out[1] = sum & 0xFF;
+  return out;
+}
+
+export default function fileUtilsTest() {
+  describe('fileUtilsTest', () => {
+    it('read_via_chunks_concatenates_all_blocks_in_order', 0, async () => {
+      // 第一块读满 4096 + 第二块部分读取：拼接必须保序且无丢失
+      const part1 = 'a'.repeat(BUFFER_SIZE);
+      const part2 = 'bc'.repeat(50);
+      const reader = new ScriptedReader(part1 + part2, [BUFFER_SIZE, part2.length]);
+      const content = await readTextViaChunks(reader);
+      expect(content).assertEqual(part1 + part2);
+      expect(reader.readCalls).assertEqual(2);
+      expect(reader.closed).assertTrue();
+    });
+
+    it('read_via_chunks_single_partial_block_reads_once', 0, async () => {
+      const reader = new ScriptedReader('short file', [10]);
+      const content = await readTextViaChunks(reader);
+      expect(content).assertEqual('short file');
+      expect(reader.readCalls).assertEqual(1);
+      expect(reader.closed).assertTrue();
+    });
+
+    it('read_via_chunks_exact_multiple_reads_one_extra_empty_block', 0, async () => {
+      // 恰好整块：还需一次额外读取得到 0 才终止；内容不重复
+      const part1 = 'x'.repeat(BUFFER_SIZE);
+      const reader = new ScriptedReader(part1, [BUFFER_SIZE, 0]);
+      const content = await readTextViaChunks(reader);
+      expect(content).assertEqual(part1);
+      expect(reader.readCalls).assertEqual(2);
+      expect(reader.closed).assertTrue();
+    });
+
+    it('constant_time_compare_behaves_like_equality', 0, () => {
+      const a = new Uint8Array([1, 2, 3]);
+      const b = new Uint8Array([1, 2, 3]);
+      const c = new Uint8Array([1, 2, 4]);
+      const d = new Uint8Array([1, 2]);
+
+      expect(constantTimeCompare(a, b)).assertTrue();
+      expect(constantTimeCompare(a, c)).assertFalse();
+      expect(constantTimeCompare(a, d)).assertFalse();
+      expect(constantTimeCompare(new Uint8Array(0), new Uint8Array(0))).assertTrue();
+    });
+
+    it('write_if_hash_differs_skips_identical_content', 0, async () => {
+      const io = new MemoryHashIo();
+      io.files.set('memory://f.txt', 'stable content');
+
+      await writeTextIfHashDiffers(io, fakeHash, 'memory://f.txt', 'stable content');
+      expect(io.writeCalls.length).assertEqual(0);
+      expect(io.files.get('memory://f.txt')).assertEqual('stable content');
+    });
+
+    it('write_if_hash_differs_writes_on_change_and_when_missing', 0, async () => {
+      const io = new MemoryHashIo();
+
+      // 文件不存在 → 直接写
+      await writeTextIfHashDiffers(io, fakeHash, 'memory://f.txt', 'v1');
+      expect(io.writeCalls.length).assertEqual(1);
+
+      // 内容变化 → 覆盖
+      await writeTextIfHashDiffers(io, fakeHash, 'memory://f.txt', 'v2');
+      expect(io.writeCalls.length).assertEqual(2);
+      expect(io.files.get('memory://f.txt')).assertEqual('v2');
+    });
+  });
+}

--- a/entry/src/test/IconPackCloudBackup.test.ets
+++ b/entry/src/test/IconPackCloudBackup.test.ets
@@ -1,0 +1,269 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  AppPreference,
+  BUILTIN_DEFAULT_PACK_ID,
+  IconPackArchiver,
+  IconPackBackupStatus,
+  IconPackCloudBackup,
+  IconPackDevicePort,
+  IconPackRestoreResult,
+  IconPackSyncState,
+  PREF_KEYS,
+  mergeEnabledPacks,
+} from 'common';
+import { MemoryFs } from './fakes/BackupFakes';
+
+/**
+ * 图标包云备份状态机测试（Phase 2 FsGateway + IconPackArchiver 端口注入）。
+ *
+ * 覆盖：IDLE→X→IDLE 互斥转换（含并发拒绝与失败复位）、备份流程
+ * （staging/zip/伴生元数据）、5 分钟去抖与云端较新判定、
+ * 清理流程、状态查询降级、enabledPacks 合并策略（纯函数）。
+ */
+
+/** 可门控的假压缩器：compress 挂起直到测试放行，用于构造并发窗口 */
+class GatedArchiver implements IconPackArchiver {
+  compressCalls: number = 0;
+  decompressCalls: number = 0;
+  private release: (() => void) | null = null;
+  private gate: Promise<void> | null = null;
+  hang: boolean = false;
+
+  compress(_srcDir: string, _destZip: string): Promise<void> {
+    this.compressCalls++;
+    if (this.hang) {
+      this.gate = new Promise<void>((resolve: () => void) => {
+        this.release = resolve;
+      });
+      return this.gate;
+    }
+    return Promise.resolve();
+  }
+
+  decompress(_zipPath: string, _destDir: string): Promise<void> {
+    this.decompressCalls++;
+    return Promise.resolve();
+  }
+
+  releaseGate(): void {
+    if (this.release !== null) {
+      this.release();
+      this.release = null;
+    }
+  }
+}
+
+/** 假设备端口：LocalUnit 下 deviceInfo API 不可用 */
+class FakeIconDevice implements IconPackDevicePort {
+  deviceId(): string {
+    return 'test-odid';
+  }
+
+  deviceName(): string {
+    return 'TestDevice';
+  }
+}
+
+function bindDeps(fs: MemoryFs, archiver: IconPackArchiver): void {
+  IconPackCloudBackup.getInstance().useDepsForTest({
+    fs: fs,
+    archiver: archiver,
+    device: new FakeIconDevice(),
+    filesDir: '/data/files',
+    cloudDir: '/cloud',
+    cacheDir: '/data/cache',
+  });
+}
+
+function resetSingleton(): void {
+  IconPackCloudBackup.getInstance().resetForTest();
+  AppPreference.setPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME, '');
+}
+
+/** 让出一轮事件循环（等待挂起操作完成状态迁移，避免用例间竞态） */
+function delayForTurn(): Promise<void> {
+  return new Promise<void>((resolve: () => void) => {
+    setTimeout(() => resolve(), 1);
+  });
+}
+
+export default function iconPackCloudBackupTest() {
+  describe('iconPackCloudBackupTest', () => {
+    it('backup_full_flow_writes_zip_meta_and_timestamp', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new GatedArchiver();
+      bindDeps(fs, archiver);
+      // 本地有图标包内容；假压缩器不产 zip，预置供 copyFile 到 cloudDir
+      fs.files.set('/data/files/icon_packs/pack1.json', '{}');
+      fs.files.set('/data/cache/icon_packs_backup.zip', 'zip');
+
+      const ok = await IconPackCloudBackup.getInstance().backupIconPacks();
+      expect(ok).assertTrue();
+      expect(archiver.compressCalls).assertEqual(1);
+      // zip 与伴生元数据文件落到 cloudDir
+      expect(fs.files.has('/cloud/icon_packs_backup.zip')).assertTrue();
+      expect(fs.files.has('/cloud/icon_packs_sync_meta.json')).assertTrue();
+      const meta = fs.files.get('/cloud/icon_packs_sync_meta.json') ?? '';
+      // 伴生元数据含设备与包列表字段
+      expect(meta.includes('"deviceName":"TestDevice"')).assertTrue();
+      expect(meta.includes('"packs"')).assertTrue();
+      // 时间戳记录（防抖基准）
+      const lastTime = AppPreference.getPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME) as string;
+      expect(lastTime.length > 0).assertTrue();
+      // staging 目录清理
+      expect(fs.files.has('/data/cache/icon_pack_staging/icon_packs_meta.json')).assertFalse();
+    });
+
+    it('backup_without_content_skips_cleanly', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new GatedArchiver();
+      bindDeps(fs, archiver);
+
+      const ok = await IconPackCloudBackup.getInstance().backupIconPacks();
+      expect(ok).assertTrue();
+      expect(archiver.compressCalls).assertEqual(0);
+      expect(fs.files.size).assertEqual(0);
+    });
+
+    it('backup_failure_returns_false_and_resets_state_to_idle', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      fs.files.set('/data/files/icon_packs/pack1.json', '{}');
+      const archiver = new GatedArchiver();
+      bindDeps(fs, archiver);
+      fs.failWrite = true;
+
+      const ok = await IconPackCloudBackup.getInstance().backupIconPacks();
+      expect(ok).assertFalse();
+      // 失败也必须回到 IDLE，否则状态机永久锁死
+      expect(IconPackCloudBackup.getInstance().getState()).assertEqual(IconPackSyncState.IDLE);
+    });
+
+    it('operations_are_mutually_exclusive_via_state_machine', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      fs.files.set('/data/files/icon_packs/pack1.json', '{}');
+      fs.files.set('/data/cache/icon_packs_backup.zip', 'zip');
+      const archiver = new GatedArchiver();
+      archiver.hang = true;
+      bindDeps(fs, archiver);
+
+      // 等待备份进入 BACKING_UP（挂起在 compress 门控上）
+      const pending = IconPackCloudBackup.getInstance().backupIconPacks();
+      await delayForTurn();
+      expect(IconPackCloudBackup.getInstance().getState()).assertEqual(IconPackSyncState.BACKING_UP);
+
+      // 并发操作全部被拒绝
+      expect(await IconPackCloudBackup.getInstance().checkCloudBackupNewer()).assertFalse();
+      expect(await IconPackCloudBackup.getInstance().clearCloudBackup()).assertFalse();
+      const restore = await IconPackCloudBackup.getInstance().restoreIconPacks();
+      expect(restore.restoredCount).assertEqual(0);
+      expect(restore.restoredFiles).assertEqual(0);
+
+      archiver.releaseGate();
+      expect(await pending).assertTrue();
+      expect(IconPackCloudBackup.getInstance().getState()).assertEqual(IconPackSyncState.IDLE);
+    });
+
+    it('check_newer_true_when_cloud_meta_is_fresher', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new GatedArchiver();
+      bindDeps(fs, archiver);
+      AppPreference.setPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME, '1000');
+      fs.files.set('/cloud/icon_packs_sync_meta.json', '{"version":1,"timestamp":5000,"deviceId":"d","deviceName":"M","enabledPacks":[],"deletedPacks":[],"packs":[]}');
+
+      const newer = await IconPackCloudBackup.getInstance().checkCloudBackupNewer();
+      expect(newer).assertTrue();
+    });
+
+    it('check_newer_false_when_within_five_minutes_debounce', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new GatedArchiver();
+      bindDeps(fs, archiver);
+      // 刚刚恢复过（相对 stub 时钟 1 分钟前）→ 去抖跳过
+      AppPreference.setPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME, `${Date.now() - 60000}`);
+      fs.files.set('/cloud/icon_packs_sync_meta.json', '{"version":1,"timestamp":9999999999999,"deviceId":"","deviceName":"","enabledPacks":[],"deletedPacks":[],"packs":[]}');
+
+      const newer = await IconPackCloudBackup.getInstance().checkCloudBackupNewer();
+      expect(newer).assertFalse();
+    });
+
+    it('check_newer_false_when_meta_missing', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new GatedArchiver();
+      bindDeps(fs, archiver);
+
+      expect(await IconPackCloudBackup.getInstance().checkCloudBackupNewer()).assertFalse();
+    });
+
+    it('clear_removes_zip_and_meta_and_returns_true', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new GatedArchiver();
+      bindDeps(fs, archiver);
+      fs.files.set('/cloud/icon_packs_backup.zip', 'zip');
+      fs.files.set('/cloud/icon_packs_sync_meta.json', '{}');
+
+      const ok = await IconPackCloudBackup.getInstance().clearCloudBackup();
+      expect(ok).assertTrue();
+      expect(fs.files.size).assertEqual(0);
+    });
+
+    it('status_reports_zip_and_meta_fields', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new GatedArchiver();
+      bindDeps(fs, archiver);
+      fs.files.set('/cloud/icon_packs_backup.zip', 'zipdata');
+      fs.files.set('/cloud/icon_packs_sync_meta.json',
+        '{"version":1,"timestamp":7000,"deviceId":"dev-1","deviceName":"Mate60","enabledPacks":["p1"],"deletedPacks":[],"packs":[{"uuid":"p1","name":"Pack One","version":2,"iconCount":10}]}');
+
+      const status: IconPackBackupStatus = await IconPackCloudBackup.getInstance().getCloudBackupStatus();
+      expect(status.exists).assertTrue();
+      expect(status.size).assertEqual(7);
+      expect(status.packCount).assertEqual(1);
+      expect(status.sourceDeviceId).assertEqual('dev-1');
+      expect(status.sourceDeviceName).assertEqual('Mate60');
+      expect(status.packs.length).assertEqual(1);
+      expect(status.packs[0].iconCount).assertEqual(10);
+    });
+
+    it('status_falls_back_to_local_pack_count_when_meta_missing', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new GatedArchiver();
+      bindDeps(fs, archiver);
+
+      const status = await IconPackCloudBackup.getInstance().getCloudBackupStatus();
+      // 无 zip、无 meta：exists=false，包数回退本地内存（LocalUnit 下为 0）
+      expect(status.exists).assertFalse();
+      expect(status.packCount).assertEqual(0);
+    });
+
+    it('merge_enabled_packs_appends_local_only_and_defaults_when_empty', 0, () => {
+      // 云端列表为基础，本地独有追加
+      let merged = mergeEnabledPacks(['p1', 'p2'], ['p2', 'p3', 'p4']);
+      expect(merged.join(',')).assertEqual('p1,p2,p3,p4');
+
+      // 云端为空 → 内置默认包兜底 + 本地追加
+      merged = mergeEnabledPacks([], ['p9']);
+      expect(merged.join(',')).assertEqual(`${BUILTIN_DEFAULT_PACK_ID},p9`);
+    });
+
+    it('restore_returns_empty_result_without_state_leak', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new GatedArchiver();
+      bindDeps(fs, archiver);
+      // 云端无 zip → stat 失败 → 空结果
+      const result: IconPackRestoreResult = await IconPackCloudBackup.getInstance().restoreIconPacks();
+      expect(result.restoredCount).assertEqual(0);
+      expect(IconPackCloudBackup.getInstance().getState()).assertEqual(IconPackSyncState.IDLE);
+    });
+  });
+}

--- a/entry/src/test/IconPackCloudBackup.test.ets
+++ b/entry/src/test/IconPackCloudBackup.test.ets
@@ -1,11 +1,14 @@
 import { describe, it, expect } from '@ohos/hypium';
 import {
   AppPreference,
+  AegisIconPack,
   BUILTIN_DEFAULT_PACK_ID,
+  HuaweiAccountManager,
   IconPackArchiver,
   IconPackBackupStatus,
   IconPackCloudBackup,
   IconPackDevicePort,
+  IconPackRegistry,
   IconPackRestoreResult,
   IconPackSyncState,
   PREF_KEYS,
@@ -62,6 +65,105 @@ class FakeIconDevice implements IconPackDevicePort {
   deviceName(): string {
     return 'TestDevice';
   }
+}
+
+/**
+ * 假解压器：decompress 时把预置的"zip 内容"写入目标目录（模拟解压产物）。
+ * 键为相对路径，值为文件内容。直接写 MemoryFs 公共字段（与既有播种惯例一致），
+ * 并逐级登记父目录——真实解压产物包含目录，递归拷贝依赖 dirs 判定 isDirectory。
+ */
+class FakeUnpackArchiver implements IconPackArchiver {
+  contents: Map<string, string> = new Map();
+  decompressCalls: number = 0;
+  fs: MemoryFs;
+
+  constructor(fs: MemoryFs) {
+    this.fs = fs;
+  }
+
+  compress(_srcDir: string, _destZip: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  decompress(_zipPath: string, destDir: string): Promise<void> {
+    this.decompressCalls++;
+    this.contents.forEach((content: string, relPath: string) => {
+      // 逐级登记父目录（与真实解压一致，供递归拷贝识别子目录）
+      const segments = relPath.split('/');
+      let prefix = destDir;
+      for (let i = 0; i < segments.length - 1; i++) {
+        prefix = `${prefix}/${segments[i]}`;
+        this.fs.dirs.add(prefix);
+      }
+      this.fs.files.set(`${destDir}/${relPath}`, content);
+    });
+    return Promise.resolve();
+  }
+}
+
+/** 假图标包注册表：内存维护包列表与启用列表，记录全部调用供断言。 */
+class FakeIconRegistry implements IconPackRegistry {
+  packs: AegisIconPack[] = [];
+  enabledPacks: string[] = [];
+  removedPacks: string[] = [];
+  addedPackPaths: string[] = [];
+  loadUserIconsCalls: string[] = [];
+  reloadEnabledPacksCalls: number = 0;
+  lastAppliedPacks: string[] = [];
+  /** addPackFromDevice 对这些路径抛错（模拟损坏包） */
+  failAddFor: Set<string> = new Set();
+
+  listPacks(): AegisIconPack[] {
+    return this.packs;
+  }
+
+  async loadUserIcons(userIconDir: string): Promise<void> {
+    this.loadUserIconsCalls.push(userIconDir);
+  }
+
+  async addPackFromDevice(path: string): Promise<void> {
+    if (this.failAddFor.has(path)) {
+      throw new Error('corrupt pack');
+    }
+    this.addedPackPaths.push(path);
+    const pack = new AegisIconPack();
+    pack.uuid = 'dyn_' + path.split('/').pop();
+    pack.on_device_path = path;
+    this.packs.push(pack);
+  }
+
+  async removePack(pack: AegisIconPack): Promise<void> {
+    this.removedPacks.push(pack.uuid);
+    this.packs = this.packs.filter(p => p.on_device_path !== pack.on_device_path);
+  }
+
+  getEnabledPacks(): string[] {
+    return this.enabledPacks;
+  }
+
+  setEnabledPacks(packs: string[]): void {
+    this.enabledPacks = packs;
+    this.lastAppliedPacks = packs;
+  }
+
+  reloadEnabledPacksFromPreference(): void {
+    this.reloadEnabledPacksCalls++;
+    // 与生产语义一致：恢复前以偏好内容为干净基线
+    this.enabledPacks = AppPreference.loadEnabledPacks();
+  }
+}
+
+function bindDepsWithRegistry(fs: MemoryFs, archiver: IconPackArchiver,
+  registry: FakeIconRegistry): void {
+  IconPackCloudBackup.getInstance().useDepsForTest({
+    fs: fs,
+    archiver: archiver,
+    device: new FakeIconDevice(),
+    registry: registry,
+    filesDir: '/data/files',
+    cloudDir: '/cloud',
+    cacheDir: '/data/cache',
+  });
 }
 
 function bindDeps(fs: MemoryFs, archiver: IconPackArchiver): void {
@@ -264,6 +366,149 @@ export default function iconPackCloudBackupTest() {
       const result: IconPackRestoreResult = await IconPackCloudBackup.getInstance().restoreIconPacks();
       expect(result.restoredCount).assertEqual(0);
       expect(IconPackCloudBackup.getInstance().getState()).assertEqual(IconPackSyncState.IDLE);
+    });
+
+    it('restore_full_chain_deletes_refreshes_merges_and_applies', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new FakeUnpackArchiver(fs);
+      const registry = new FakeIconRegistry();
+      // 本地已有 p1（将被云端 deletedPacks 标记删除）
+      const localPack = new AegisIconPack();
+      localPack.uuid = 'p1';
+      localPack.on_device_path = '/data/files/icon_packs/p1';
+      registry.packs.push(localPack);
+      registry.enabledPacks = ['p1'];
+      bindDepsWithRegistry(fs, archiver, registry);
+
+      // 云端：zip + "解压产物"（新包 packA + 元数据）
+      fs.files.set('/cloud/icon_packs_backup.zip', 'zip');
+      archiver.contents.set('icon_packs/packA/pack.json', '{"name":"PackA"}');
+      archiver.contents.set('icon_packs_meta.json',
+        '{"version":1,"timestamp":5000,"enabledPacks":["p2"],"deletedPacks":["p1"],' +
+        '"packs":[{"uuid":"p2","name":"Pack Two","version":1,"iconCount":3},{"uuid":"p3","name":"Pack Three","version":1,"iconCount":4}]}');
+
+      const result = await IconPackCloudBackup.getInstance().restoreIconPacks();
+      // 恢复结果计数
+      expect(result.restoredCount).assertEqual(2);
+      expect(result.restoredFiles).assertEqual(1);
+      // deletedPacks 清理：p1 被删除
+      expect(registry.removedPacks.join(',')).assertEqual('p1');
+      // 磁盘重载：user_icons 触达 + 新包 packA 按路径加载
+      expect(registry.loadUserIconsCalls.join(',')).assertEqual('/data/files/user_icons');
+      expect(registry.addedPackPaths.join(',')).assertEqual('/data/files/icon_packs/packA');
+      // 合并应用：云端 enabledPacks 为基础 + 本地新增 packA（dyn_packA）
+      expect(registry.lastAppliedPacks.join(',')).assertEqual('p2,dyn_packA');
+      // 偏好持久化 + 恢复时间戳更新（防抖基准）
+      const saved = AppPreference.getPreference(PREF_KEYS.APPEARANCE_ICON_PACK_ENABLED) as string;
+      expect(saved).assertEqual('["p2","dyn_packA"]');
+      const lastTime = AppPreference.getPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME) as string;
+      expect(lastTime).assertEqual('5000');
+      // 临时目录已清理（解压产物不残留）
+      expect(fs.files.has('/data/cache/icon_pack_restore/icon_packs_meta.json')).assertFalse();
+      // 拷贝确实发生：filesDir 出现解压出的包文件
+      expect(fs.files.has('/data/files/icon_packs/packA/pack.json')).assertTrue();
+      // 状态机复位
+      expect(IconPackCloudBackup.getInstance().getState()).assertEqual(IconPackSyncState.IDLE);
+    });
+
+    it('restore_skips_unknown_deleted_uuid_and_broken_pack_load', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new FakeUnpackArchiver(fs);
+      const registry = new FakeIconRegistry();
+      bindDepsWithRegistry(fs, archiver, registry);
+      // deletedPacks 引用本地不存在的 uuid；解压出的包损坏（加载抛错）不得中断恢复
+      fs.files.set('/cloud/icon_packs_backup.zip', 'zip');
+      archiver.contents.set('icon_packs/broken/pack.json', 'not-json');
+      archiver.contents.set('icon_packs_meta.json',
+        '{"version":1,"timestamp":6000,"enabledPacks":["p2"],"deletedPacks":["ghost"],' +
+        '"packs":[{"uuid":"p2","name":"Pack Two","version":1,"iconCount":1}]}');
+      registry.failAddFor.add('/data/files/icon_packs/broken');
+
+      const result = await IconPackCloudBackup.getInstance().restoreIconPacks();
+      // 未知 uuid 不触发删除；损坏包跳过后恢复整体仍成功
+      expect(registry.removedPacks.length).assertEqual(0);
+      expect(result.restoredCount).assertEqual(1);
+      expect(registry.lastAppliedPacks.join(',')).assertEqual('p2');
+    });
+
+    it('restore_without_meta_copies_files_but_skips_registry_mutations', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new FakeUnpackArchiver(fs);
+      const registry = new FakeIconRegistry();
+      bindDepsWithRegistry(fs, archiver, registry);
+      // zip 存在但无元数据（旧版本备份）：文件拷贝仍执行，注册表不改写
+      fs.files.set('/cloud/icon_packs_backup.zip', 'zip');
+      archiver.contents.set('user_icons/custom.svg', 'svg-data');
+
+      const result = await IconPackCloudBackup.getInstance().restoreIconPacks();
+      expect(result.restoredCount).assertEqual(0);
+      expect(result.restoredFiles).assertEqual(1);
+      expect(registry.removedPacks.length).assertEqual(0);
+      expect(registry.lastAppliedPacks.length).assertEqual(0);
+      expect(registry.reloadEnabledPacksCalls).assertEqual(0);
+      // 拷贝发生：user_icons 内容落地 filesDir
+      expect(fs.files.has('/data/files/user_icons/custom.svg')).assertTrue();
+      expect(AppPreference.getPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME) as string).assertEqual('');
+    });
+
+    it('auto_restore_full_chain_gated_by_pref_login_and_fires', 0, async () => {
+      resetSingleton();
+      const fs = new MemoryFs();
+      const archiver = new FakeUnpackArchiver(fs);
+      const registry = new FakeIconRegistry();
+      bindDepsWithRegistry(fs, archiver, registry);
+      fs.files.set('/cloud/icon_packs_backup.zip', 'zip');
+      // 去抖/较新判定读取的是伴生元数据文件（不解压 zip）
+      fs.files.set('/cloud/icon_packs_sync_meta.json', '{"version":1,"timestamp":9000,"deviceId":"d","deviceName":"M","enabledPacks":["cloud1"],"deletedPacks":[],"packs":[{"uuid":"cloud1","name":"C","version":1,"iconCount":1}]}');
+      archiver.contents.set('icon_packs_meta.json',
+        '{"version":1,"timestamp":9000,"enabledPacks":["cloud1"],"deletedPacks":[],"packs":[{"uuid":"cloud1","name":"C","version":1,"iconCount":1}]}');
+      // 账号门禁直接改单例布尔，finally 复位防跨套件泄漏
+      HuaweiAccountManager.getInstance().userLogin = false;
+      try {
+        // 云同步开关关闭 → 直接跳过
+        AppPreference.setPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, false);
+        expect(await IconPackCloudBackup.getInstance().checkAndAutoRestore()).assertFalse();
+
+        // 开关开启但账号未登录 → 跳过
+        AppPreference.setPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, true);
+        expect(await IconPackCloudBackup.getInstance().checkAndAutoRestore()).assertFalse();
+
+        // 登录后整链路执行：恢复成功返回 true，状态机复位
+        HuaweiAccountManager.getInstance().userLogin = true;
+        expect(await IconPackCloudBackup.getInstance().checkAndAutoRestore()).assertTrue();
+        expect(registry.lastAppliedPacks.join(',')).assertEqual('cloud1');
+        expect(AppPreference.getPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME) as string).assertEqual('9000');
+        expect(IconPackCloudBackup.getInstance().getState()).assertEqual(IconPackSyncState.IDLE);
+      } finally {
+        HuaweiAccountManager.getInstance().userLogin = false;
+      }
+    });
+
+    it('auto_restore_skips_when_local_already_fresh', 0, async () => {
+      resetSingleton();
+      HuaweiAccountManager.getInstance().userLogin = true;
+      const fs = new MemoryFs();
+      const archiver = new FakeUnpackArchiver(fs);
+      const registry = new FakeIconRegistry();
+      bindDepsWithRegistry(fs, archiver, registry);
+      AppPreference.setPreference(PREF_KEYS.APPEARANCE_HUAWEI_CLOUD_SYNC_ENABLE, true);
+      // 刚刚恢复过（相对 stub 时钟 1 分钟前）→ 去抖内不自动恢复。
+      // 伴生元数据存在且时间戳更新，保证走的是去抖分支而非"缺 meta"分支
+      AppPreference.setPreference(PREF_KEYS.ICON_PACK_CLOUD_SYNC_TIME, `${Date.now() - 60000}`);
+      fs.files.set('/cloud/icon_packs_backup.zip', 'zip');
+      fs.files.set('/cloud/icon_packs_sync_meta.json', '{"version":1,"timestamp":9999999999999,"deviceId":"","deviceName":"","enabledPacks":[],"deletedPacks":[],"packs":[]}');
+      archiver.contents.set('icon_packs_meta.json',
+        '{"version":1,"timestamp":9999999999999,"enabledPacks":[],"deletedPacks":[],"packs":[]}');
+
+      try {
+        expect(await IconPackCloudBackup.getInstance().checkAndAutoRestore()).assertFalse();
+        expect(archiver.decompressCalls).assertEqual(0);
+      } finally {
+        HuaweiAccountManager.getInstance().userLogin = false;
+      }
     });
   });
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -41,6 +41,7 @@ import fileUtilsTest from './FileUtils.test';
 import storagePortsTest from './StoragePorts.test';
 import oathAppletTest from './OathApplet.test';
 import iconPackCloudBackupTest from './IconPackCloudBackup.test';
+import transferProtocolTest from './TransferProtocol.test';
 
 export default function testsuite() {
   localUnitTest();
@@ -86,4 +87,5 @@ export default function testsuite() {
   storagePortsTest();
   oathAppletTest();
   iconPackCloudBackupTest();
+  transferProtocolTest();
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -3,6 +3,7 @@ import smokeTest from './Smoke.test';
 import base32Test from './Base32.test';
 import cardOTPUtilsTest from './CardOTPUtils.test';
 import tokenUtilsExtraTest from './TokenUtilsExtra.test';
+import tokenUtilsIconPackTest from './TokenUtilsIconPack.test';
 import steamUtilsTest from './SteamUtils.test';
 import syncTimeHelperTest from './SyncTimeHelper.test';
 import colorUtilsTest from './ColorUtils.test';
@@ -14,11 +15,20 @@ import steamProtoTest from './SteamProto.test';
 import steamMessagesTest from './SteamMessages.test';
 import steamCryptoTest from './SteamCrypto.test';
 import steamClientTest from './SteamClient.test';
+import steamClientExtraTest from './SteamClientExtra.test';
 import steamAuthTest from './SteamAuth.test';
 import steamFlowTest from './SteamFlow.test';
 import steamActionsTest from './SteamActions.test';
 import steamHttpTest from './SteamHttp.test';
 import googleAuthMigrationTest from './GoogleAuthMigration.test';
+import cloudBackupCryptoTest from './CloudBackupCrypto.test';
+import tokenGroupStoreTest from './TokenGroupStore.test';
+import appPreferenceTest from './AppPreference.test';
+import snackBarTest from './SnackBar.test';
+import base64UtilTest from './Base64Util.test';
+import uiUtilsMiscTest from './UiUtilsMisc.test';
+import tokenImporterRegistryTest from './TokenImporter.test';
+import responsiveLayoutPolicyTest from './ResponsiveLayoutPolicy.test';
 
 export default function testsuite() {
   localUnitTest();
@@ -26,6 +36,7 @@ export default function testsuite() {
   base32Test();
   cardOTPUtilsTest();
   tokenUtilsExtraTest();
+  tokenUtilsIconPackTest();
   steamUtilsTest();
   syncTimeHelperTest();
   colorUtilsTest();
@@ -37,9 +48,18 @@ export default function testsuite() {
   steamMessagesTest();
   steamCryptoTest();
   steamClientTest();
+  steamClientExtraTest();
   steamAuthTest();
   steamFlowTest();
   steamActionsTest();
   steamHttpTest();
   googleAuthMigrationTest();
+  cloudBackupCryptoTest();
+  tokenGroupStoreTest();
+  appPreferenceTest();
+  snackBarTest();
+  base64UtilTest();
+  uiUtilsMiscTest();
+  tokenImporterRegistryTest();
+  responsiveLayoutPolicyTest();
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -29,6 +29,18 @@ import base64UtilTest from './Base64Util.test';
 import uiUtilsMiscTest from './UiUtilsMisc.test';
 import tokenImporterRegistryTest from './TokenImporter.test';
 import responsiveLayoutPolicyTest from './ResponsiveLayoutPolicy.test';
+import tokenStoreTest from './TokenStore.test';
+import cryptoUtilsTest from './CryptoUtils.test';
+import cloudBackupManagerTest from './CloudBackupManager.test';
+import backupRestoreHelperTest from './BackupRestoreHelper.test';
+import tokenBackupTest from './TokenBackup.test';
+import tokenCardStoreTest from './TokenCardStore.test';
+import steamSecretStoreTest from './SteamSecretStore.test';
+import tokenKvBatchTest from './TokenKvBatch.test';
+import fileUtilsTest from './FileUtils.test';
+import storagePortsTest from './StoragePorts.test';
+import oathAppletTest from './OathApplet.test';
+import iconPackCloudBackupTest from './IconPackCloudBackup.test';
 
 export default function testsuite() {
   localUnitTest();
@@ -62,4 +74,16 @@ export default function testsuite() {
   uiUtilsMiscTest();
   tokenImporterRegistryTest();
   responsiveLayoutPolicyTest();
+  tokenStoreTest();
+  cryptoUtilsTest();
+  cloudBackupManagerTest();
+  backupRestoreHelperTest();
+  tokenBackupTest();
+  tokenCardStoreTest();
+  steamSecretStoreTest();
+  tokenKvBatchTest();
+  fileUtilsTest();
+  storagePortsTest();
+  oathAppletTest();
+  iconPackCloudBackupTest();
 }

--- a/entry/src/test/OathApplet.test.ets
+++ b/entry/src/test/OathApplet.test.ets
@@ -1,0 +1,372 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { OathError, OathSession, OathCredential } from '../main/ets/oath/OathApplet';
+import { FakeOathCrypto, ScriptedTagTransport } from './fakes/BackupFakes';
+
+/**
+ * OATH Applet 协议层测试（快速赢面 11 号，Phase 2 头落地）。
+ *
+ * 传输与密码学均注入脚本化/确定性假实现，覆盖：
+ * SELECT 解析与锁定、VALIDATE 三种结果、CALCULATE ALL 的凭据分类
+ * （默认周期取码 / HOTP 与非默认周期重算 / touch 跳过）、
+ * 61xx 分片链、状态字错误映射、TLV 与验证码格式化边界。
+ * PBKDF2/HMAC-SHA1 数值归真机 ohosTest（RFC 向量）。
+ */
+
+const SW_OK = 0x9000;
+
+function tlv(tag: number, value: number[]): number[] {
+  return [tag, value.length].concat(value);
+}
+
+function withSw(data: number[], sw: number): number[] {
+  return data.concat([(sw >> 8) & 0xFF, sw & 0xFF]);
+}
+
+function numbersToBytes(numbers: number[]): Uint8Array {
+  return new Uint8Array(numbers);
+}
+
+function bytesToNumbers(data: Uint8Array): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < data.length; i++) {
+    out.push(data[i]);
+  }
+  return out;
+}
+
+/** SELECT 成功响应：版本 + 盐 + 可选 challenge（存在即锁定） */
+function selectResponse(version: number[], salt: number[], challenge: number[] | null): number[] {
+  let data: number[] = tlv(0x79, version).concat(tlv(0x71, salt));
+  if (challenge !== null) {
+    data = data.concat(tlv(0x74, challenge));
+  }
+  return withSw(data, SW_OK);
+}
+
+/** CALCULATE ALL 凭据对：名称 TLV + 响应 TLV */
+function credentialPair(name: string, responseTag: number, responseValue: number[]): number[] {
+  const nameBytes: number[] = [];
+  for (let i = 0; i < name.length; i++) {
+    nameBytes.push(name.charCodeAt(i));
+  }
+  return tlv(0x71, nameBytes).concat(tlv(responseTag, responseValue));
+}
+
+/** truncated = [digits, 4 字节大端 hash] */
+function truncated(digits: number, hashValue: number): number[] {
+  return [digits, (hashValue >>> 24) & 0xFF, (hashValue >>> 16) & 0xFF, (hashValue >>> 8) & 0xFF, hashValue & 0xFF];
+}
+
+interface SessionRig {
+  transport: ScriptedTagTransport;
+  crypto: FakeOathCrypto;
+  session: OathSession;
+}
+
+function freshSession(locked: boolean): SessionRig {
+  const transport = new ScriptedTagTransport();
+  const crypto = new FakeOathCrypto();
+  transport.queueResponse(selectResponse([5, 7, 1], [0x11, 0x22], locked ? [1, 2, 3, 4, 5, 6, 7, 8] : null));
+  const session = new OathSession(transport, crypto);
+  return { transport: transport, crypto: crypto, session: session };
+}
+
+export default function oathAppletTest() {
+  describe('oathAppletTest', () => {
+    it('select_unlocked_parses_version_salt_and_stays_unlocked', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      // locked getter 不经外部可查，行为经 calculateAll 是否要求认证体现；
+      // 此处验证 SELECT APDU 结构（00 A4 04 00 07 + AID）
+      expect(rig.transport.sentApdus.length).assertEqual(1);
+      const apdu = rig.transport.sentApdus[0];
+      expect(apdu[0]).assertEqual(0x00);
+      expect(apdu[1]).assertEqual(0xA4);
+      expect(apdu[4]).assertEqual(0x07);
+      expect(apdu.length).assertEqual(12);
+    });
+
+    it('select_non_oath_card_maps_to_not_oath_error', 0, async () => {
+      const transport = new ScriptedTagTransport();
+      transport.queueResponse(withSw([], 0x6A82));
+      const session = new OathSession(transport, new FakeOathCrypto());
+
+      let kind = '';
+      try {
+        await session.select();
+      } catch (e) {
+        const err = e as OathError;
+        kind = err.kind;
+        expect(err.sw).assertEqual(0x6A82);
+      }
+      expect(kind).assertEqual('NOT_OATH');
+    });
+
+    it('validate_when_unlocked_is_noop', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      await rig.session.validate('password');
+      // 未锁定：零额外 APDU、零派生
+      expect(rig.transport.sentApdus.length).assertEqual(1);
+      expect(rig.crypto.deriveCalls).assertEqual(0);
+    });
+
+    it('validate_success_unlocks_session', 0, async () => {
+      const rig = freshSession(true);
+      await rig.session.select();
+
+      // VALIDATE 响应须携带与本地计算一致的 0x75 response（假 HMAC 双侧一致）
+      const crypto = rig.crypto;
+      const key = await crypto.pbkdf2Sha1Derive('pw', numbersToBytes([0x11, 0x22]), 1000, 16);
+      const newChallenge = crypto.randomBytes(8);
+      const expected = await crypto.hmacSha1(key, newChallenge);
+      rig.transport.queueResponse(withSw(tlv(0x75, bytesToNumbers(expected)), SW_OK));
+
+      const derivesBefore = rig.crypto.deriveCalls;
+      await rig.session.validate('pw');
+      // 会话内部恰好再派生一次
+      expect(rig.crypto.deriveCalls).assertEqual(derivesBefore + 1);
+      // 解锁后 calculateAll 不再要求认证（下一用例反向验证）
+    });
+
+    it('validate_wrong_password_maps_to_wrong_password_error', 0, async () => {
+      const rig = freshSession(true);
+      await rig.session.select();
+      rig.transport.queueResponse(withSw([], 0x6982));
+
+      let kind = '';
+      try {
+        await rig.session.validate('bad');
+      } catch (e) {
+        kind = (e as OathError).kind;
+      }
+      expect(kind).assertEqual('WRONG_PASSWORD');
+    });
+
+    it('validate_response_mismatch_maps_to_wrong_password_error', 0, async () => {
+      const rig = freshSession(true);
+      await rig.session.select();
+      // 返回错误的 0x75（与本地对新 challenge 的 HMAC 不一致）
+      rig.transport.queueResponse(withSw(tlv(0x75, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+        17, 18, 19, 20]), SW_OK));
+
+      let kind = '';
+      try {
+        await rig.session.validate('pw');
+      } catch (e) {
+        kind = (e as OathError).kind;
+      }
+      expect(kind).assertEqual('WRONG_PASSWORD');
+    });
+
+    it('calculate_all_default_period_takes_code_directly', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      rig.transport.queueResponse(withSw(
+        credentialPair('30/GitHub:octocat', 0x76, truncated(6, 12345678)),
+        SW_OK));
+
+      const credentials = await rig.session.calculateAll(1000000000);
+      expect(credentials.length).assertEqual(1);
+      const cred = credentials[0];
+      expect(cred.issuer).assertEqual('GitHub');
+      expect(cred.name).assertEqual('octocat');
+      expect(cred.oathType).assertEqual('TOTP');
+      expect(cred.period).assertEqual(30);
+      expect(cred.digits).assertEqual(6);
+      // (12345678 & 0x7FFFFFFF) % 10^6
+      expect(cred.code).assertEqual('345678');
+      // 默认周期直接取码：无额外 CALCULATE APDU
+      expect(rig.transport.sentApdus.length).assertEqual(2);
+    });
+
+    it('calculate_all_requires_password_when_locked_returns_6982', 0, async () => {
+      const rig = freshSession(true);
+      await rig.session.select();
+      rig.transport.queueResponse(withSw([], 0x6982));
+
+      let kind = '';
+      try {
+        await rig.session.calculateAll(1000000000);
+      } catch (e) {
+        kind = (e as OathError).kind;
+      }
+      expect(kind).assertEqual('PASSWORD_REQUIRED');
+    });
+
+    it('calculate_all_hotp_credentials_recoded_via_single_calculate', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      // HOTP 凭据：0x77 响应标签，无码 → 触发空 challenge CALCULATE
+      rig.transport.queueResponse(withSw(
+        credentialPair('hotpaccount', 0x77, []),
+        SW_OK));
+      rig.transport.queueResponse(withSw(tlv(0x76, truncated(6, 999999)), SW_OK));
+
+      const credentials = await rig.session.calculateAll(1000000000);
+      expect(credentials.length).assertEqual(1);
+      const cred = credentials[0];
+      expect(cred.oathType).assertEqual('HOTP');
+      expect(cred.period).assertEqual(0);
+      expect(cred.code).assertEqual('999999');
+      // CALCULATE APDU：空 challenge（74 00）
+      const calc = rig.transport.sentApdus[2];
+      expect(calc[1]).assertEqual(0xA2);
+      const tail = calc.slice(calc.length - 2);
+      expect(tail[0]).assertEqual(0x74);
+      expect(tail[1]).assertEqual(0x00);
+    });
+
+    it('calculate_all_non_default_period_recalculates_with_own_period', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      // 名称带 60 前缀 + 0x76 truncated → 非默认周期需重算
+      rig.transport.queueResponse(withSw(
+        credentialPair('60/Slow:alice', 0x76, truncated(6, 1)),
+        SW_OK));
+      rig.transport.queueResponse(withSw(tlv(0x76, truncated(6, 2)), SW_OK));
+
+      const credentials = await rig.session.calculateAll(1000000000);
+      expect(credentials.length).assertEqual(1);
+      expect(credentials[0].period).assertEqual(60);
+      expect(credentials[0].code).assertEqual('000002');
+    });
+
+    it('calculate_all_touch_credentials_are_skipped', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      rig.transport.queueResponse(withSw(
+        credentialPair('touchy', 0x7C, []),
+        SW_OK));
+
+      const credentials = await rig.session.calculateAll(1000000000);
+      expect(credentials.length).assertEqual(0);
+    });
+
+    it('calculate_all_malformed_name_pair_is_skipped', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      // 名称对缺失：第一个 TLV 不是 0x71 → 跳过
+      rig.transport.queueResponse(withSw(
+        tlv(0x76, truncated(6, 5)).concat(tlv(0x76, truncated(6, 5))),
+        SW_OK));
+
+      const credentials = await rig.session.calculateAll(1000000000);
+      expect(credentials.length).assertEqual(0);
+    });
+
+    it('calculate_all_single_calculate_failure_skips_credential', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      // HOTP 凭据触发重算，但 CALCULATE 返回错误 SW → 跳过该凭据
+      rig.transport.queueResponse(withSw(credentialPair('broken', 0x77, []), SW_OK));
+      rig.transport.queueResponse(withSw([], 0x6A80));
+
+      const credentials = await rig.session.calculateAll(1000000000);
+      expect(credentials.length).assertEqual(0);
+    });
+
+    it('transmit_apdu_chains_61xx_remaining_data', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      // CALCULATE ALL 响应拆成 61xx 分片
+      const part1 = credentialPair('30/A:B', 0x76, truncated(6, 4321));
+      const chunk1 = part1.slice(0, 4);
+      const chunk2 = part1.slice(4);
+      rig.transport.queueResponse(withSw(chunk1, 0x6105));
+      rig.transport.queueResponse(withSw(chunk2, SW_OK));
+
+      const credentials = await rig.session.calculateAll(1000000000);
+      expect(credentials.length).assertEqual(1);
+      expect(credentials[0].code).assertEqual('004321');
+      // SEND REMAINING APDU：00 A5 00 00 00
+      const remaining = rig.transport.sentApdus[2];
+      expect(remaining[0]).assertEqual(0x00);
+      expect(remaining[1]).assertEqual(0xA5);
+      expect(remaining[4]).assertEqual(0x00);
+    });
+
+    it('calculate_all_protocol_error_maps_to_protocol_kind', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      rig.transport.queueResponse(withSw([], 0x6D00));
+
+      let kind = '';
+      try {
+        await rig.session.calculateAll(1000000000);
+      } catch (e) {
+        kind = (e as OathError).kind;
+      }
+      expect(kind).assertEqual('PROTOCOL');
+    });
+
+    it('hotp_credid_issuer_split_on_first_colon', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      rig.transport.queueResponse(withSw(
+        credentialPair('MyIssuer:user@host', 0x77, []),
+        SW_OK));
+      rig.transport.queueResponse(withSw(tlv(0x76, truncated(6, 7)), SW_OK));
+
+      const credentials = await rig.session.calculateAll(1000000000);
+      expect(credentials[0].issuer).assertEqual('MyIssuer');
+      expect(credentials[0].name).assertEqual('user@host');
+    });
+
+    it('totp_credid_without_period_defaults_to_30', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      rig.transport.queueResponse(withSw(
+        credentialPair('plainname', 0x76, truncated(6, 2)),
+        SW_OK));
+
+      const credentials = await rig.session.calculateAll(1000000000);
+      expect(credentials[0].period).assertEqual(30);
+      expect(credentials[0].issuer).assertEqual('');
+      expect(credentials[0].name).assertEqual('plainname');
+    });
+
+    it('format_code_zero_pads_to_digit_count', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      // 8 位 + hash 值 42 → (42 % 10^8) = 42 → '00000042'
+      rig.transport.queueResponse(withSw(
+        credentialPair('pad', 0x76, truncated(8, 42)),
+        SW_OK));
+
+      const credentials = await rig.session.calculateAll(1000000000);
+      expect(credentials[0].code).assertEqual('00000042');
+      expect(credentials[0].digits).assertEqual(8);
+    });
+
+    it('close_is_idempotent_and_closes_transport_once', 0, async () => {
+      const rig = freshSession(false);
+      const transport = rig.transport;
+      await rig.session.close();
+      await rig.session.close();
+      expect(transport.closed).assertTrue();
+    });
+
+    it('oath_error_carries_status_word', 0, () => {
+      const err = new OathError('PROTOCOL', 'boom', 0x6A82);
+      expect(err.kind).assertEqual('PROTOCOL');
+      expect(err.sw).assertEqual(0x6A82);
+      expect(err.name).assertEqual('OathError');
+      const plain = new OathError('NO_TOKENS', 'empty');
+      expect(plain.sw === undefined).assertTrue();
+    });
+
+    it('credential_default_digits_falls_back_to_six', 0, async () => {
+      const rig = freshSession(false);
+      await rig.session.select();
+      // 空 truncated 值 → digits 回退 6
+      rig.transport.queueResponse(withSw(
+        credentialPair('empty76', 0x76, []),
+        SW_OK));
+
+      const credentials: OathCredential[] = await rig.session.calculateAll(1000000000);
+      expect(credentials[0].digits).assertEqual(6);
+      expect(credentials[0].code).assertEqual('');
+    });
+  });
+}

--- a/entry/src/test/ResponsiveLayoutPolicy.test.ets
+++ b/entry/src/test/ResponsiveLayoutPolicy.test.ets
@@ -1,0 +1,63 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  RESPONSIVE_SIDE_NAV_MIN_WIDTH_VP,
+  RESPONSIVE_SPLIT_MAX_ASPECT_RATIO,
+  RESPONSIVE_SPLIT_MIN_WIDTH_VP,
+  ResponsiveLayoutPolicy,
+  ResponsiveLayoutState,
+} from 'common';
+
+/**
+ * 响应式布局断点决策测试（纯 vp 数值入口 resolveVp）。
+ * 一级导航只看横向断点；业务分栏还需宽高比 < 1.2，二者独立判定。
+ */
+export default function responsiveLayoutPolicyTest() {
+  describe('responsiveLayoutPolicyTest', () => {
+    it('breakpoint_constants_match_official_lg_threshold', 0, () => {
+      expect(RESPONSIVE_SIDE_NAV_MIN_WIDTH_VP).assertEqual(840);
+      expect(RESPONSIVE_SPLIT_MIN_WIDTH_VP).assertEqual(840);
+      expect(RESPONSIVE_SPLIT_MAX_ASPECT_RATIO).assertEqual(1.2);
+    });
+
+    it('phone_portrait_uses_neither_side_nav_nor_split', 0, () => {
+      const state = ResponsiveLayoutPolicy.resolveVp(360, 780);
+      expect(state.widthVp).assertEqual(360);
+      expect(state.heightVp).assertEqual(780);
+      expect(state.useSideNavigation).assertFalse();
+      expect(state.allowSplit).assertFalse();
+      expect(state.heightToWidthRatio > 2).assertTrue();
+    });
+
+    it('side_nav_starts_exactly_at_lg_breakpoint', 0, () => {
+      expect(ResponsiveLayoutPolicy.resolveVp(839.9, 900).useSideNavigation).assertFalse();
+      expect(ResponsiveLayoutPolicy.resolveVp(840, 900).useSideNavigation).assertTrue();
+      expect(ResponsiveLayoutPolicy.resolveVp(1024, 600).useSideNavigation).assertTrue();
+    });
+
+    it('split_requires_friendly_aspect_ratio', 0, () => {
+      // 达到 lg 但太“瘦高”（比例 ≥ 1.2）→ 不允许分栏
+      const tall = ResponsiveLayoutPolicy.resolveVp(840, 1100);
+      expect(tall.useSideNavigation).assertTrue();
+      expect(tall.allowSplit).assertFalse();
+
+      // 比例 1.071 < 1.2 → 允许
+      const wide = ResponsiveLayoutPolicy.resolveVp(840, 900);
+      expect(wide.allowSplit).assertTrue();
+
+      // 边界：比例恰为 1.2 → 不允许（严格小于）
+      const boundary = ResponsiveLayoutPolicy.resolveVp(1000, 1200);
+      expect(boundary.allowSplit).assertFalse();
+
+      // 窄窗口即使比例友好也不分栏
+      const narrow = ResponsiveLayoutPolicy.resolveVp(600, 600);
+      expect(narrow.allowSplit).assertFalse();
+    });
+
+    it('zero_width_avoids_division_by_zero', 0, () => {
+      const state: ResponsiveLayoutState = ResponsiveLayoutPolicy.resolveVp(0, 500);
+      expect(state.heightToWidthRatio).assertEqual(0);
+      expect(state.useSideNavigation).assertFalse();
+      expect(state.allowSplit).assertFalse();
+    });
+  });
+}

--- a/entry/src/test/SnackBar.test.ets
+++ b/entry/src/test/SnackBar.test.ets
@@ -1,0 +1,39 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  setSnackBarImpl,
+  showSnackBar,
+  SnackBarNotifyOptions,
+  SnackBarNotifyType,
+} from 'common';
+
+/**
+ * SnackBar 注入点测试：LocalUnit 无 UI，注入记录函数验证分发行为。
+ * 注意：impl 是模块级单例，注入后会影响后续用例——保持断言不依赖默认实现。
+ */
+export default function snackBarTest() {
+  describe('snackBarTest', () => {
+    it('notify_type_enum_values', 0, () => {
+      expect(SnackBarNotifyType.INFO).assertEqual('INFO');
+      expect(SnackBarNotifyType.WARNING).assertEqual('WARNING');
+      expect(SnackBarNotifyType.ERROR).assertEqual('ERROR');
+      expect(SnackBarNotifyType.SUCCESS).assertEqual('SUCCESS');
+    });
+
+    it('show_snackbar_delegates_to_injected_impl', 0, () => {
+      const calls: string[] = [];
+      setSnackBarImpl((message: ResourceStr, type: SnackBarNotifyType,
+        options: SnackBarNotifyOptions) => {
+        calls.push(`${String(message)}|${type}|${options.duration ?? -1}`);
+      });
+
+      showSnackBar('saved', SnackBarNotifyType.SUCCESS, { duration: 1500 });
+      expect(calls.length).assertEqual(1);
+      expect(calls[0]).assertEqual('saved|SUCCESS|1500');
+
+      // 默认参数：INFO 类型 + 空 options
+      showSnackBar('plain');
+      expect(calls.length).assertEqual(2);
+      expect(calls[1]).assertEqual('plain|INFO|-1');
+    });
+  });
+}

--- a/entry/src/test/SteamClientExtra.test.ets
+++ b/entry/src/test/SteamClientExtra.test.ets
@@ -1,0 +1,386 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { HttpRequestSpec, HttpResult, HttpTransport, SteamTransport } from '../main/ets/steam/SteamHttp';
+import { ProtoReader, ProtoWriter } from 'common';
+import {
+  Sleeper,
+  SteamAccessToken,
+  SteamAuthSession,
+  SteamClient,
+  SteamQrChallenge,
+} from '../main/ets/steam/SteamClient';
+import { base64Decode, base64Encode, utf8ToBytes } from '../main/ets/steam/SteamCrypto';
+import { EAuthSessionGuardType } from '../main/ets/steam/proto/SteamMessages';
+
+/**
+ * Steam 客户端补充测试：接续 SteamClient.test.ets（轮询/确认已覆盖），
+ * 这里覆盖 RSA 公钥解析、BeginAuthSession 响应解码（含 float interval）、
+ * newClientId 迁移分支、迁移/撤销/状态查询全链路与请求体字段回读。
+ * 全部走假传输层，无网络。
+ */
+
+const STEAMID = 76561198000000000n;
+const SECRET_B64 = 'MDEyMzQ1Njc4OWFiY2RlZg==';
+
+class FakeSleeper implements Sleeper {
+  sleep(ms: number): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class FakeTransport implements HttpTransport {
+  specs: HttpRequestSpec[] = [];
+  private queue: HttpResult[] = [];
+
+  push(result: HttpResult): void {
+    this.queue.push(result);
+  }
+
+  send(spec: HttpRequestSpec): Promise<HttpResult> {
+    this.specs.push(spec);
+    const next: HttpResult | undefined = this.queue.shift();
+    return Promise.resolve(next === undefined ? new HttpResult() : next);
+  }
+}
+
+function okResult(bytes: Uint8Array): HttpResult {
+  const result = new HttpResult();
+  result.statusCode = 200;
+  result.headers = { 'x-eresult': '1' };
+  result.bytes = bytes;
+  return result;
+}
+
+function okText(text: string): HttpResult {
+  const result = new HttpResult();
+  result.statusCode = 200;
+  result.headers = { 'x-eresult': '1' };
+  result.text = text;
+  return result;
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) {
+    total += p.length;
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+/** ProtoWriter 不支持写 float（fixed32 LE），这里手工编码 field tag + IEEE754 LE */
+function fieldFloat32(field: number, value: number): Uint8Array {
+  const dv = new DataView(new ArrayBuffer(4));
+  dv.setFloat32(0, value, true);
+  const tagByte = (field << 3) | 5;
+  const tagBytes: Uint8Array = tagByte < 0x80
+    ? new Uint8Array([tagByte])
+    : new Uint8Array([0x80 | (tagByte & 0x7f), tagByte >> 7]);
+  return concatBytes([tagBytes, new Uint8Array(dv.buffer)]);
+}
+
+function beginAuthBytes(includeInterval: boolean): Uint8Array {
+  const w = new ProtoWriter();
+  w.writeUint64(1, 987654321n);
+  w.writeBytes(2, Uint8Array.from([9, 8, 7]));
+  const confirm = new ProtoWriter();
+  confirm.writeInt32(1, EAuthSessionGuardType.DEVICE_CODE);
+  confirm.writeString(2, 'check your device');
+  w.writeMessage(4, confirm);
+  const confirm2 = new ProtoWriter();
+  confirm2.writeInt32(1, EAuthSessionGuardType.EMAIL_CODE);
+  w.writeMessage(4, confirm2);
+  w.writeUint64(5, STEAMID);
+  if (includeInterval) {
+    return concatBytes([w.finish(), fieldFloat32(3, 7.0)]);
+  }
+  return w.finish();
+}
+
+function pollBytesAuthorized(newClientId: bigint): Uint8Array {
+  const w = new ProtoWriter();
+  // field 1: newClientId —— 迁移分支只有拿到凭证后才会执行
+  w.writeUint64(1, newClientId);
+  w.writeString(3, 'refresh-xyz');
+  w.writeString(4, 'access-xyz');
+  w.writeString(6, 'account');
+  return w.finish();
+}
+
+/** 回读请求体：input_protobuf_encoded=<percent(base64(payload))> → 原始 protobuf 字节 */
+function decodeProtoFromBody(body: string): Uint8Array {
+  const prefix = 'input_protobuf_encoded=';
+  expect(body.startsWith(prefix)).assertTrue();
+  return base64Decode(decodeURIComponent(body.substring(prefix.length)));
+}
+
+function readFieldString(buf: Uint8Array, fieldNo: number): string {
+  const r = new ProtoReader(buf);
+  while (r.next()) {
+    if (r.field() === fieldNo) {
+      return r.readString();
+    }
+    r.skip();
+  }
+  return '';
+}
+
+function readFieldBool(buf: Uint8Array, fieldNo: number): boolean {
+  const r = new ProtoReader(buf);
+  while (r.next()) {
+    if (r.field() === fieldNo) {
+      return r.readBool();
+    }
+    r.skip();
+  }
+  return false;
+}
+
+const RSA_JSON = '{"response":{"publickey_mod":"EFCDAB8974523011234567890ABCDEF0",'
+  + '"publickey_exp":"010001","timestamp":"1700000001"}}';
+
+export default function steamClientExtraTest() {
+  describe('steamClientExtraTest', () => {
+    it('get_password_rsa_public_key_parses_response', 0, async () => {
+      const transport = new FakeTransport();
+      transport.push(okText(RSA_JSON));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      const key = await client.getPasswordRsaPublicKey('gabe');
+
+      expect(key.publickeyMod).assertEqual('EFCDAB8974523011234567890ABCDEF0');
+      expect(key.publickeyExp).assertEqual('010001');
+      expect(key.timestamp.toString()).assertEqual('1700000001');
+      expect(transport.specs[0].method).assertEqual('GET');
+      expect(transport.specs[0].url.indexOf('account_name=gabe') > 0).assertTrue();
+    });
+
+    it('begin_auth_session_decodes_interval_and_confirmations', 0, async () => {
+      const transport = new FakeTransport();
+      transport.push(okText(RSA_JSON));
+      transport.push(okResult(beginAuthBytes(true)));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      const session = await client.beginAuthSession('gabe', 'pw', 'My Device');
+
+      expect(session.clientId.toString()).assertEqual('987654321');
+      expect(Array.from(session.requestId).join(',')).assertEqual('9,8,7');
+      // 服务端 interval（float 字段）优先生效
+      expect(session.intervalSeconds).assertEqual(7);
+      expect(session.steamid.toString()).assertEqual(STEAMID.toString());
+      expect(session.preferredConfirmation()!.confirmationType)
+        .assertEqual(EAuthSessionGuardType.DEVICE_CODE);
+      expect(session.requiresCode()).assertTrue();
+    });
+
+    it('begin_auth_session_defaults_interval_when_missing', 0, async () => {
+      const transport = new FakeTransport();
+      transport.push(okText(RSA_JSON));
+      transport.push(okResult(beginAuthBytes(false)));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      const session = await client.beginAuthSession('gabe', 'pw', 'dev');
+      expect(session.intervalSeconds).assertEqual(5);
+    });
+
+    it('poll_migrates_client_id_when_server_assigns_new_one', 0, async () => {
+      const transport = new FakeTransport();
+      transport.push(okResult(pollBytesAuthorized(424242n)));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      const session = new SteamAuthSession();
+      session.clientId = 1n;
+      session.requestId = new Uint8Array(0);
+      session.intervalSeconds = 1;
+
+      // 拿到凭证且服务端下发了 newClientId → 会话被迁移
+      const done = await client.pollAuthSessionStatus(session);
+      expect(done).assertTrue();
+      expect(session.clientId.toString()).assertEqual('424242');
+      expect(session.refreshToken).assertEqual('refresh-xyz');
+      expect(session.accountName).assertEqual('account');
+    });
+
+    it('submit_steam_guard_code_posts_protobuf', 0, async () => {
+      const transport = new FakeTransport();
+      transport.push(okResult(new Uint8Array(0)));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      const session = new SteamAuthSession();
+      session.clientId = 55n;
+      session.steamid = STEAMID;
+
+      await client.submitSteamGuardCode(session, 'ABC123', EAuthSessionGuardType.DEVICE_CODE);
+
+      expect(transport.specs[0].url.indexOf('UpdateAuthSessionWithSteamGuardCode') > 0).assertTrue();
+      const payload = decodeProtoFromBody(transport.specs[0].body);
+      // 回读全部请求字段：clientId=varint(1)、steamid=fixed64(2)、code=string(3)、codeType=int32(4)
+      const r = new ProtoReader(payload);
+      let clientId = 0n;
+      let steamid = 0n;
+      let code = '';
+      let codeType = -1;
+      while (r.next()) {
+        switch (r.field()) {
+          case 1: clientId = r.readUint64(); break;
+          case 2: steamid = r.readFixed64(); break;
+          case 3: code = r.readString(); break;
+          case 4: codeType = r.readInt32(); break;
+          default: r.skip(); break;
+        }
+      }
+      expect(clientId.toString()).assertEqual('55');
+      expect(steamid.toString()).assertEqual(STEAMID.toString());
+      expect(code).assertEqual('ABC123');
+      expect(codeType).assertEqual(EAuthSessionGuardType.DEVICE_CODE);
+    });
+
+    it('finalize_add_authenticator_parses_response_and_request_fields', 0, async () => {
+      const transport = new FakeTransport();
+      const w = new ProtoWriter();
+      w.writeBool(1, true);
+      w.writeUint64(3, 1788953926n);
+      w.writeInt32(4, 1);
+      transport.push(okResult(w.finish()));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      const response = await client.finalizeAddAuthenticator(STEAMID, 'access-1', '5digit',
+        1788953925.7, 'SMS-999');
+
+      expect(response.success).assertTrue();
+      expect(response.serverTime.toString()).assertEqual('1788953926');
+      expect(response.status).assertEqual(1);
+      expect(transport.specs[0].url.indexOf('access_token=access-1') > 0).assertTrue();
+      const payload = decodeProtoFromBody(transport.specs[0].body);
+      expect(readFieldString(payload, 2)).assertEqual('5digit');
+      expect(readFieldString(payload, 4)).assertEqual('SMS-999');
+      expect(readFieldBool(payload, 6)).assertTrue();
+    });
+
+    it('transfer_start_and_sms_code_roundtrip', 0, async () => {
+      const transport = new FakeTransport();
+      transport.push(okResult(new Uint8Array(0)));
+      const response = new ProtoWriter();
+      response.writeBool(1, true);
+      const replacement = new ProtoWriter();
+      replacement.writeBytes(1, Uint8Array.from([1, 2, 3]));
+      replacement.writeString(3, 'R0V0C0DE');
+      replacement.writeString(6, 'account');
+      response.writeMessage(2, replacement);
+      transport.push(okResult(response.finish()));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      expect(await client.startTransferAuthenticator(STEAMID, 'access-1')).assertTrue();
+
+      const result = await client.submitTransferSmsCode(STEAMID, 'access-1', '12345');
+      expect(result.success).assertTrue();
+      expect(result.replacementToken!.revocationCode).assertEqual('R0V0C0DE');
+      expect(result.replacementToken!.accountName).assertEqual('account');
+      expect(Array.from(result.replacementToken!.sharedSecret).join(',')).assertEqual('1,2,3');
+
+      const smsPayload = decodeProtoFromBody(transport.specs[1].body);
+      expect(readFieldString(smsPayload, 1)).assertEqual('12345');
+      expect(readFieldBool(smsPayload, 2)).assertTrue();
+      expect(transport.specs[1].url.indexOf('access_token=access-1') > 0).assertTrue();
+    });
+
+    it('revoke_authenticator_sends_revocation_code', 0, async () => {
+      const transport = new FakeTransport();
+      const w = new ProtoWriter();
+      w.writeBool(1, true);
+      w.writeUint64(3, 42n);
+      transport.push(okResult(w.finish()));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      const response = await client.revokeAuthenticator(STEAMID, 'access-1', 'R0V0C0DE');
+
+      expect(response.success).assertTrue();
+      const payload = decodeProtoFromBody(transport.specs[0].body);
+      expect(readFieldString(payload, 2)).assertEqual('R0V0C0DE');
+    });
+
+    it('query_status_parses_state_and_request_steamid', 0, async () => {
+      const transport = new FakeTransport();
+      const w = new ProtoWriter();
+      w.writeUint32(1, 2);
+      w.writeString(6, 'gid-88');
+      w.writeBool(7, true);
+      transport.push(okResult(w.finish()));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      const status = await client.queryStatus(STEAMID, 'access-1');
+
+      expect(status.state).assertEqual(2);
+      expect(status.tokenGid).assertEqual('gid-88');
+      expect(status.emailValidated).assertTrue();
+      // steamid 在 CTwoFactor_Status_Request 里是 fixed64 字段 1
+      const payload = decodeProtoFromBody(transport.specs[0].body);
+      const r = new ProtoReader(payload);
+      let foundSteamid = 0n;
+      while (r.next()) {
+        if (r.field() === 1) {
+          foundSteamid = r.readFixed64();
+        } else {
+          r.skip();
+        }
+      }
+      expect(foundSteamid.toString()).assertEqual(STEAMID.toString());
+    });
+
+    it('approve_qr_login_builds_signed_body_both_persistence_modes', 0, async () => {
+      const transport = new FakeTransport();
+      transport.push(okResult(new Uint8Array(0)));
+      transport.push(okResult(new Uint8Array(0)));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      const challenge = new SteamQrChallenge();
+      challenge.version = 2;
+      challenge.clientId = 1234567890123456789n;
+
+      await client.approveQrLogin(STEAMID, 'access-1', SECRET_B64, challenge, true);
+      await client.approveQrLogin(STEAMID, 'access-1', SECRET_B64, challenge, false);
+
+      const body1 = transport.specs[0].body;
+      expect(body1.indexOf('confirm=true') > 0).assertTrue();
+      expect(body1.indexOf('persistence=1') > 0).assertTrue();
+      expect(body1.indexOf('version=2') > 0).assertTrue();
+      expect(body1.indexOf('client_id=1234567890123456789') > 0).assertTrue();
+      expect(body1.indexOf('signature=') > 0).assertTrue();
+      expect(transport.specs[0].url.indexOf('access_token=access-1') > 0).assertTrue();
+
+      expect(transport.specs[1].body.indexOf('persistence=0') > 0).assertTrue();
+    });
+
+    it('get_confirmations_returns_empty_when_conf_field_missing', 0, async () => {
+      const transport = new FakeTransport();
+      transport.push(okText('{"success":true,"message":""}'));
+      const client = new SteamClient(new SteamTransport(transport), new FakeSleeper());
+
+      const list = await client.getConfirmations(STEAMID, 'access-1', SECRET_B64, 'dev', 1788953926);
+      expect(list.length).assertEqual(0);
+    });
+
+    it('access_token_validity_requires_margin_and_token', 0, () => {
+      const empty = new SteamAccessToken();
+      expect(empty.isValid(1000)).assertFalse();
+
+      const shortLived = new SteamAccessToken();
+      shortLived.token = 't';
+      shortLived.expiresAtSeconds = 1120;
+      // 余量不足 120 秒 → 视为过期，触发刷新
+      expect(shortLived.isValid(1000)).assertFalse();
+      expect(shortLived.isValid(999)).assertTrue();
+    });
+
+    it('base64_roundtrip_for_proto_payloads', 0, () => {
+      const payload = Uint8Array.from([0, 1, 2, 250, 251, 252, 253, 254, 255]);
+      expect(Array.from(base64Decode(base64Encode(payload))).join(','))
+        .assertEqual(Array.from(payload).join(','));
+      expect(base64Encode(utf8ToBytes('foobar'))).assertEqual('Zm9vYmFy');
+    });
+  });
+}

--- a/entry/src/test/SteamSecretStore.test.ets
+++ b/entry/src/test/SteamSecretStore.test.ets
@@ -1,0 +1,144 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { NamedSecretStore, SteamAuth, SteamSecretStore } from 'common';
+import { MemoryNamedSecretStore } from './fakes/BackupFakes';
+
+/**
+ * Steam 凭证分片存储测试（Phase 2 NamedSecretStore 端口注入）。
+ *
+ * 覆盖：别名规则、空值删除语义、refresh_token 分片与尾部分片回收、
+ * load「ASSET 有值才覆盖」语义（保护旧 mafile 迁移路径）、remove 全量清理。
+ */
+
+const ALIAS_PREFIX = 'opt_steam_sec_';
+
+/** hypium 顺序执行：绑定后端并存模块级引用，避免数组解构（ArkTS 禁用） */
+let currentBackend: MemoryNamedSecretStore = new MemoryNamedSecretStore();
+
+function bindSteamStore(): SteamSecretStore {
+  currentBackend = new MemoryNamedSecretStore();
+  const store = SteamSecretStore.getInstance();
+  store.useBackendForTest(currentBackend);
+  return store;
+}
+
+function makeAuth(identity: string, revocation: string, refresh: string): SteamAuth {
+  const auth = new SteamAuth();
+  auth.identitySecret = identity;
+  auth.revocationCode = revocation;
+  auth.refreshToken = refresh;
+  return auth;
+}
+
+function longRefreshToken(): string {
+  // > 800 字节（STEAM_SECRET_CHUNK_BYTES），必然产生 ≥2 个分片
+  return 'a'.repeat(2000);
+}
+
+export default function steamSecretStoreTest() {
+  describe('steamSecretStoreTest', () => {
+    it('save_writes_identity_and_revocation_aliases', 0, async () => {
+      const store = bindSteamStore();
+      const backend = currentBackend;
+
+      await store.save('uuid1', makeAuth('identity_v2', 'R123', ''));
+
+      expect(backend.secrets.get(`${ALIAS_PREFIX}uuid1_id`)).assertEqual('identity_v2');
+      expect(backend.secrets.get(`${ALIAS_PREFIX}uuid1_rev`)).assertEqual('R123');
+    });
+
+    it('save_empty_value_removes_alias', 0, async () => {
+      const store = bindSteamStore();
+      const backend = currentBackend;
+      await store.save('uuid1', makeAuth('id', 'rev', ''));
+      expect(backend.secrets.has(`${ALIAS_PREFIX}uuid1_id`)).assertTrue();
+
+      // 置空 → 对应别名被删除
+      await store.save('uuid1', makeAuth('', 'rev', ''));
+      expect(backend.secrets.has(`${ALIAS_PREFIX}uuid1_id`)).assertFalse();
+      expect(backend.secrets.has(`${ALIAS_PREFIX}uuid1_rev`)).assertTrue();
+    });
+
+    it('refresh_token_chunking_splits_and_joins', 0, async () => {
+      const store = bindSteamStore();
+      const backend = currentBackend;
+      const refresh = longRefreshToken();
+
+      await store.save('uuid2', makeAuth('id', 'rev', refresh));
+
+      // 多分片写入：_rt_0 与 _rt_1 均存在
+      const chunk0 = backend.secrets.get(`${ALIAS_PREFIX}uuid2_rt_0`);
+      const chunk1 = backend.secrets.get(`${ALIAS_PREFIX}uuid2_rt_1`);
+      expect(chunk0 !== undefined && chunk1 !== undefined).assertTrue();
+
+      // load 按序拼接还原
+      const auth = makeAuth('', '', '');
+      await store.load('uuid2', auth);
+      expect(auth.identitySecret).assertEqual('id');
+      expect(auth.refreshToken).assertEqual(refresh);
+    });
+
+    it('save_shorter_refresh_token_removes_stale_chunks', 0, async () => {
+      const store = bindSteamStore();
+      const backend = currentBackend;
+      await store.save('uuid3', makeAuth('', '', longRefreshToken()));
+      expect(backend.secrets.has(`${ALIAS_PREFIX}uuid3_rt_1`)).assertTrue();
+
+      // 缩短为单分片：探测到残留分片并回收，避免下次 load 拼接出错误长 token
+      await store.save('uuid3', makeAuth('', '', 'short-token'));
+      expect(backend.secrets.has(`${ALIAS_PREFIX}uuid3_rt_0`)).assertTrue();
+      expect(backend.secrets.has(`${ALIAS_PREFIX}uuid3_rt_1`)).assertFalse();
+      // 先探测再删除：probe 调用包含 _rt_1
+      let probedStale = false;
+      for (const alias of backend.probeCalls) {
+        if (alias === `${ALIAS_PREFIX}uuid3_rt_1`) {
+          probedStale = true;
+        }
+      }
+      expect(probedStale).assertTrue();
+    });
+
+    it('load_keeps_existing_values_when_asset_empty', 0, async () => {
+      const store = bindSteamStore();
+      // mafile 迁移路径：TokenStore 先用 mafile 构造 SteamAuth，此时 ASSET 尚无数据
+      const auth = makeAuth('mafile_identity', 'mafile_rev', 'mafile_refresh');
+
+      await store.load('uuid4', auth);
+      // ASSET 为空必须保留调用方已有值，否则等于把密钥丢掉
+      expect(auth.identitySecret).assertEqual('mafile_identity');
+      expect(auth.revocationCode).assertEqual('mafile_rev');
+      expect(auth.refreshToken).assertEqual('mafile_refresh');
+    });
+
+    it('load_overrides_only_fields_present_in_asset', 0, async () => {
+      const store = bindSteamStore();
+      const backend = currentBackend;
+      backend.secrets.set(`${ALIAS_PREFIX}uuid5_id`, 'asset_identity');
+
+      const auth = makeAuth('local_identity', 'local_rev', '');
+      await store.load('uuid5', auth);
+      expect(auth.identitySecret).assertEqual('asset_identity');
+      expect(auth.revocationCode).assertEqual('local_rev');
+    });
+
+    it('remove_cleans_all_aliases_including_chunks', 0, async () => {
+      const store = bindSteamStore();
+      const backend = currentBackend;
+      await store.save('uuid6', makeAuth('id', 'rev', longRefreshToken()));
+      expect(backend.secrets.size >= 4).assertTrue();
+
+      await store.remove('uuid6');
+      expect(backend.secrets.size).assertEqual(0);
+    });
+
+    it('named_backend_failure_keeps_alias_missing_semantics', 0, async () => {
+      const store = bindSteamStore();
+      const backend = currentBackend;
+      backend.failUpsertFor.add(`${ALIAS_PREFIX}uuid7_id`);
+
+      const auth = makeAuth('id_value', '', '');
+      await store.save('uuid7', auth);
+      // upsert 失败 → 无别名落盘（不抛错，由上层验证三重机制兜底）
+      expect(backend.secrets.has(`${ALIAS_PREFIX}uuid7_id`)).assertFalse();
+    });
+  });
+}

--- a/entry/src/test/StoragePorts.test.ets
+++ b/entry/src/test/StoragePorts.test.ets
@@ -1,0 +1,67 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  BACKUP_FILE_EXT,
+  BACKUP_FILE_PREFIX,
+  formatRecordDate,
+  isBackupFileName,
+  parseBackupTimestamp,
+  utf8ByteLength,
+} from 'common';
+
+/**
+ * Phase 2 端口基础工具与共享助手测试：
+ * utf8ByteLength（ASSET 900 字节上限判定基础）、备份文件名解析/过滤/日期格式化。
+ */
+
+export default function storagePortsTest() {
+  describe('storagePortsTest', () => {
+    it('utf8_byte_length_counts_ascii_single_bytes', 0, () => {
+      expect(utf8ByteLength('')).assertEqual(0);
+      expect(utf8ByteLength('hello')).assertEqual(5);
+      expect(utf8ByteLength('JBSWY3DPEHPK3PXP')).assertEqual(16);
+    });
+
+    it('utf8_byte_length_counts_cjk_three_bytes', 0, () => {
+      expect(utf8ByteLength('令')).assertEqual(3);
+      expect(utf8ByteLength('中文abc')).assertEqual(3 + 3 + 3);
+    });
+
+    it('utf8_byte_length_counts_emoji_as_four_bytes', 0, () => {
+      // 😀 = U+1F600，代理对，4 字节
+      expect(utf8ByteLength('😀')).assertEqual(4);
+      expect(utf8ByteLength('a😀b')).assertEqual(6);
+    });
+
+    it('utf8_byte_length_matches_asset_900_byte_boundary', 0, () => {
+      // 900 字节 ASCII 恰好在限内；901 超限
+      const ok = 'a'.repeat(900);
+      const tooLong = 'a'.repeat(901);
+      expect(utf8ByteLength(ok) <= 900).assertTrue();
+      expect(utf8ByteLength(tooLong) <= 900).assertFalse();
+      // 300 个汉字 = 900 字节（恰好在限内）
+      expect(utf8ByteLength('令'.repeat(300))).assertEqual(900);
+    });
+
+    it('backup_file_name_filter_matches_prefix_and_suffix', 0, () => {
+      expect(isBackupFileName('otp_backup_123.enc')).assertTrue();
+      expect(isBackupFileName('otp_backup_notanumber.enc')).assertTrue();
+      expect(isBackupFileName('otp_backup_123.txt')).assertFalse();
+      expect(isBackupFileName('other_otp_backup_123.enc')).assertFalse();
+      expect(BACKUP_FILE_PREFIX).assertEqual('otp_backup_');
+      expect(BACKUP_FILE_EXT).assertEqual('.enc');
+    });
+
+    it('parse_backup_timestamp_reads_millisecond_field', 0, () => {
+      expect(parseBackupTimestamp('otp_backup_1745385600000.enc')).assertEqual(1745385600000);
+      expect(isNaN(parseBackupTimestamp('otp_backup_notanumber.enc'))).assertTrue();
+    });
+
+    it('format_record_date_produces_display_format', 0, () => {
+      // 2025-04-23 14:30 UTC+8 = 1745385000000；本地时区影响绝对值，
+      // 因此用本地 Date 构造后对照字段值
+      const d = new Date(2025, 3, 23, 14, 30, 0);
+      const formatted = formatRecordDate(d.getTime());
+      expect(formatted).assertEqual('2025-04-23 14:30');
+    });
+  });
+}

--- a/entry/src/test/TokenBackup.test.ets
+++ b/entry/src/test/TokenBackup.test.ets
@@ -1,0 +1,162 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  BackupTextIo,
+  base32Encode,
+  stringToIntArray,
+  TokenBackup,
+  TokenConfig,
+  TokenGroup,
+  TokenGroupKvBackend,
+  TokenGroupStore,
+  otpType,
+  restoreFromBackup,
+  saveBackupToFile,
+  useCryptoEngineForTest,
+} from 'common';
+import { FakeCryptoEngine } from './fakes/BackupFakes';
+
+/**
+ * 本地文件备份管线测试（Phase 2 BackupTextIo 端口注入 + CryptoEngine 假引擎）。
+ *
+ * 覆盖：明文/加密 base32 往返、magic/结构校验、分组合并。
+ * 文件 I/O 经内存 BackupTextIo，cryptoFramework 经假引擎。
+ */
+
+const TOKEN_BACKUP_MAGIC = 0x55aaeebb;
+
+class MemoryBackupTextIo implements BackupTextIo {
+  files: Map<string, string> = new Map();
+  writeCalls: number = 0;
+
+  readText(uri: string): Promise<string> {
+    const content = this.files.get(uri);
+    if (content === undefined) {
+      return Promise.reject(new Error(`no such file ${uri}`));
+    }
+    return Promise.resolve(content);
+  }
+
+  writeText(uri: string, content: string): Promise<void> {
+    this.writeCalls++;
+    this.files.set(uri, content);
+    return Promise.resolve();
+  }
+}
+
+class MemoryGroupKv implements TokenGroupKvBackend {
+  saved: TokenGroup[] | null = null;
+
+  getValue<T>(_key: string): Promise<T | null> {
+    if (this.saved === null) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(JSON.parse(JSON.stringify(this.saved)) as T);
+  }
+
+  setValue<T>(_key: string, value: T): Promise<void> {
+    this.saved = JSON.parse(JSON.stringify(value)) as TokenGroup[];
+    return Promise.resolve();
+  }
+}
+
+function makeToken(uuid: string, secret: string): TokenConfig {
+  const token = new TokenConfig(secret, otpType.TOTP);
+  token.TokenUUID = uuid;
+  token.RankScore = 0;
+  return token;
+}
+
+/** TokenGroupStore 绑定内存 KV，隔离分组状态 */
+function bindGroupStore(): void {
+  TokenGroupStore.getInstance().useKvBackendForTest(new MemoryGroupKv());
+  TokenGroupStore.getInstance().state.groups = [];
+}
+
+function putBackupFile(io: MemoryBackupTextIo, uri: string, json: string): void {
+  io.files.set(uri, base32Encode(stringToIntArray(json)));
+}
+
+export default function tokenBackupTest() {
+  describe('tokenBackupTest', () => {
+    it('plaintext_backup_roundtrip_preserves_configs_and_groups', 0, async () => {
+      const io = new MemoryBackupTextIo();
+      bindGroupStore();
+      const group = new TokenGroup('g1', 'Work', 0xFF0000FF);
+      TokenGroupStore.getInstance().state.groups = [group];
+
+      const backup = new TokenBackup(1, [makeToken('u1', 'secret1'), makeToken('u2', 'secret2')]);
+      await saveBackupToFile('memory://backup.txt', backup, false, '', io);
+
+      // 写出内容应为 base32 文本，且只写一次
+      const written = io.files.get('memory://backup.txt') ?? '';
+      expect(written.length > 0).assertTrue();
+      expect(io.writeCalls).assertEqual(1);
+
+      // 清空内存分组后恢复：分组按 ID 合并回来
+      TokenGroupStore.getInstance().state.groups = [];
+      const restored = await restoreFromBackup('memory://backup.txt', false, '', undefined, io);
+      expect(restored.magic).assertEqual(TOKEN_BACKUP_MAGIC);
+      expect(restored.configs.length).assertEqual(2);
+      expect(restored.configs[0].TokenUUID).assertEqual('u1');
+      expect(restored.configs[1].TokenSecret).assertEqual('secret2');
+      const groups = TokenGroupStore.getInstance().state.groups;
+      expect(groups.length).assertEqual(1);
+      expect(groups[0].id).assertEqual('g1');
+    });
+
+    it('encrypted_backup_roundtrip_with_fake_engine', 0, async () => {
+      useCryptoEngineForTest(new FakeCryptoEngine());
+      const io = new MemoryBackupTextIo();
+      bindGroupStore();
+
+      const backup = new TokenBackup(1, [makeToken('u1', 'enc_secret')]);
+      await saveBackupToFile('memory://enc.txt', backup, true, 'password1', io);
+      const written = io.files.get('memory://enc.txt') ?? '';
+      expect(written.length > 0).assertTrue();
+
+      const restored = await restoreFromBackup('memory://enc.txt', true, 'password1', undefined, io);
+      expect(restored.configs.length).assertEqual(1);
+      expect(restored.configs[0].TokenSecret).assertEqual('enc_secret');
+    });
+
+    it('restore_rejects_wrong_magic', 0, async () => {
+      const io = new MemoryBackupTextIo();
+      bindGroupStore();
+      putBackupFile(io, 'memory://bad.txt', '{"magic":1,"version":1,"configs":[]}');
+
+      let threw = false;
+      try {
+        await restoreFromBackup('memory://bad.txt', false, '', undefined, io);
+      } catch (e) {
+        threw = (e as Error).message === 'invalid backup file';
+      }
+      expect(threw).assertTrue();
+    });
+
+    it('restore_rejects_non_array_configs', 0, async () => {
+      const io = new MemoryBackupTextIo();
+      bindGroupStore();
+      putBackupFile(io, 'memory://bad2.txt', `{"magic":${TOKEN_BACKUP_MAGIC},"version":1,"configs":{}}`);
+
+      let threw = false;
+      try {
+        await restoreFromBackup('memory://bad2.txt', false, '', undefined, io);
+      } catch (e) {
+        threw = true;
+      }
+      expect(threw).assertTrue();
+    });
+
+    it('restore_missing_file_rejects', 0, async () => {
+      const io = new MemoryBackupTextIo();
+      bindGroupStore();
+      let threw = false;
+      try {
+        await restoreFromBackup('memory://missing.txt', false, '', undefined, io);
+      } catch (e) {
+        threw = true;
+      }
+      expect(threw).assertTrue();
+    });
+  });
+}

--- a/entry/src/test/TokenCardStore.test.ets
+++ b/entry/src/test/TokenCardStore.test.ets
@@ -1,0 +1,180 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  AppPreference,
+  CardConfig,
+  emptyCardData,
+  KeyValueStore,
+  PREF_KEYS,
+  TokenCardStore,
+  TokenConfig,
+  TokenStore,
+  otpType,
+} from 'common';
+import { MemorySecretStore, MemoryTokenKv } from './fakes/BackupFakes';
+
+/**
+ * 桌面卡片配置存取测试（Phase 2 KeyValueStore 端口注入）。
+ *
+ * 覆盖：配置 CRUD 与索引列表维护、卡片字段映射（generateCardData）、
+ * HOTP 计数器自增。preferences 与 TokenStore 均为内存实现。
+ * （TokenGroupStore 默认后端在 LocalUnit 下 getValue 安全返回 null，无需绑定。）
+ */
+
+class MemoryPrefKv implements KeyValueStore {
+  entries: Map<string, string> = new Map();
+
+  getValue<T>(key: string): Promise<T | null> {
+    const raw = this.entries.get(key);
+    if (raw === undefined) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(JSON.parse(raw) as T);
+  }
+
+  setValue<T>(key: string, value: T): Promise<void> {
+    this.entries.set(key, JSON.stringify(value));
+    return Promise.resolve();
+  }
+
+  deleteValue(key: string): Promise<void> {
+    this.entries.delete(key);
+    return Promise.resolve();
+  }
+}
+
+function makeToken(uuid: string, secret: string, rank: number = 0, type: otpType = otpType.TOTP): TokenConfig {
+  const token = new TokenConfig(secret, type);
+  token.TokenUUID = uuid;
+  token.RankScore = rank;
+  return token;
+}
+
+function freshCardStore(): TokenCardStore {
+  const prefKv = new MemoryPrefKv();
+  const store = TokenCardStore.getInstance();
+  store.useStoreForTest(prefKv);
+  return store;
+}
+
+/** TokenStore 绑定内存后端并预置令牌 */
+async function bindTokenStore(tokens: TokenConfig[]): Promise<void> {
+  const kv = new MemoryTokenKv();
+  const store = TokenStore.getInstance();
+  store.useBackendsForTest(kv, new MemorySecretStore());
+  for (const token of tokens) {
+    kv.entries.set(`_token_uuid_${token.TokenUUID}`, JSON.stringify(token));
+  }
+  AppPreference.setPreference(PREF_KEYS.ASSET_MIGRATION_DONE, true);
+  await store.LoadTokenByDataBase();
+}
+
+export default function tokenCardStoreTest() {
+  describe('tokenCardStoreTest', () => {
+    it('empty_card_data_has_two_slots_and_flag_false', 0, () => {
+      const data = emptyCardData('form-1', 'My Card');
+      expect(data['hasToken']).assertEqual('false');
+      expect(data['formId']).assertEqual('form-1');
+      expect(data['formName']).assertEqual('My Card');
+      for (let i = 0; i < 2; i++) {
+        expect(data[`token${i}_issuer`]).assertEqual('');
+        expect(data[`token${i}_secret`]).assertEqual('');
+      }
+    });
+
+    it('card_config_crud_maintains_index_list', 0, async () => {
+      const store = freshCardStore();
+
+      const config1: CardConfig = { formId: 'f1', formName: 'Card One', tokenUUIDs: ['u1'] };
+      const config2: CardConfig = { formId: 'f2', formName: 'Card Two', tokenUUIDs: ['u2', 'u3'] };
+      await store.saveCardConfig(config1);
+      await store.saveCardConfig(config2);
+      // 同 formId 重复保存：索引不重复
+      await store.saveCardConfig(config1);
+
+      const list = await store.getCardConfigList();
+      expect(list.length).assertEqual(2);
+      expect(list.includes('f1')).assertTrue();
+      expect(list.includes('f2')).assertTrue();
+
+      const loaded = await store.getCardConfig('f2');
+      expect(loaded !== null).assertTrue();
+      expect(loaded!.formName).assertEqual('Card Two');
+      expect(loaded!.tokenUUIDs.length).assertEqual(2);
+
+      await store.removeCardConfig('f1');
+      const afterRemove = await store.getCardConfigList();
+      expect(afterRemove.length).assertEqual(1);
+      expect(afterRemove.includes('f2')).assertTrue();
+      expect(await store.getCardConfig('f1')).assertNull();
+    });
+
+    it('remove_missing_config_is_noop', 0, async () => {
+      const store = freshCardStore();
+      await store.removeCardConfig('missing');
+      const list = await store.getCardConfigList();
+      expect(list.length).assertEqual(0);
+    });
+
+    it('generate_card_data_maps_token_fields_with_margin_pref', 0, async () => {
+      const store = freshCardStore();
+      const t1 = makeToken('u1', 'secret_a', 0);
+      t1.TokenIssuer = 'GitHub';
+      t1.TokenName = 'octocat';
+      t1.TokenDigits = 8;
+      t1.TokenPeriod = 60;
+      await bindTokenStore([t1]);
+
+      const config: CardConfig = { formId: 'f1', formName: 'Card One', tokenUUIDs: ['u1', 'missing'] };
+      AppPreference.setPreference(PREF_KEYS.APPEARANCE_TOKEN_COUNTER_NEXT_MARGIN, 9);
+      const data = await store.generateCardData('f1', config);
+
+      expect(data['hasToken']).assertEqual('true');
+      expect(data['token0_issuer']).assertEqual('GitHub');
+      expect(data['token0_name']).assertEqual('octocat');
+      expect(data['token0_digits']).assertEqual('8');
+      expect(data['token0_period']).assertEqual('60');
+      expect(data['token0_type']).assertEqual('0');
+      expect(data['token0_counter']).assertEqual('0');
+      // 用户设置的过期阈值流入卡片数据
+      expect(data['token0_next_margin']).assertEqual('9');
+      // 第二个槽位找不到令牌：保持空
+      expect(data['token1_issuer']).assertEqual('');
+    });
+
+    it('generate_card_data_uses_default_margin_when_pref_not_numeric', 0, async () => {
+      const store = freshCardStore();
+      await bindTokenStore([makeToken('u1', 's', 0)]);
+      const config: CardConfig = { formId: 'f1', formName: 'Card One', tokenUUIDs: ['u1'] };
+      // 非数字偏好 → typeof 守卫走兜底 5
+      AppPreference.setPreference(PREF_KEYS.APPEARANCE_TOKEN_COUNTER_NEXT_MARGIN, 'oops');
+      const data = await store.generateCardData('f1', config);
+      expect(data['token0_next_margin']).assertEqual('5');
+    });
+
+    it('generate_card_data_without_config_or_tokens_is_empty', 0, async () => {
+      const store = freshCardStore();
+      await bindTokenStore([]);
+
+      const noConfig = await store.generateCardData('none');
+      expect(noConfig['hasToken']).assertEqual('false');
+
+      const emptyTokens: CardConfig = { formId: 'f1', formName: 'Card One', tokenUUIDs: [] };
+      const noBound = await store.generateCardData('f1', emptyTokens);
+      expect(noBound['hasToken']).assertEqual('false');
+    });
+
+    it('increment_token_counter_persists_and_returns_new_value', 0, async () => {
+      const store = freshCardStore();
+      await bindTokenStore([makeToken('hotp1', 's', 0, otpType.HOTP)]);
+
+      const value = await store.incrementTokenCounter('hotp1');
+      expect(value).assertEqual(1);
+
+      const again = await store.incrementTokenCounter('hotp1');
+      expect(again).assertEqual(2);
+
+      const missing = await store.incrementTokenCounter('missing');
+      expect(missing).assertEqual(-1);
+    });
+  });
+}

--- a/entry/src/test/TokenGroupStore.test.ets
+++ b/entry/src/test/TokenGroupStore.test.ets
@@ -1,0 +1,232 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  ALL_TOKEN_GROUPS,
+  FAVORITE_TOKEN_GROUP,
+  TokenGroup,
+  TokenGroupKvBackend,
+  TokenGroupStore,
+} from 'common';
+
+/**
+ * TokenGroupStore 纯逻辑测试（注入内存 KV 后端，无 distributedKVStore）。
+ *
+ * 覆盖：isValidName 校验、renameOrCreate/remove/move、merge 的 ID 合并策略、
+ * load 后的选中态自愈（reconcileSelection）。持久化层行为由
+ * scripts/token-group-store.test.mjs 的 Node 移植套件补充回归。
+ */
+
+class MemoryKv implements TokenGroupKvBackend {
+  saved: TokenGroup[] | null = null;
+  failNextSave: boolean = false;
+
+  getValue<T>(key: string): Promise<T | null> {
+    if (this.saved === null) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(JSON.parse(JSON.stringify(this.saved)) as T);
+  }
+
+  setValue<T>(key: string, value: T): Promise<void> {
+    if (this.failNextSave) {
+      return Promise.reject(new Error('kv write failed'));
+    }
+    this.saved = JSON.parse(JSON.stringify(value)) as TokenGroup[];
+    return Promise.resolve();
+  }
+}
+
+function group(id: string, name: string, color?: number): TokenGroup {
+  return new TokenGroup(id, name, color);
+}
+
+/** 重置单例状态并绑定内存后端，隔离用例间污染 */
+function freshStore(kv: MemoryKv): TokenGroupStore {
+  const store = TokenGroupStore.getInstance();
+  store.useKvBackendForTest(kv);
+  store.state.groups = [];
+  store.state.selectedId = ALL_TOKEN_GROUPS;
+  kv.saved = null;
+  return store;
+}
+
+export default function tokenGroupStoreTest() {
+  describe('tokenGroupStoreTest', () => {
+    it('is_valid_name_rejects_empty_too_long_and_duplicates', 0, () => {
+      const kv = new MemoryKv();
+      const store = freshStore(kv);
+      store.state.groups = [group('g1', '工作'), group('g2', 'Finance')];
+
+      expect(store.isValidName('')).assertFalse();
+      expect(store.isValidName('   ')).assertFalse();
+      // 上限 24 字符（按 UTF-16 code unit 计）
+      expect(store.isValidName('a'.repeat(25))).assertFalse();
+      expect(store.isValidName('a'.repeat(24))).assertTrue();
+      // 大小写不敏感查重
+      expect(store.isValidName('FINANCE')).assertFalse();
+      expect(store.isValidName('finance  ')).assertFalse();
+      expect(store.isValidName('生活')).assertTrue();
+      // exceptId：重命名时排除自身
+      expect(store.isValidName('Finance', 'g2')).assertTrue();
+    });
+
+    it('rename_existing_group_updates_state_and_persists', 0, async () => {
+      const kv = new MemoryKv();
+      const store = freshStore(kv);
+      store.state.groups = [group('g1', 'Old'), group('g2', 'Keep')];
+
+      await store.renameOrCreate('Renamed', 'g1', 0xFF0000FF);
+
+      expect(store.state.groups[0].name).assertEqual('Renamed');
+      expect(store.state.groups[0].color).assertEqual(0xFF0000FF);
+      expect(store.state.groups[1].name).assertEqual('Keep');
+      // 状态与持久化一致
+      expect(kv.saved!.length).assertEqual(2);
+      expect(kv.saved![0].name).assertEqual('Renamed');
+      // 名称统一为 trim 后的值
+      await store.renameOrCreate('  Trimmed  ', 'g1');
+      expect(store.state.groups[0].name).assertEqual('Trimmed');
+    });
+
+    it('rename_or_create_throws_on_invalid_name', 0, async () => {
+      const kv = new MemoryKv();
+      const store = freshStore(kv);
+      store.state.groups = [group('g1', 'Dup')];
+
+      let threw = false;
+      try {
+        await store.renameOrCreate('dup');
+      } catch (e) {
+        threw = (e as Error).message === 'Invalid group name';
+      }
+      expect(threw).assertTrue();
+      // 失败时不应改动目录
+      expect(store.state.groups.length).assertEqual(1);
+    });
+
+    it('rename_or_create_without_id_appends_new_group', 0, async () => {
+      const kv = new MemoryKv();
+      const store = freshStore(kv);
+      // LocalUnit 下 util.generateRandomUUID 返回空串（真机为随机 UUID），
+      // 因此只断言追加行为与名称，不断言 id 非空。
+      await store.renameOrCreate(' NewGroup ');
+      expect(store.state.groups.length).assertEqual(1);
+      expect(store.state.groups[0].name).assertEqual('NewGroup');
+      expect(kv.saved!.length).assertEqual(1);
+    });
+
+    it('remove_deletes_only_target_group', 0, async () => {
+      const kv = new MemoryKv();
+      const store = freshStore(kv);
+      store.state.groups = [group('g1', 'A'), group('g2', 'B')];
+
+      await store.remove('g1');
+      expect(store.state.groups.length).assertEqual(1);
+      expect(store.state.groups[0].id).assertEqual('g2');
+    });
+
+    it('move_swaps_order_within_bounds_and_noop_out_of_bounds', 0, async () => {
+      const kv = new MemoryKv();
+      const store = freshStore(kv);
+      store.state.groups = [group('a', 'A'), group('b', 'B'), group('c', 'C')];
+
+      await store.move('c', -1);
+      expect(store.state.groups.map(g => g.id).join(',')).assertEqual('a,c,b');
+
+      await store.move('a', -1); // 越界：不变
+      expect(store.state.groups.map(g => g.id).join(',')).assertEqual('a,c,b');
+
+      await store.move('b', 1); // 越界：不变
+      expect(store.state.groups.map(g => g.id).join(',')).assertEqual('a,c,b');
+
+      await store.move('a', 1);
+      expect(store.state.groups.map(g => g.id).join(',')).assertEqual('c,a,b');
+
+      // 未知 id：from < 0，直接返回
+      await store.move('missing', 1);
+      expect(store.state.groups.length).assertEqual(3);
+    });
+
+    it('merge_by_id_skips_reserved_invalid_and_duplicates', 0, async () => {
+      const kv = new MemoryKv();
+      const store = freshStore(kv);
+      store.state.groups = [group('g1', 'A')];
+
+      await store.merge([
+        group(ALL_TOKEN_GROUPS, 'All'),
+        group(FAVORITE_TOKEN_GROUP, 'Favorites'),
+        group('', 'no id'),
+        group('x1', '   '),
+        group('g1', 'dup id'),
+        group('x2', '  Padded  ', 0x11223344),
+        group('x3', 'y'.repeat(30)),
+      ]);
+
+      expect(store.state.groups.length).assertEqual(3);
+      expect(store.state.groups[1].id).assertEqual('x2');
+      expect(store.state.groups[1].name).assertEqual('Padded');
+      expect(store.state.groups[1].color).assertEqual(0x11223344);
+      // 名称截断到 24 字符
+      expect(store.state.groups[2].name.length).assertEqual(24);
+    });
+
+    it('merge_ignores_undefined_and_empty_arrays', 0, async () => {
+      const kv = new MemoryKv();
+      const store = freshStore(kv);
+      store.state.groups = [group('g1', 'A')];
+
+      await store.merge(undefined);
+      await store.merge([]);
+      expect(store.state.groups.length).assertEqual(1);
+      expect(kv.saved).assertNull();
+    });
+
+    it('load_restores_groups_and_reconciles_selection', 0, async () => {
+      const kv = new MemoryKv();
+      const store = freshStore(kv);
+      kv.saved = [group('g1', 'A'), group('g2', 'B')];
+
+      // 选中了不存在的分组 → 自愈为「全部」
+      store.state.selectedId = 'missing';
+      await store.load();
+      expect(store.state.groups.length).assertEqual(2);
+      expect(store.state.selectedId).assertEqual(ALL_TOKEN_GROUPS);
+
+      // 选中合法分组 → 保留
+      store.state.selectedId = 'g2';
+      await store.load();
+      expect(store.state.selectedId).assertEqual('g2');
+
+      // 内置「收藏」筛选不参与自愈
+      store.state.selectedId = FAVORITE_TOKEN_GROUP;
+      await store.load();
+      expect(store.state.selectedId).assertEqual(FAVORITE_TOKEN_GROUP);
+    });
+
+    it('token_group_color_normalizes_signed_and_rejects_invalid', 0, () => {
+      expect(new TokenGroup('i', 'n', 0xFF112233).color).assertEqual(0xFF112233);
+      // 有符号 ARGB -1 归一为无符号 0xFFFFFFFF
+      expect(new TokenGroup('i', 'n', -1).color).assertEqual(0xFFFFFFFF);
+      expect(new TokenGroup('i', 'n', -0x80000000).color).assertEqual(0x80000000);
+      expect(new TokenGroup('i', 'n', 1.5).color === undefined).assertTrue();
+      expect(new TokenGroup('i', 'n', NaN).color === undefined).assertTrue();
+      expect(new TokenGroup('i', 'n').color === undefined).assertTrue();
+    });
+
+    it('save_failure_keeps_state_unchanged', 0, async () => {
+      const kv = new MemoryKv();
+      const store = freshStore(kv);
+      store.state.groups = [group('g1', 'A')];
+      kv.failNextSave = true;
+
+      let threw = false;
+      try {
+        await store.remove('g1');
+      } catch (e) {
+        threw = true;
+      }
+      expect(threw).assertTrue();
+      // 写入失败时内存目录不变（状态与持久层保持一致）
+      expect(store.state.groups.length).assertEqual(1);
+    });
+  });
+}

--- a/entry/src/test/TokenGroupStore.test.ets
+++ b/entry/src/test/TokenGroupStore.test.ets
@@ -33,6 +33,10 @@ class MemoryKv implements TokenGroupKvBackend {
     this.saved = JSON.parse(JSON.stringify(value)) as TokenGroup[];
     return Promise.resolve();
   }
+
+  deleteValue(_key: string): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 function group(id: string, name: string, color?: number): TokenGroup {

--- a/entry/src/test/TokenImporter.test.ets
+++ b/entry/src/test/TokenImporter.test.ets
@@ -1,0 +1,59 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { TokenConfig } from 'common';
+import { TokenImporterRegistry } from 'common';
+import { URIImporter } from 'common';
+
+/**
+ * 导入器注册表测试：注册顺序、幂等 init、同 id 覆盖与 URI 导入器的空实现契约。
+ */
+export default function tokenImporterRegistryTest() {
+  describe('tokenImporterRegistryTest', () => {
+    it('init_registers_builtin_importers_in_order', 0, () => {
+      const registry = TokenImporterRegistry.getInstance();
+      registry.init();
+
+      const all = registry.getAll();
+      expect(all.length >= 2).assertTrue();
+      expect(all[0].id).assertEqual('twofa');
+      expect(all[1].id).assertEqual('uri');
+    });
+
+    it('init_is_idempotent_no_duplicate_registration', 0, () => {
+      const registry = TokenImporterRegistry.getInstance();
+      registry.init();
+      registry.init();
+      registry.init();
+
+      const ids = registry.getAll().map(i => i.id);
+      const unique = new Set<string>(ids);
+      expect(unique.size).assertEqual(ids.length);
+    });
+
+    it('register_same_id_overwrites_previous_entry', 0, () => {
+      const registry = TokenImporterRegistry.getInstance();
+      const before = registry.getAll().length;
+
+      const custom = new URIImporter();
+      registry.register(custom);
+
+      expect(registry.getAll().length).assertEqual(before);
+      expect(registry.getAll()[registry.getAll().length - 1] === custom).assertTrue();
+    });
+
+    it('uri_importer_contract_and_noop_import', 0, () => {
+      const importer = new URIImporter();
+      expect(importer.id).assertEqual('uri');
+      expect(importer.name !== undefined).assertTrue();
+      expect(importer.description !== undefined).assertTrue();
+      expect(importer.icon !== undefined).assertTrue();
+
+      // 实际对话框由 BackupAndMigrationSheet 负责，import() 必须是无副作用空操作
+      let called = false;
+      importer.import(undefined as ESObject as UIContext,
+        (_tokens: Array<TokenConfig>) => {
+          called = true;
+        });
+      expect(called).assertFalse();
+    });
+  });
+}

--- a/entry/src/test/TokenKvBatch.test.ets
+++ b/entry/src/test/TokenKvBatch.test.ets
@@ -1,0 +1,161 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  KvBatchEntry,
+  TokenBatchProgress,
+  TokenBatchStage,
+  commitTokenBatchInChunks,
+  migrateLegacyTokenEntries,
+} from 'common';
+import { MemoryLegacyKv, MemoryTransactionalKv } from './fakes/BackupFakes';
+
+/**
+ * 令牌 KV 批量提交与旧版本迁移测试（Phase 2 从 KvManager 抽出的编排逻辑）。
+ *
+ * 覆盖：128 分块、事务提交/回滚、空批量短路、进度回调序列、
+ * `$.SA_token_uuids_` 旧前缀 → 新前缀的逐条迁移。
+ */
+
+interface RecordedProgress {
+  stage: number;
+  current: number;
+  total: number;
+}
+
+function makeEntries(count: number): KvBatchEntry[] {
+  const out: KvBatchEntry[] = [];
+  for (let i = 0; i < count; i++) {
+    const entry: KvBatchEntry = { key: `key_${i}`, value: `value_${i}` };
+    out.push(entry);
+  }
+  return out;
+}
+
+export default function tokenKvBatchTest() {
+  describe('tokenKvBatchTest', () => {
+    it('commit_persists_entries_and_deletes_in_transaction', 0, async () => {
+      const kv = new MemoryTransactionalKv();
+      const entries = makeEntries(3);
+
+      await commitTokenBatchInChunks(kv, entries, ['gone_1', 'gone_2']);
+
+      expect(kv.startCount).assertEqual(1);
+      expect(kv.commitCount).assertEqual(1);
+      expect(kv.rollbackCount).assertEqual(0);
+      expect(kv.committed.get('key_0')).assertEqual('value_0');
+      expect(kv.committed.get('key_2')).assertEqual('value_2');
+      expect(kv.committed.has('gone_1')).assertFalse();
+      expect(kv.committed.has('gone_2')).assertFalse();
+    });
+
+    it('commit_chunks_batches_at_128', 0, async () => {
+      const kv = new MemoryTransactionalKv();
+
+      await commitTokenBatchInChunks(kv, makeEntries(300), []);
+
+      // 300 = 128 + 128 + 44
+      expect(kv.putBatchCalls.length).assertEqual(3);
+      expect(kv.putBatchCalls[0].length).assertEqual(128);
+      expect(kv.putBatchCalls[1].length).assertEqual(128);
+      expect(kv.putBatchCalls[2].length).assertEqual(44);
+
+      // 删除同样分块：257 个 key = 128 + 128 + 1
+      const kv2 = new MemoryTransactionalKv();
+      const deleteKeys: string[] = [];
+      for (let i = 0; i < 257; i++) {
+        deleteKeys.push(`del_${i}`);
+      }
+      await commitTokenBatchInChunks(kv2, [], deleteKeys);
+      expect(kv2.deleteBatchCalls.length).assertEqual(3);
+      expect(kv2.deleteBatchCalls[2].length).assertEqual(1);
+    });
+
+    it('empty_batch_is_noop_without_transaction', 0, async () => {
+      const kv = new MemoryTransactionalKv();
+
+      await commitTokenBatchInChunks(kv, [], []);
+
+      expect(kv.startCount).assertEqual(0);
+      expect(kv.commitCount).assertEqual(0);
+    });
+
+    it('failure_rolls_back_and_rethrows_with_nothing_committed', 0, async () => {
+      const kv = new MemoryTransactionalKv();
+      // 第二个分块（下标 1）失败
+      kv.failPutBatchAt = 1;
+
+      let threw = false;
+      try {
+        await commitTokenBatchInChunks(kv, makeEntries(200), []);
+      } catch (e) {
+        threw = (e as Error).message === 'putBatch failed';
+      }
+      expect(threw).assertTrue();
+      expect(kv.rollbackCount).assertEqual(1);
+      expect(kv.commitCount).assertEqual(0);
+      expect(kv.committed.size).assertEqual(0);
+    });
+
+    it('progress_reports_saving_committing_sequence', 0, async () => {
+      const kv = new MemoryTransactionalKv();
+      const progress: RecordedProgress[] = [];
+
+      await commitTokenBatchInChunks(kv, makeEntries(2), [], (item: TokenBatchProgress): void => {
+        progress.push({ stage: item.stage, current: item.completed, total: item.total });
+      });
+
+      // 首条 SAVING 0/2；随后 SAVING 2/2；COMMITTING 收尾
+      expect(progress.length >= 3).assertTrue();
+      expect(progress[0].stage).assertEqual(TokenBatchStage.SAVING);
+      expect(progress[0].current).assertEqual(0);
+      expect(progress[0].total).assertEqual(2);
+      expect(progress[1].current).assertEqual(2);
+      const lastStage = progress[progress.length - 1].stage;
+      expect(lastStage).assertEqual(TokenBatchStage.COMMITTING);
+    });
+
+    it('progress_reports_rolling_back_on_failure', 0, async () => {
+      const kv = new MemoryTransactionalKv();
+      kv.failPutBatchAt = 0;
+      const progress: RecordedProgress[] = [];
+
+      try {
+        await commitTokenBatchInChunks(kv, makeEntries(1), [], (item: TokenBatchProgress): void => {
+          progress.push({ stage: item.stage, current: item.completed, total: item.total });
+        });
+      } catch (e) {
+        // 预期失败
+      }
+      const lastStage = progress[progress.length - 1].stage;
+      expect(lastStage).assertEqual(TokenBatchStage.ROLLING_BACK);
+    });
+
+    it('legacy_migration_moves_old_prefix_to_new_and_cleans_up', 0, async () => {
+      const kv = new MemoryLegacyKv();
+      kv.entries.set('$.SA_token_uuids_uuid-a', '$.SA_token_uuids_uuid-a');
+      kv.entries.set('token_uuid-a', '{"TokenUUID":"uuid-a"}');
+      kv.entries.set('$.SA_token_uuids_uuid-b', '$.SA_token_uuids_uuid-b');
+      // token_uuid-b 的值缺失 → 迁移为空串
+      kv.entries.set('untouched', 'keep');
+
+      await migrateLegacyTokenEntries(kv, '_token_uuid_');
+
+      // 新键写入
+      expect(kv.entries.get('_token_uuid_uuid-a')).assertEqual('{"TokenUUID":"uuid-a"}');
+      expect(kv.entries.get('_token_uuid_uuid-b')).assertEqual('');
+      // 旧键全部清理
+      expect(kv.entries.has('$.SA_token_uuids_uuid-a')).assertFalse();
+      expect(kv.entries.has('$.SA_token_uuids_uuid-b')).assertFalse();
+      expect(kv.entries.has('token_uuid-a')).assertFalse();
+      // 无关键不动
+      expect(kv.entries.get('untouched')).assertEqual('keep');
+    });
+
+    it('legacy_migration_without_legacy_keys_is_noop', 0, async () => {
+      const kv = new MemoryLegacyKv();
+      kv.entries.set('_token_uuid_existing', 'x');
+
+      await migrateLegacyTokenEntries(kv, '_token_uuid_');
+      expect(kv.entries.size).assertEqual(1);
+    });
+  });
+}

--- a/entry/src/test/TokenStore.test.ets
+++ b/entry/src/test/TokenStore.test.ets
@@ -1,0 +1,661 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  AppPreference,
+  PREF_KEYS,
+  otpType,
+  SteamAuth,
+  TokenGroup,
+  TokenConfig,
+  TokenGroupStore,
+  TokenStore,
+} from 'common';
+import { MemoryNamedSecretStore, MemorySecretStore, MemoryTokenKv } from './fakes/BackupFakes';
+import { SteamSecretStore } from 'common';
+
+/**
+ * TokenStore 纯逻辑测试（Phase 2 端口注入：KeyValueStore + SecretStore + Steam 后端）。
+ *
+ * 覆盖高风险清单首位的迁移决策（ASSET 三重验证的每个失败分支）、
+ * KV 双写/降级语义、持久化编排（Rank/收藏/脱敏）与删除重排。
+ * distributedKVStore/asset 均被内存假实现替换。
+ */
+
+const TOKEN_PREFIX = '_token_uuid_';
+
+function makeToken(uuid: string, secret: string, rank: number = 0, type: otpType = otpType.TOTP): TokenConfig {
+  const token = new TokenConfig(secret, type);
+  token.TokenUUID = uuid;
+  token.RankScore = rank;
+  return token;
+}
+
+function putTokenInKv(kv: MemoryTokenKv, token: TokenConfig): void {
+  kv.entries.set(`${TOKEN_PREFIX}${token.TokenUUID}`, JSON.stringify(token));
+}
+
+/** 重绑全部端口并清空迁移标记，隔离用例间污染 */
+function freshStore(): TokenStore {
+  const kv = new MemoryTokenKv();
+  const secrets = new MemorySecretStore();
+  const store = TokenStore.getInstance();
+  store.useBackendsForTest(kv, secrets);
+  TokenGroupStore.getInstance().useKvBackendForTest(kv);
+  AppPreference.setPreference(PREF_KEYS.ASSET_MIGRATION_DONE, false);
+  return store;
+}
+
+/** 迁移已完成标记 */
+function setMigrationDone(done: boolean): void {
+  AppPreference.setPreference(PREF_KEYS.ASSET_MIGRATION_DONE, done);
+}
+
+function migrationDone(): boolean {
+  return AppPreference.getPreference(PREF_KEYS.ASSET_MIGRATION_DONE) === true;
+}
+
+export default function tokenStoreTest() {
+  describe('tokenStoreTest', () => {
+    it('initTokenStore_initializes_kv_and_loads', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, new MemorySecretStore());
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(false);
+
+      await store.initTokenStore();
+      expect(kv.initCalls).assertEqual(1);
+      // 重复调用幂等：底层 init 不再触发
+      await store.initTokenStore();
+      expect(kv.initCalls).assertEqual(1);
+    });
+
+    it('migration_flag_set_true_skips_all_asset_io', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 'JBSWY3DPEHPK3PXP'));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+
+      await store.LoadTokenByDataBase();
+      const tokens = await store.getTokens();
+      expect(tokens.length).assertEqual(1);
+      // 标记已置位：零 ASSET 调用（含批量预查）
+      expect(secrets.upsertCalls.length).assertEqual(0);
+      expect(secrets.batchQueryCalls).assertEqual(0);
+      expect(migrationDone()).assertTrue();
+    });
+
+    it('migration_empty_token_list_sets_flag_directly', 0, async () => {
+      const store = freshStore();
+      expect(migrationDone()).assertFalse();
+
+      await store.LoadTokenByDataBase();
+      expect(migrationDone()).assertTrue();
+    });
+
+    it('migration_asset_already_has_secret_wins_over_kv', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 'kv_secret'));
+      secrets.secrets.set('u1', 'asset_secret');
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(false);
+
+      await store.LoadTokenByDataBase();
+      const tokens = await store.getTokens();
+      expect(tokens[0].TokenSecret).assertEqual('asset_secret');
+      expect(secrets.upsertCalls.length).assertEqual(0);
+      expect(migrationDone()).assertTrue();
+    });
+
+    it('migration_kv_only_secret_triple_verified_and_copied_to_asset', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 'kv_only_secret'));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(false);
+
+      await store.LoadTokenByDataBase();
+      // 三重验证：upsert 一次 + 查询一致；KV 保留不动（双写）
+      expect(secrets.upsertCalls.length).assertEqual(1);
+      expect(secrets.upsertCalls[0]).assertEqual('u1');
+      expect(secrets.secrets.get('u1')).assertEqual('kv_only_secret');
+      const tokens = await store.getTokens();
+      expect(tokens[0].TokenSecret).assertEqual('kv_only_secret');
+      expect(migrationDone()).assertTrue();
+    });
+
+    it('migration_upsert_failure_keeps_flag_unset_for_retry', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 'retry_secret'));
+      secrets.failUpsertFor.add('u1');
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(false);
+
+      await store.LoadTokenByDataBase();
+      // 第一重失败：不置位，KV 数据保留，下次加载重试
+      expect(migrationDone()).assertFalse();
+      const tokens = await store.getTokens();
+      expect(tokens[0].TokenSecret).assertEqual('retry_secret');
+    });
+
+    it('migration_verify_not_found_keeps_flag_unset', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 'verify_secret'));
+      // upsert 成功但第二重（查回）失败
+      secrets.dropQueryFor.add('u1');
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(false);
+
+      await store.LoadTokenByDataBase();
+      expect(secrets.upsertCalls.length).assertEqual(1);
+      expect(migrationDone()).assertFalse();
+    });
+
+    it('migration_verify_content_mismatch_keeps_flag_unset', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 'original_secret'));
+      // 第三重（内容一致）失败：查回被篡改的值
+      secrets.corruptQueryFor.set('u1', 'tampered_secret');
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(false);
+
+      await store.LoadTokenByDataBase();
+      expect(secrets.upsertCalls.length).assertEqual(1);
+      // 内存不被篡改值污染
+      const tokens = await store.getTokens();
+      expect(tokens[0].TokenSecret).assertEqual('original_secret');
+      expect(migrationDone()).assertFalse();
+    });
+
+    it('migration_oversized_secret_degrades_to_kv_and_sets_flag', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      // >900 UTF-8 字节（700 个两字节汉字 ≈ 1400 字节）
+      const bigSecret = '令'.repeat(700);
+      putTokenInKv(kv, makeToken('u1', bigSecret));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(false);
+
+      await store.LoadTokenByDataBase();
+      // 设计降级：不迁移、不视为失败（置位，避免每次加载重复探测）
+      expect(secrets.upsertCalls.length).assertEqual(0);
+      const tokens = await store.getTokens();
+      expect(tokens[0].TokenSecret).assertEqual(bigSecret);
+      expect(migrationDone()).assertTrue();
+    });
+
+    it('migration_mixed_batch_any_failure_blocks_flag', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('ok', 'secret_ok', 0));
+      putTokenInKv(kv, makeToken('bad', 'secret_bad', 1));
+      secrets.failUpsertFor.add('bad');
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(false);
+
+      await store.LoadTokenByDataBase();
+      // ok 已迁移；bad 失败 → 整体标记不置位
+      expect(secrets.secrets.get('ok')).assertEqual('secret_ok');
+      expect(migrationDone()).assertFalse();
+    });
+
+    it('migration_both_empty_secret_is_noop', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', ''));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(false);
+
+      await store.LoadTokenByDataBase();
+      expect(secrets.upsertCalls.length).assertEqual(0);
+      expect(migrationDone()).assertTrue();
+    });
+
+    it('steam_token_load_keeps_secrets_without_migration_writes', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      const named = new MemoryNamedSecretStore();
+      const steamStore = SteamSecretStore.getInstance();
+      steamStore.useBackendForTest(named);
+
+      const token = makeToken('steam1', 'shared_secret_b64', 0, otpType.Steam);
+      const auth = new SteamAuth();
+      auth.identitySecret = 'identity_x';
+      auth.revocationCode = 'R1';
+      token.SteamAuth = auth;
+      putTokenInKv(kv, token);
+
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets, steamStore);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(false);
+
+      await store.LoadTokenByDataBase();
+      // 非 mafile 路径：load 回填（ASSET 空 → 保留内存值），不触发迁移写
+      expect(named.upsertCalls.length).assertEqual(0);
+      const tokens = await store.getTokens();
+      expect(tokens[0].TokenType).assertEqual(otpType.Steam);
+    });
+
+    it('updateToken_new_token_appended_with_next_rank_and_secret_written', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('old', 'old_secret', 3));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      const created = makeToken('new', 'new_secret', 99);
+      await store.updateToken(created);
+
+      const tokens = await store.getTokens();
+      expect(tokens.length).assertEqual(2);
+      // 新令牌追加末尾，历史 RankScore 间隙被兼容（nextRank = max+1）
+      expect(tokens[1].TokenUUID).assertEqual('new');
+      expect(tokens[1].RankScore).assertEqual(4);
+      expect(tokens[1].TokenGroupId).assertEqual('');
+      // 密钥变化 → 写 ASSET
+      expect(secrets.upsertCalls.length).assertEqual(1);
+      expect(secrets.upsertCalls[0]).assertEqual('new');
+      // KV 已写入
+      expect(kv.entries.has(`${TOKEN_PREFIX}new`)).assertTrue();
+    });
+
+    it('updateToken_existing_keeps_rank_and_local_favorite', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      const existing = makeToken('u1', 'old_secret', 2);
+      existing.TokenFavorite = true;
+      existing.TokenGroupId = 'g1';
+      putTokenInKv(kv, existing);
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      const incoming = makeToken('u1', 'new_secret', 42);
+      incoming.TokenFavorite = false;
+      await store.updateToken(incoming);
+
+      const tokens = await store.getTokens();
+      expect(tokens.length).assertEqual(1);
+      expect(tokens[0].RankScore).assertEqual(2);
+      // 本地收藏保留，不被备份/导入数据覆盖
+      expect(tokens[0].TokenFavorite).assertTrue();
+      expect(tokens[0].TokenSecret).assertEqual('new_secret');
+      expect(secrets.upsertCalls.length).assertEqual(1);
+    });
+
+    it('updateToken_invalid_inputs_throw_and_do_not_touch_state', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      let threwEmpty = false;
+      try {
+        await store.updateToken(makeToken('', 'secret'));
+      } catch (e) {
+        threwEmpty = (e as Error).message === 'Invalid persistent token';
+      }
+      expect(threwEmpty).assertTrue();
+
+      const nfc = makeToken('nfc', 'secret', 0, otpType.NFC_external);
+      let threwNfc = false;
+      try {
+        await store.updateToken(nfc);
+      } catch (e) {
+        threwNfc = true;
+      }
+      expect(threwNfc).assertTrue();
+      expect((await store.getTokens()).length).assertEqual(0);
+      expect(kv.batchCallCount).assertEqual(0);
+    });
+
+    it('updateToken_kv_failure_rolls_back_memory_and_skips_asset', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+      kv.failNextBatch = true;
+
+      let threw = false;
+      try {
+        await store.updateToken(makeToken('u1', 'secret'));
+      } catch (e) {
+        threw = true;
+      }
+      expect(threw).assertTrue();
+      // 不发布未保存数据：内存与 ASSET 都未变
+      expect((await store.getTokens()).length).assertEqual(0);
+      expect(secrets.upsertCalls.length).assertEqual(0);
+    });
+
+    it('updateToken_unchanged_secret_skips_asset_io', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 'same_secret', 0));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+      secrets.upsertCalls = [];
+
+      const renamed = makeToken('u1', 'same_secret', 0);
+      renamed.TokenName = 'Renamed';
+      await store.updateToken(renamed);
+
+      expect(secrets.upsertCalls.length).assertEqual(0);
+      expect(secrets.removeCalls.length).assertEqual(0);
+    });
+
+    it('updateToken_oversized_secret_removes_stale_asset_copy', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 'short', 0));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      await store.updateToken(makeToken('u1', '长'.repeat(600)));
+
+      // 超限密钥降级 KV：清除旧 ASSET 副本，避免迁移回填旧值
+      expect(secrets.upsertCalls.length).assertEqual(0);
+      expect(secrets.removeCalls.length).assertEqual(1);
+      expect(secrets.removeCalls[0]).assertEqual('u1');
+    });
+
+    it('updateToken_cleared_secret_removes_asset_copy', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 'short', 0));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      await store.updateToken(makeToken('u1', ''));
+      expect(secrets.removeCalls.length).assertEqual(1);
+      expect(secrets.removeCalls[0]).assertEqual('u1');
+    });
+
+    it('updateToken_asset_save_failure_removes_partial_secret', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 'old', 0));
+      secrets.failUpsertFor.add('u1');
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      await store.updateToken(makeToken('u1', 'changed'));
+      // 写入失败不保留可能过期的密钥；加密 KV 仍是降级来源
+      expect(secrets.upsertCalls.length).assertEqual(1);
+      expect(secrets.removeCalls.length).assertEqual(1);
+      expect(secrets.removeCalls[0]).assertEqual('u1');
+    });
+
+    it('persistTokens_strips_steam_credentials_from_kv_payload', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      const named = new MemoryNamedSecretStore();
+      const steamStore = SteamSecretStore.getInstance();
+      steamStore.useBackendForTest(named);
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets, steamStore);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      const steamToken = makeToken('st', 'shared_secret', 0, otpType.Steam);
+      const auth = new SteamAuth();
+      auth.identitySecret = 'identity_x';
+      auth.revocationCode = 'R1';
+      auth.refreshToken = 'jwt_token';
+      steamToken.SteamAuth = auth;
+
+      await store.updateToken(steamToken);
+
+      // Steam 凭证进 ASSET（别名分片语义由 SteamSecretStore 套件覆盖）
+      expect(named.upsertCalls.length).assertEqual(3);
+      // 内存对象保留明文
+      const tokens = await store.getTokens();
+      const memAuth = tokens[0].SteamAuth;
+      expect(memAuth !== undefined).assertTrue();
+      // KV 载荷已脱敏：identity/refresh/revocation 不落 KV
+      const kvRaw = kv.entries.get(`${TOKEN_PREFIX}st`) ?? '';
+      expect(kvRaw.includes('identity_x')).assertFalse();
+      expect(kvRaw.includes('jwt_token')).assertFalse();
+      expect(kvRaw.includes('R1')).assertFalse();
+    });
+
+    it('deleteTokens_compacts_ranks_only_after_first_removal_and_cleans_secrets', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      const named = new MemoryNamedSecretStore();
+      const steamStore = SteamSecretStore.getInstance();
+      steamStore.useBackendForTest(named);
+      putTokenInKv(kv, makeToken('a', 'sa', 0));
+      putTokenInKv(kv, makeToken('b', 'sb', 1));
+      putTokenInKv(kv, makeToken('c', 'sc', 2));
+      putTokenInKv(kv, makeToken('d', 'sd', 3));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets, steamStore);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      await store.deleteTokens(['a', 'c']);
+
+      const tokens = await store.getTokens();
+      expect(tokens.length).assertEqual(2);
+      expect(tokens[0].TokenUUID).assertEqual('b');
+      // 旧排序语义：只扣除前面删除的数量
+      expect(tokens[0].RankScore).assertEqual(0);
+      expect(tokens[1].TokenUUID).assertEqual('d');
+      expect(tokens[1].RankScore).assertEqual(1);
+      // 被删令牌的密钥从 ASSET 与 Steam 存储清除（Steam 每令牌 id+rev 两个别名）
+      expect(secrets.removeCalls.length).assertEqual(2);
+      expect(named.removeCalls.length).assertEqual(4);
+    });
+
+    it('deleteTokens_unknown_uuids_is_noop', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('a', 'sa', 0));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      await store.deleteTokens(['missing']);
+      expect((await store.getTokens()).length).assertEqual(1);
+      expect(secrets.removeCalls.length).assertEqual(0);
+    });
+
+    it('updateTokenRank_moves_within_bounds_and_noop_out_of_bounds', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('a', 'sa', 0));
+      putTokenInKv(kv, makeToken('b', 'sb', 1));
+      putTokenInKv(kv, makeToken('c', 'sc', 2));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      await store.updateTokenRank(2, 0);
+      let uuids = (await store.getTokens()).map((t: TokenConfig): string => t.TokenUUID);
+      expect(uuids.join(',')).assertEqual('c,a,b');
+
+      // 越界：不变
+      await store.updateTokenRank(-1, 0);
+      await store.updateTokenRank(0, 3);
+      await store.updateTokenRank(1, 1);
+      uuids = (await store.getTokens()).map((t: TokenConfig): string => t.TokenUUID);
+      expect(uuids.join(',')).assertEqual('c,a,b');
+
+      // 窗口内 RankScore 重写为连续索引
+      const tokens = await store.getTokens();
+      for (let i = 0; i < tokens.length; i++) {
+        expect(tokens[i].RankScore).assertEqual(i);
+      }
+    });
+
+    it('moveTokenToGroup_validates_group_and_persists_kv_only', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('u1', 's', 0));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      const groupKv = new MemoryTokenKv();
+      TokenGroupStore.getInstance().useKvBackendForTest(groupKv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+      // load 会以 KV 内容覆盖目录：种子放在 load 之后（本用例只读 state.groups）
+      TokenGroupStore.getInstance().state.groups = [new TokenGroup('g1', 'Work')];
+      secrets.upsertCalls = [];
+
+      // 分组不存在 → 抛错
+      let threw = false;
+      try {
+        await store.moveTokenToGroup('u1', 'missing');
+      } catch (e) {
+        threw = (e as Error).message === 'Group no longer exists';
+      }
+      expect(threw).assertTrue();
+
+      await store.moveTokenToGroup('u1', 'g1');
+      let tokens = await store.getTokens();
+      expect(tokens[0].TokenGroupId).assertEqual('g1');
+      // 分组变更只写 KV（saveTokenKvOnly 而非事务批量），不触碰 ASSET
+      expect(kv.batchCallCount).assertEqual(0);
+      const kvRaw = kv.entries.get(`${TOKEN_PREFIX}u1`) ?? '';
+      expect(kvRaw.includes('g1')).assertTrue();
+      expect(secrets.upsertCalls.length).assertEqual(0);
+
+      // 同组重复移动：no-op（不再产生 KV 写）
+      const rawBefore = kvRaw;
+      await store.moveTokenToGroup('u1', 'g1');
+      expect(kv.entries.get(`${TOKEN_PREFIX}u1`)).assertEqual(rawBefore);
+
+      // 归还到未分组
+      await store.moveTokenToGroup('u1', '');
+      tokens = await store.getTokens();
+      expect(tokens[0].TokenGroupId).assertEqual('');
+    });
+
+    it('setTokensFavorite_writes_only_real_changes_and_skips_nfc', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      const t1 = makeToken('t1', 's1', 0);
+      t1.TokenFavorite = true;
+      putTokenInKv(kv, t1);
+      putTokenInKv(kv, makeToken('nfc', 's2', 1, otpType.NFC_external));
+      const t3 = makeToken('t3', 's3', 2);
+      putTokenInKv(kv, t3);
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+      await store.LoadTokenByDataBase();
+
+      // t1 true→false 是唯一真实变更；NFC 排除；t3 已是 false 不写
+      await store.setTokensFavorite(['t1', 'nfc', 't3', 'missing'], false);
+      expect(kv.lastBatchTokens.length).assertEqual(1);
+      expect(kv.lastBatchTokens[0].TokenUUID).assertEqual('t1');
+      let tokens = await store.getTokens();
+      const byUuid = new Map<string, TokenConfig>();
+      for (const t of tokens) {
+        byUuid.set(t.TokenUUID, t);
+      }
+      const afterT1 = byUuid.get('t1');
+      expect(afterT1 !== undefined && afterT1.TokenFavorite === false).assertTrue();
+      const afterNfc = byUuid.get('nfc');
+      expect(afterNfc !== undefined && afterNfc.TokenFavorite === false).assertTrue();
+
+      // 全部无变更：不产生 KV 写
+      const before = kv.batchCallCount;
+      await store.setTokensFavorite(['t1', 'nfc', 't3'], false);
+      expect(kv.batchCallCount).assertEqual(before);
+
+      await store.setTokenFavorite('t3', true);
+      tokens = await store.getTokens();
+      const afterT3 = tokens.find((t: TokenConfig): boolean => t.TokenUUID === 't3');
+      expect(afterT3 !== undefined && afterT3.TokenFavorite === true).assertTrue();
+    });
+
+    it('queryToken_backfills_secret_from_asset_when_kv_empty', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      const bare = makeToken('u1', '', 0);
+      putTokenInKv(kv, bare);
+      secrets.secrets.set('u1', 'asset_backfill');
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+
+      const token = await store.queryToken('u1');
+      expect(token.TokenSecret).assertEqual('asset_backfill');
+
+      const missing = await store.queryToken('missing');
+      expect(missing.TokenSecret).assertEqual('');
+    });
+
+    it('load_revives_json_bare_objects_and_sorts_by_rank', 0, async () => {
+      const kv = new MemoryTokenKv();
+      const secrets = new MemorySecretStore();
+      putTokenInKv(kv, makeToken('second', 's2', 5));
+      putTokenInKv(kv, makeToken('first', 's1', 1));
+      const store = TokenStore.getInstance();
+      store.useBackendsForTest(kv, secrets);
+      TokenGroupStore.getInstance().useKvBackendForTest(kv);
+      setMigrationDone(true);
+
+      await store.LoadTokenByDataBase();
+      const tokens = await store.getTokens();
+      expect(tokens[0].TokenUUID).assertEqual('first');
+      expect(tokens[1].TokenUUID).assertEqual('second');
+    });
+  });
+}

--- a/entry/src/test/TokenUtilsIconPack.test.ets
+++ b/entry/src/test/TokenUtilsIconPack.test.ets
@@ -1,0 +1,52 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { counterToBytes64, OTPDefaultIconPack } from 'common';
+
+/**
+ * OTPDefaultIconPack 数据完整性与 counterToBytes64 大数值边界。
+ * （getIconPathByIssuer 基础映射已由 TokenUtilsExtra.test.ets 覆盖；
+ * base32 各变体已由 Base32.test.ets 覆盖。）
+ */
+export default function tokenUtilsIconPackTest() {
+  describe('tokenUtilsIconPackTest', () => {
+    it('issuer_table_has_no_duplicates_and_is_lowercase', 0, () => {
+      const pack = new OTPDefaultIconPack();
+      const unique = new Set<string>(pack.issuers);
+      expect(unique.size).assertEqual(pack.issuers.length);
+      for (const issuer of pack.issuers) {
+        expect(issuer).assertEqual(issuer.toLowerCase());
+      }
+    });
+
+    it('built_in_path_set_covers_every_issuer', 0, () => {
+      const pack = new OTPDefaultIconPack();
+      expect(pack.default_icon_pack_path.length).assertEqual(pack.issuers.length);
+      for (const path of pack.default_icon_pack_path) {
+        expect(path.startsWith('rawfile://icons/token_image_')).assertTrue();
+        expect(path.endsWith('.svg')).assertTrue();
+      }
+    });
+
+    it('get_icon_path_normalizes_space_and_case_or_empty', 0, () => {
+      const pack = new OTPDefaultIconPack();
+      expect(pack.getIconPathByIssuer('')).assertEqual('');
+      expect(pack.getIconPathByIssuer('GITHUB')).assertEqual('rawfile://icons/token_image_github.svg');
+      expect(pack.getIconPathByIssuer('Microsoft Teams'))
+        .assertEqual('rawfile://icons/token_image_microsoft_teams.svg');
+      // key 存在性查的是小写集合：非法 issuer 返回空串而不是抛异常
+      expect(pack.getIconPathByIssuer('Not An Issuer')).assertEqual('');
+    });
+
+    it('counter_to_bytes64_handles_large_counters', 0, () => {
+      // 2^40 = 0x0000010000000000：32 位右移实现会出错的量级
+      expect(Array.from(counterToBytes64(1099511627776)).join(','))
+        .assertEqual('0,0,1,0,0,0,0,0');
+      expect(Array.from(counterToBytes64(1)).join(','))
+        .assertEqual('0,0,0,0,0,0,0,1');
+      expect(Array.from(counterToBytes64(0)).join(','))
+        .assertEqual('0,0,0,0,0,0,0,0');
+      // 接近 2^53（JS 安全整数上限）
+      expect(Array.from(counterToBytes64(9007199254740991)).join(','))
+        .assertEqual('0,31,255,255,255,255,255,255');
+    });
+  });
+}

--- a/entry/src/test/TransferProtocol.test.ets
+++ b/entry/src/test/TransferProtocol.test.ets
@@ -1,0 +1,365 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { TokenConfig, otpType } from 'common';
+import {
+  TransferBatch,
+  TransferHeader,
+  TransferFrameBuilder,
+  TransferFrameEventKind,
+  TransferFrameOptions,
+  TransferFrameReceiver,
+  concatenateChunks,
+  reuseLocalTokenUuids,
+  utf8Decode,
+  utf8Encode,
+} from 'common';
+
+/**
+ * 手机↔手表 传输协议纯类测试（Phase 3，docs/TEST_PLAN.md 第 4 节）。
+ *
+ * 覆盖：纯 TS UTF-8 编解码（多字节/代理对/非法字节容错）、分帧构建
+ * （边界切片/收尾帧标记/空载荷）、无前缀（BLE）与 OTPW 前缀（WearEngine）
+ * 两种接收状态机（批次重启/非法头帧保持批次/孤儿帧/total 上限）、
+ * 重组精确性与越界保护、令牌批次 UUID 复用决策、双通道端到端帧回路。
+ */
+
+const BLE_MAX_CHUNK = 480;
+const BLE_MAX_TOTAL = 512 * 1024;
+const WEAR_PREFIX = 'OTPW';
+
+function bytesOf(text: string): Uint8Array {
+  return utf8Encode(text);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function bleReceiver(): TransferFrameReceiver {
+  return new TransferFrameReceiver({ headerPrefix: '', maxTotal: BLE_MAX_TOTAL } as TransferFrameOptions);
+}
+
+function wearReceiver(): TransferFrameReceiver {
+  return new TransferFrameReceiver({ headerPrefix: WEAR_PREFIX, maxTotal: 0 } as TransferFrameOptions);
+}
+
+export default function transferProtocolTest() {
+  describe('transferProtocolTest', () => {
+    it('utf8_roundtrip_ascii_multibyte_and_emoji', 0, () => {
+      const samples = ['hello', 'café', '中文令牌', 'emoji 😀🎉', 'mix中e😀文', ''];
+      for (const s of samples) {
+        expect(utf8Decode(utf8Encode(s))).assertEqual(s);
+      }
+      // 已知字节向量：'A中' = 41 E4 B8 AD；😀 = F0 9F 98 80（代理对合并）
+      const a = utf8Encode('A中');
+      expect([a[0], a[1], a[2], a[3]].join(',')).assertEqual('65,228,184,173');
+      const e = utf8Encode('😀');
+      expect([e[0], e[1], e[2], e[3]].join(',')).assertEqual('240,159,152,128');
+    });
+
+    it('utf8_decode_replaces_invalid_bytes_with_replacement_char', 0, () => {
+      // 非法首字节 0xFF、截断的 2 字节序列 0xC3（缺续字节）
+      const bad = new Uint8Array([0x61, 0xFF, 0xC3, 0x62]);
+      const text = utf8Decode(bad);
+      // 每个非法字节独立替换，不吞掉后续合法字节
+      expect(text.length).assertEqual(4);
+      expect(text.charCodeAt(1)).assertEqual(0xFFFD);
+      expect(text.charCodeAt(3)).assertEqual('b'.charCodeAt(0));
+    });
+
+    it('utf8_decode_rejects_overlong_surrogate_and_overflow_encodings', 0, () => {
+      // 过度编码 E0 80 AF（合法应为 C2 AF）：首字节边界校验拒绝
+      const t1 = utf8Decode(new Uint8Array([0xE0, 0x80, 0xAF]));
+      expect(t1.length).assertEqual(3);
+      expect(t1.charCodeAt(0)).assertEqual(0xFFFD);
+      // 代理区编码 ED A0 80（U+D800 的 CESU-8 形态）：拒绝
+      const t2 = utf8Decode(new Uint8Array([0xED, 0xA0, 0x80]));
+      expect(t2.length).assertEqual(3);
+      // 超出 U+10FFFF 的 F4 90 80 80：拒绝
+      const t3 = utf8Decode(new Uint8Array([0xF4, 0x90, 0x80, 0x80]));
+      expect(t3.length).assertEqual(4);
+      // 边界内仍精确解码：E0 A0 80 = U+0800（3 字节序列的最小编码），F4 8F BF BF = U+10FFFF
+      expect(utf8Decode(new Uint8Array([0xE0, 0xA0, 0x80])).charCodeAt(0)).assertEqual(0x0800);
+    });
+
+    it('utf8_encode_encodes_lone_surrogate_as_replacement_char', 0, () => {
+      // 孤立高代理（无后续低代理）与孤立低代理 → U+FFFD 三字节 EF BF BD（对齐 TextEncoder）
+      const loneHigh = utf8Encode(String.fromCharCode(0xD800));
+      expect([loneHigh[0], loneHigh[1], loneHigh[2]].join(',')).assertEqual('239,191,189');
+      const loneLow = utf8Encode(String.fromCharCode(0xDC00));
+      expect(loneLow.length).assertEqual(3);
+      // 合法代理对不受影响（已在 roundtrip 用例覆盖），此处验证混合场景
+      const mixed = utf8Encode(`${String.fromCharCode(0xD83D)}${String.fromCharCode(0xDE00)}`);
+      expect(mixed.length).assertEqual(4);
+    });
+
+    it('builder_header_carries_prefix_json_and_total', 0, () => {
+      const builder = new TransferFrameBuilder(WEAR_PREFIX, BLE_MAX_CHUNK);
+      const header = utf8Decode(builder.buildHeaderBytes(1234, 7, 'tokens'));
+      expect(header.startsWith(WEAR_PREFIX)).assertTrue();
+      const parsed = JSON.parse(header.substring(WEAR_PREFIX.length)) as TransferHeader;
+      expect(parsed.total).assertEqual(1234);
+      expect(parsed.count).assertEqual(7);
+      expect(parsed.type).assertEqual('tokens');
+
+      // BLE 无前缀：纯 JSON
+      const bleHeader = utf8Decode(new TransferFrameBuilder('', BLE_MAX_CHUNK).buildHeaderBytes(9, 1, 'settings'));
+      expect(bleHeader.startsWith('{')).assertTrue();
+    });
+
+    it('builder_frames_single_chunk_marks_only_last_final', 0, () => {
+      const payload = bytesOf('a'.repeat(100));
+      const frames = new TransferFrameBuilder('', BLE_MAX_CHUNK).buildFrames(payload, 1, 'tokens');
+      expect(frames.length).assertEqual(2);
+      expect(frames[0].isFinal).assertFalse();
+      expect(frames[1].isFinal).assertTrue();
+      expect(bytesEqual(frames[1].bytes, payload)).assertTrue();
+    });
+
+    it('builder_frames_split_exact_multiple_and_remainder', 0, () => {
+      // 整除边界：2×480 → 两片，第二片 isFinal
+      const exact = new Uint8Array(BLE_MAX_CHUNK * 2);
+      const frames = new TransferFrameBuilder('', BLE_MAX_CHUNK).buildFrames(exact, 2, 'tokens');
+      expect(frames.length).assertEqual(3);
+      expect(frames[1].bytes.length).assertEqual(BLE_MAX_CHUNK);
+      expect(frames[1].isFinal).assertFalse();
+      expect(frames[2].isFinal).assertTrue();
+
+      // 余数：2×480+100 → 480/480/100
+      const rem = new Uint8Array(BLE_MAX_CHUNK * 2 + 100);
+      const frames2 = new TransferFrameBuilder('', BLE_MAX_CHUNK).buildFrames(rem, 2, 'tokens');
+      expect(frames2.length).assertEqual(4);
+      expect(frames2[3].bytes.length).assertEqual(100);
+      expect(frames2[2].isFinal).assertFalse();
+      expect(frames2[3].isFinal).assertTrue();
+    });
+
+    it('builder_empty_payload_produces_header_only', 0, () => {
+      const frames = new TransferFrameBuilder('', BLE_MAX_CHUNK).buildFrames(new Uint8Array(0), 0, 'tokens');
+      expect(frames.length).assertEqual(1);
+      expect(frames[0].isFinal).assertFalse();
+    });
+
+    it('ble_receiver_full_batch_lifecycle_with_type_default', 0, () => {
+      const receiver = bleReceiver();
+      const payload = new Uint8Array(700); // 两片
+      const frames = new TransferFrameBuilder('', BLE_MAX_CHUNK).buildFrames(payload, 3, 'tokens');
+
+      let e = receiver.onFrame(frames[0].bytes);
+      expect(e.kind).assertEqual(TransferFrameEventKind.BATCH_STARTED);
+      expect(receiver.isInProgress()).assertTrue();
+
+      e = receiver.onFrame(frames[1].bytes);
+      expect(e.kind).assertEqual(TransferFrameEventKind.CHUNK_ACCEPTED);
+
+      e = receiver.onFrame(frames[2].bytes);
+      expect(e.kind).assertEqual(TransferFrameEventKind.BATCH_COMPLETE);
+      const batch: TransferBatch = e.batch!;
+      expect(batch.total).assertEqual(700);
+      expect(batch.count).assertEqual(3);
+      expect(batch.type).assertEqual('tokens');
+      expect(batch.receivedBytes).assertEqual(700);
+      expect(bytesEqual(concatenateChunks(batch.total, batch.chunks), payload)).assertTrue();
+      // 收齐后状态自动复位，可立即开新批次
+      expect(receiver.isInProgress()).assertFalse();
+    });
+
+    it('ble_receiver_defaults_type_to_tokens_for_legacy_header', 0, () => {
+      const receiver = bleReceiver();
+      // 旧版发送端头帧无 type 字段
+      receiver.onFrame(bytesOf('{"total":2,"count":1}'));
+      const done = receiver.onFrame(new Uint8Array([1, 2]));
+      expect(done.kind).assertEqual(TransferFrameEventKind.BATCH_COMPLETE);
+      expect(done.batch!.type).assertEqual('tokens');
+    });
+
+    it('ble_receiver_rejects_invalid_headers_as_orphan_frames', 0, () => {
+      const receiver = bleReceiver();
+      // 乱码（解密分片误当头帧）
+      expect(receiver.onFrame(new Uint8Array([0x00, 0xFF, 0x37])).kind)
+        .assertEqual(TransferFrameEventKind.ORPHAN_CHUNK);
+      // JSON 标量 total=0 / 负数 / 超上限 / 非数值 total 均拒绝
+      expect(receiver.onFrame(bytesOf('{"total":0,"count":1}')).kind)
+        .assertEqual(TransferFrameEventKind.ORPHAN_CHUNK);
+      expect(receiver.onFrame(bytesOf('{"total":-5,"count":1}')).kind)
+        .assertEqual(TransferFrameEventKind.ORPHAN_CHUNK);
+      expect(receiver.onFrame(bytesOf(`{"total":${BLE_MAX_TOTAL + 1},"count":1}`)).kind)
+        .assertEqual(TransferFrameEventKind.ORPHAN_CHUNK);
+      expect(receiver.onFrame(bytesOf('{"total":"5","count":1}')).kind)
+        .assertEqual(TransferFrameEventKind.ORPHAN_CHUNK);
+      expect(receiver.isInProgress()).assertFalse();
+    });
+
+    it('ble_receiver_discards_stale_batch_when_new_header_arrives', 0, () => {
+      const receiver = bleReceiver();
+      receiver.onFrame(bytesOf('{"total":100,"count":1,"type":"tokens"}'));
+      receiver.onFrame(new Uint8Array(10));
+      // 批次中途新头帧：残留分片丢弃，干净重启
+      const e = receiver.onFrame(bytesOf('{"total":3,"count":1,"type":"settings"}'));
+      expect(e.kind).assertEqual(TransferFrameEventKind.BATCH_STARTED);
+      const done = receiver.onFrame(new Uint8Array([7, 8, 9]));
+      expect(done.kind).assertEqual(TransferFrameEventKind.BATCH_COMPLETE);
+      expect(done.batch!.receivedBytes).assertEqual(3);
+      expect(done.batch!.type).assertEqual('settings');
+    });
+
+    it('wear_receiver_prefix_discriminates_header_and_ignores_orphans', 0, () => {
+      const receiver = wearReceiver();
+      // 无前缀数据帧且无批次 → 孤儿帧静默（WearEngine 语义）
+      expect(receiver.onFrame(new Uint8Array([1, 2, 3])).kind)
+        .assertEqual(TransferFrameEventKind.ORPHAN_CHUNK);
+      // 比前缀还短的帧同样安全
+      expect(receiver.onFrame(new Uint8Array([0x4F])).kind)
+        .assertEqual(TransferFrameEventKind.ORPHAN_CHUNK);
+
+      const builder = new TransferFrameBuilder(WEAR_PREFIX, 4000);
+      const payload = new Uint8Array(4001); // 跨两帧
+      const frames = builder.buildFrames(payload, 1, 'tokens');
+      expect(receiver.onFrame(frames[0].bytes).kind).assertEqual(TransferFrameEventKind.BATCH_STARTED);
+      expect(receiver.onFrame(frames[1].bytes).kind).assertEqual(TransferFrameEventKind.CHUNK_ACCEPTED);
+      const done = receiver.onFrame(frames[2].bytes);
+      expect(done.kind).assertEqual(TransferFrameEventKind.BATCH_COMPLETE);
+      expect(done.batch!.total).assertEqual(4001);
+      expect(bytesEqual(concatenateChunks(done.batch!.total, done.batch!.chunks), payload)).assertTrue();
+    });
+
+    it('wear_receiver_invalid_header_keeps_batch_and_restarts_on_valid', 0, () => {
+      const receiver = wearReceiver();
+      receiver.onFrame(bytesOf(`${WEAR_PREFIX}{"total":10,"count":1,"type":"tokens"}`));
+      receiver.onFrame(new Uint8Array(4));
+      // 非法头帧（total≤0 / 非 JSON）：批次保持不触碰。
+      // 注意：这是对 WearEngine 旧实现的有意收口——旧代码对 total≤0 静默忽略（批次保留），
+      // 但 JSON 解析抛错会落入外层 catch 重置批次致传输挂死；新实现统一为无副作用忽略。
+      expect(receiver.onFrame(bytesOf(`${WEAR_PREFIX}{"total":0,"count":1}`)).kind)
+        .assertEqual(TransferFrameEventKind.HEADER_INVALID);
+      expect(receiver.onFrame(bytesOf(`${WEAR_PREFIX}not-json`)).kind)
+        .assertEqual(TransferFrameEventKind.HEADER_INVALID);
+      expect(receiver.isInProgress()).assertTrue();
+      // 原批次仍可继续收齐：4 + 6 = 10
+      const done = receiver.onFrame(new Uint8Array(6));
+      expect(done.kind).assertEqual(TransferFrameEventKind.BATCH_COMPLETE);
+      expect(done.batch!.receivedBytes).assertEqual(10);
+    });
+
+    it('receiver_completes_on_overshoot_and_surfaces_received_bytes', 0, () => {
+      // 收齐判定为 received >= total：超量投递时完成事件带真实字节数，
+      // 精确性校验由通道层的 receivedBytes !== total 分支承担（判失败丢弃）
+      const receiver = bleReceiver();
+      receiver.onFrame(bytesOf('{"total":4,"count":1,"type":"tokens"}'));
+      const done = receiver.onFrame(new Uint8Array(9));
+      expect(done.kind).assertEqual(TransferFrameEventKind.BATCH_COMPLETE);
+      expect(done.batch!.receivedBytes).assertEqual(9);
+      expect(done.batch!.total).assertEqual(4);
+    });
+
+    it('wear_receiver_accepts_unlimited_total_and_restarts_mid_batch', 0, () => {
+      const receiver = wearReceiver();
+      // maxTotal=0 不设上限（P2P 头帧无上限校验）
+      const e = receiver.onFrame(bytesOf(`${WEAR_PREFIX}{"total":99999999,"count":1,"type":"tokens"}`));
+      expect(e.kind).assertEqual(TransferFrameEventKind.BATCH_STARTED);
+      // 批次中途新头帧重启
+      const restart = receiver.onFrame(bytesOf(`${WEAR_PREFIX}{"total":1,"count":1,"type":"tokens"}`));
+      expect(restart.kind).assertEqual(TransferFrameEventKind.BATCH_STARTED);
+      const done = receiver.onFrame(new Uint8Array([9]));
+      expect(done.kind).assertEqual(TransferFrameEventKind.BATCH_COMPLETE);
+      expect(done.batch!.receivedBytes).assertEqual(1);
+    });
+
+    it('receiver_reset_drops_pending_batch', 0, () => {
+      const receiver = bleReceiver();
+      receiver.onFrame(bytesOf('{"total":100,"count":1,"type":"tokens"}'));
+      receiver.reset();
+      expect(receiver.isInProgress()).assertFalse();
+      // 复位后数据帧成为孤儿帧
+      expect(receiver.onFrame(new Uint8Array(5)).kind).assertEqual(TransferFrameEventKind.ORPHAN_CHUNK);
+    });
+
+    it('concatenate_chunks_underfill_pads_and_overflow_throws', 0, () => {
+      // 分片不足 total：缓冲区按 total 分配，尾部补零（与抽离前实现一致）
+      const short = concatenateChunks(5, [new Uint8Array([1, 2])]);
+      expect(short.length).assertEqual(5);
+      expect([short[0], short[1], short[4]].join(',')).assertEqual('1,2,0');
+      // 分片超出 total：set 越界抛异常（交叠写入保护路径）
+      let threw = false;
+      try {
+        concatenateChunks(2, [new Uint8Array([1, 2, 3])]);
+      } catch (err) {
+        threw = true;
+      }
+      expect(threw).assertTrue();
+    });
+
+    it('reuse_local_token_uuids_matches_issuer_and_name', 0, () => {
+      const local1 = new TokenConfig('SECRET1', otpType.TOTP, 'GitHub', 'github');
+      local1.TokenUUID = 'local-uuid-1';
+      const local2 = new TokenConfig('SECRET2', otpType.TOTP, 'GitLab', 'gitlab');
+      local2.TokenUUID = 'local-uuid-2';
+
+      const incoming1 = new TokenConfig('SECRET1', otpType.TOTP, 'GitHub', 'github');
+      incoming1.TokenUUID = 'device-uuid-x';
+      const incoming2 = new TokenConfig('SECRET3', otpType.TOTP, 'NewService', 'new');
+      incoming2.TokenUUID = 'device-uuid-y';
+      const incoming3 = new TokenConfig('SECRET9', otpType.TOTP, 'GitHub', 'gitee'); // issuer 不同不复用
+      incoming3.TokenUUID = 'device-uuid-z';
+
+      const reused = reuseLocalTokenUuids([incoming1, incoming2, incoming3], [local1, local2]);
+      expect(reused).assertEqual(1);
+      expect(incoming1.TokenUUID).assertEqual('local-uuid-1');
+      expect(incoming2.TokenUUID).assertEqual('device-uuid-y');
+      expect(incoming3.TokenUUID).assertEqual('device-uuid-z');
+      // 同 issuer+name 多本地匹配取第一个
+      const dup = new TokenConfig('SECRET1', otpType.TOTP, 'GitHub', 'github');
+      dup.TokenUUID = 'device-uuid-z';
+      expect(reuseLocalTokenUuids([dup], [local1, local2])).assertEqual(1);
+      expect(dup.TokenUUID).assertEqual('local-uuid-1');
+      // 空批次
+      expect(reuseLocalTokenUuids([], [])).assertEqual(0);
+    });
+
+    it('end_to_end_ble_frames_reassemble_to_original_payload', 0, () => {
+      // 加密载荷模拟：随机字节 1000 字节（跨三片）
+      const cipher = new Uint8Array(1000);
+      for (let i = 0; i < cipher.length; i++) {
+        cipher[i] = (i * 31 + 7) % 256;
+      }
+      const sender = new TransferFrameBuilder('', BLE_MAX_CHUNK);
+      const receiver = bleReceiver();
+      let batch: TransferBatch | null = null;
+      for (const frame of sender.buildFrames(cipher, 5, 'tokens')) {
+        const e = receiver.onFrame(frame.bytes);
+        if (e.kind === TransferFrameEventKind.BATCH_COMPLETE) {
+          batch = e.batch;
+        }
+      }
+      expect(batch !== null).assertTrue();
+      expect(bytesEqual(concatenateChunks(batch!.total, batch!.chunks), cipher)).assertTrue();
+    });
+
+    it('end_to_end_wear_frames_reassemble_with_settings_type', 0, () => {
+      const cipher = new Uint8Array(5200);
+      for (let i = 0; i < cipher.length; i++) {
+        cipher[i] = (i * 17) % 256;
+      }
+      const sender = new TransferFrameBuilder(WEAR_PREFIX, 4000);
+      const receiver = wearReceiver();
+      let batch: TransferBatch | null = null;
+      for (const frame of sender.buildFrames(cipher, 26, 'settings')) {
+        const e = receiver.onFrame(frame.bytes);
+        if (e.kind === TransferFrameEventKind.BATCH_COMPLETE) {
+          batch = e.batch;
+        }
+      }
+      expect(batch !== null).assertTrue();
+      expect(batch!.type).assertEqual('settings');
+      expect(batch!.count).assertEqual(26);
+      expect(bytesEqual(concatenateChunks(batch!.total, batch!.chunks), cipher)).assertTrue();
+    });
+  });
+}

--- a/entry/src/test/UiUtilsMisc.test.ets
+++ b/entry/src/test/UiUtilsMisc.test.ets
@@ -1,0 +1,108 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { throttle } from 'common';
+import { delay, nowUnixSeconds, padZero } from 'common';
+import {
+  reportTokenBatchProgress,
+  TokenBatchProgress,
+  TokenBatchStage,
+} from 'common';
+
+/**
+ * UI 旁路纯函数测试：UiUtils.throttle、TokenBatchProgress 观察者协议、
+ * CommonUtils 时间/延时工具。均不依赖 UI 上下文。
+ */
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise<void>((resolve: () => void) => {
+    setTimeout(() => resolve(), ms);
+  });
+}
+
+export default function uiUtilsMiscTest() {
+  describe('uiUtilsMiscTest', () => {
+    it('throttle_executes_once_per_window', 0, async () => {
+      let count = 0;
+      const handler = (event: ClickEvent): void => {
+        count++;
+      };
+      const throttled = throttle(handler, 60);
+
+      throttled({} as ClickEvent);
+      throttled({} as ClickEvent);
+      throttled({} as ClickEvent);
+      expect(count).assertEqual(1);
+
+      await waitMs(80);
+      throttled({} as ClickEvent);
+      expect(count).assertEqual(2);
+    });
+
+    it('default_throttle_window_is_one_second', 0, async () => {
+      let count = 0;
+      const throttled = throttle((event: ClickEvent): void => {
+        count++;
+      });
+
+      throttled({} as ClickEvent);
+      throttled({} as ClickEvent);
+      expect(count).assertEqual(1);
+      // 默认 1000ms 窗口内不重放；不真正等 1 秒，只验证仍处于抑制期
+      await waitMs(50);
+      throttled({} as ClickEvent);
+      expect(count).assertEqual(1);
+    });
+
+    it('token_batch_stage_enum_order', 0, () => {
+      expect(TokenBatchStage.PREPARING).assertEqual(0);
+      expect(TokenBatchStage.SAVING).assertEqual(5);
+      expect(TokenBatchStage.DONE).assertEqual(10);
+    });
+
+    it('report_progress_invokes_observer_with_snapshot', 0, () => {
+      const seen: TokenBatchProgress[] = [];
+      reportTokenBatchProgress((progress: TokenBatchProgress): void => {
+        seen.push(progress);
+      }, TokenBatchStage.SAVING, 64, 128);
+
+      expect(seen.length).assertEqual(1);
+      expect(seen[0].stage).assertEqual(TokenBatchStage.SAVING);
+      expect(seen[0].completed).assertEqual(64);
+      expect(seen[0].total).assertEqual(128);
+    });
+
+    it('missing_or_throwing_observer_never_breaks_persistence', 0, () => {
+      // 无观察者：静默返回
+      reportTokenBatchProgress(undefined, TokenBatchStage.COMMITTING);
+
+      // 观察者抛异常不得向事务传播（UI 已销毁时不能回滚数据）
+      let reached = false;
+      try {
+        reportTokenBatchProgress((progress: TokenBatchProgress): void => {
+          throw new Error('observer gone');
+        }, TokenBatchStage.ROLLING_BACK);
+        reached = true;
+      } catch (e) {
+        reached = false;
+      }
+      expect(reached).assertTrue();
+    });
+
+    it('common_utils_delay_resolves', 0, async () => {
+      // LocalUnit 下 Date.now() 同样被 stub（不推进），无法断言真实耗时；
+      // 契约锁定为：delay 返回的 Promise 在定时器触发后 resolve。
+      let resolved = false;
+      await delay(5).then(() => {
+        resolved = true;
+      });
+      expect(resolved).assertTrue();
+    });
+
+    it('common_utils_now_unix_seconds_returns_finite_number', 0, () => {
+      const now = nowUnixSeconds();
+      // LocalUnit 下 systemDateTime 被 stub（不与真实时钟对齐），真机回归校准时钟一致性；
+      // 这里只锁定契约：返回有限数值，供 TOTP 计算取模使用。
+      expect(typeof now === 'number' && !isNaN(now) && isFinite(now)).assertTrue();
+      expect(padZero(5)).assertEqual('05');
+    });
+  });
+}

--- a/entry/src/test/fakes/BackupFakes.ets
+++ b/entry/src/test/fakes/BackupFakes.ets
@@ -1,0 +1,672 @@
+import {
+  CryptoEngine,
+  CryptoSealedBytes,
+  FsGateway,
+  FsStatInfo,
+  KvBatchEntry,
+  LegacyTokenKv,
+  NamedSecretStore,
+  SecretStore,
+  TokenBatchProgressCallback,
+  TokenKvStore,
+  TransactionalKv,
+  utf8ByteLength,
+} from 'common';
+import { TokenConfig } from 'common';
+import { OathCryptoPort } from '../../main/ets/oath/OathApplet';
+import { TagTransport } from '../../main/ets/oath/TagTransport';
+
+/**
+ * Phase 2 共享测试假实现（docs/TEST_PLAN.md 第 4 节端口注入）。
+ * 仅在 entry/src/test 下使用；全部为确定性实现，无 @ohos 系统 API。
+ */
+
+/** TokenKvStore 内存实现：JSON 序列化存储，与生产加密 KV 行为一致；支持失败注入。 */
+export class MemoryTokenKv implements TokenKvStore {
+  entries: Map<string, string> = new Map();
+  initCalls: number = 0;
+  failNextBatch: boolean = false;
+  lastBatchTokens: TokenConfig[] = [];
+  lastBatchDeletes: string[] = [];
+  batchCallCount: number = 0;
+
+  init(): Promise<void> {
+    this.initCalls++;
+    return Promise.resolve();
+  }
+
+  getValue<T>(key: string): Promise<T | null> {
+    const raw = this.entries.get(key);
+    if (raw === undefined) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(JSON.parse(raw) as T);
+  }
+
+  setValue<T>(key: string, value: T): Promise<void> {
+    this.entries.set(key, JSON.stringify(value));
+    return Promise.resolve();
+  }
+
+  deleteValue(key: string): Promise<void> {
+    this.entries.delete(key);
+    return Promise.resolve();
+  }
+
+  getTokenArray(prefix: string): Promise<TokenConfig[]> {
+    const out: TokenConfig[] = [];
+    this.entries.forEach((value: string, key: string) => {
+      if (key.startsWith(prefix) && value.length > 0) {
+        out.push(JSON.parse(value) as TokenConfig);
+      }
+    });
+    return Promise.resolve(out);
+  }
+
+  saveTokenBatch(prefix: string, tokens: TokenConfig[], deletedUuids?: string[],
+    onProgress?: TokenBatchProgressCallback): Promise<void> {
+    this.batchCallCount++;
+    if (this.failNextBatch) {
+      this.failNextBatch = false;
+      return Promise.reject(new Error('kv batch failed'));
+    }
+    this.lastBatchTokens = tokens;
+    this.lastBatchDeletes = deletedUuids !== undefined ? deletedUuids : [];
+    for (const token of tokens) {
+      this.entries.set(`${prefix}${token.TokenUUID}`, JSON.stringify(token));
+    }
+    for (const uuid of this.lastBatchDeletes) {
+      this.entries.delete(`${prefix}${uuid}`);
+    }
+    return Promise.resolve();
+  }
+}
+
+/** SecretStore 内存实现：三重验证各失败点可独立注入。 */
+export class MemorySecretStore implements SecretStore {
+  secrets: Map<string, string> = new Map();
+  namedSecrets: Map<string, string> = new Map();
+  /** upsertSecret 对这些 uuid 返回 false（模拟 ASSET add 失败） */
+  failUpsertFor: Set<string> = new Set();
+  /** querySecret 对这些 uuid 返回 null（模拟验证阶段查不到） */
+  dropQueryFor: Set<string> = new Set();
+  /** querySecret 对这些 uuid 返回被篡改值（模拟验证阶段内容不一致） */
+  corruptQueryFor: Map<string, string> = new Map();
+  upsertCalls: string[] = [];
+  removeCalls: string[] = [];
+  batchQueryCalls: number = 0;
+
+  isSecretSizeValid(secret: string): boolean {
+    if (secret.length === 0) {
+      return false;
+    }
+    return utf8ByteLength(secret) <= 900;
+  }
+
+  async upsertSecret(tokenUUID: string, secret: string): Promise<boolean> {
+    this.upsertCalls.push(tokenUUID);
+    if (this.failUpsertFor.has(tokenUUID)) {
+      return false;
+    }
+    this.secrets.set(tokenUUID, secret);
+    return true;
+  }
+
+  querySecret(tokenUUID: string): Promise<string | null> {
+    if (this.dropQueryFor.has(tokenUUID)) {
+      return Promise.resolve(null);
+    }
+    // 篡改仅在 upsert 之后生效：批量预查（迁移前）视为不存在，验证查询返回被篡改值
+    const corrupt = this.corruptQueryFor.get(tokenUUID);
+    if (corrupt !== undefined && this.upsertCalls.indexOf(tokenUUID) >= 0) {
+      return Promise.resolve(corrupt);
+    }
+    const value = this.secrets.get(tokenUUID);
+    return Promise.resolve(value !== undefined ? value : null);
+  }
+
+  async removeSecret(tokenUUID: string): Promise<void> {
+    this.removeCalls.push(tokenUUID);
+    this.secrets.delete(tokenUUID);
+  }
+
+  async batchQuerySecrets(tokenUUIDs: string[]): Promise<Map<string, string>> {
+    this.batchQueryCalls++;
+    const result = new Map<string, string>();
+    for (const uuid of tokenUUIDs) {
+      const secret = await this.querySecret(uuid);
+      if (secret !== null) {
+        result.set(uuid, secret);
+      }
+    }
+    return result;
+  }
+
+  upsertNamedSecret(alias: string, secret: string): Promise<boolean> {
+    this.namedSecrets.set(alias, secret);
+    return Promise.resolve(true);
+  }
+
+  queryNamedSecret(alias: string): Promise<string | null> {
+    const value = this.namedSecrets.get(alias);
+    return Promise.resolve(value !== undefined ? value : null);
+  }
+
+  async removeNamedSecret(alias: string): Promise<void> {
+    this.namedSecrets.delete(alias);
+  }
+}
+
+/** NamedSecretStore 内存实现（SteamSecretStore 用），记录调用序供断言。 */
+export class MemoryNamedSecretStore implements NamedSecretStore {
+  secrets: Map<string, string> = new Map();
+  upsertCalls: string[] = [];
+  removeCalls: string[] = [];
+  probeCalls: string[] = [];
+  /** 对命中的 alias 让 upsert 失败 */
+  failUpsertFor: Set<string> = new Set();
+
+  upsertNamedSecret(alias: string, secret: string): Promise<boolean> {
+    this.upsertCalls.push(alias);
+    if (this.failUpsertFor.has(alias)) {
+      return Promise.resolve(false);
+    }
+    this.secrets.set(alias, secret);
+    return Promise.resolve(true);
+  }
+
+  queryNamedSecret(alias: string): Promise<string | null> {
+    this.probeCalls.push(alias);
+    const value = this.secrets.get(alias);
+    return Promise.resolve(value !== undefined ? value : null);
+  }
+
+  async removeNamedSecret(alias: string): Promise<void> {
+    this.removeCalls.push(alias);
+    this.secrets.delete(alias);
+  }
+}
+
+/** FsGateway 内存实现：文件内容 + 删除/写入记录 + location 覆盖。 */
+export class MemoryFs implements FsGateway {
+  files: Map<string, string> = new Map();
+  dirs: Set<string> = new Set();
+  written: Map<string, string> = new Map();
+  deletedPaths: string[] = [];
+  copiedPairs: string[] = [];
+  failWrite: boolean = false;
+  locationOverride: Map<string, number> = new Map();
+
+  stat(path: string): Promise<FsStatInfo> {
+    const info = new FsStatInfo();
+    const loc = this.locationOverride.get(path);
+    info.location = loc !== undefined ? loc : 0;
+    if (this.dirs.has(path)) {
+      info.size = 0;
+      info.isDirectory = true;
+      return Promise.resolve(info);
+    }
+    const content = this.files.get(path);
+    if (content === undefined) {
+      return Promise.reject(new Error(`stat: no such file ${path}`));
+    }
+    info.size = content.length;
+    info.isDirectory = false;
+    return Promise.resolve(info);
+  }
+
+  listFiles(dir: string): Promise<string[]> {
+    // 与 fs.listFile 语义一致：仅列出直接子项（含子目录名）
+    const out: string[] = [];
+    this.files.forEach((_: string, path: string) => {
+      const idx = path.lastIndexOf('/');
+      const parent = idx > 0 ? path.substring(0, idx) : '/';
+      if (parent === dir) {
+        out.push(path.substring(dir.length + 1));
+      }
+    });
+    this.dirs.forEach((path: string) => {
+      const idx = path.lastIndexOf('/');
+      const parent = idx > 0 ? path.substring(0, idx) : '/';
+      if (parent === dir) {
+        out.push(path.substring(dir.length + 1));
+      }
+    });
+    return Promise.resolve(out);
+  }
+
+  readTextFile(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) {
+      return Promise.reject(new Error(`read: no such file ${path}`));
+    }
+    return Promise.resolve(content);
+  }
+
+  writeTextFile(path: string, content: string): Promise<void> {
+    if (this.failWrite) {
+      return Promise.reject(new Error('write failed'));
+    }
+    this.files.set(path, content);
+    this.written.set(path, content);
+    return Promise.resolve();
+  }
+
+  writeBinaryFile(path: string, data: Uint8Array): Promise<void> {
+    if (this.failWrite) {
+      return Promise.reject(new Error('write failed'));
+    }
+    let text = '';
+    for (let i = 0; i < data.length; i++) {
+      text += String.fromCharCode(data[i]);
+    }
+    this.files.set(path, text);
+    this.written.set(path, text);
+    return Promise.resolve();
+  }
+
+  makeDir(path: string): Promise<void> {
+    this.dirs.add(path);
+    return Promise.resolve();
+  }
+
+  removeDir(path: string): Promise<void> {
+    // 与 fs.rmdir 语义一致：仅能删除空目录
+    if (!this.dirs.has(path)) {
+      return Promise.reject(new Error(`rmdir: no such directory ${path}`));
+    }
+    let empty = true;
+    this.files.forEach((_: string, p: string) => {
+      const idx = p.lastIndexOf('/');
+      const parent = idx > 0 ? p.substring(0, idx) : '/';
+      if (parent === path) {
+        empty = false;
+      }
+    });
+    if (empty) {
+      this.dirs.forEach((d: string) => {
+        const idx = d.lastIndexOf('/');
+        const parent = idx > 0 ? d.substring(0, idx) : '/';
+        if (parent === path) {
+          empty = false;
+        }
+      });
+    }
+    if (!empty) {
+      return Promise.reject(new Error(`rmdir: not empty ${path}`));
+    }
+    this.dirs.delete(path);
+    return Promise.resolve();
+  }
+
+  deleteFile(path: string): Promise<void> {
+    // 与 fs.unlink 语义一致：删除不存在的文件必须报错；目录不能用 unlink 删除
+    if (this.dirs.has(path)) {
+      return Promise.reject(new Error(`delete: is a directory ${path}`));
+    }
+    if (!this.files.has(path)) {
+      return Promise.reject(new Error(`delete: no such file ${path}`));
+    }
+    this.deletedPaths.push(path);
+    this.files.delete(path);
+    return Promise.resolve();
+  }
+
+  copyFile(src: string, dest: string): Promise<void> {
+    const content = this.files.get(src);
+    if (content === undefined) {
+      return Promise.reject(new Error(`copy: no such file ${src}`));
+    }
+    this.copiedPairs.push(`${src}->${dest}`);
+    this.files.set(dest, content);
+    return Promise.resolve();
+  }
+}
+
+/** TransactionalKv 内存实现：暂存写入，commit 落盘、rollback 丢弃，记录分块调用。 */
+export class MemoryTransactionalKv implements TransactionalKv {
+  committed: Map<string, string> = new Map();
+  staged: Map<string, string> = new Map();
+  stagedDeletes: string[] = [];
+  startCount: number = 0;
+  commitCount: number = 0;
+  rollbackCount: number = 0;
+  putBatchCalls: number[][] = [];
+  deleteBatchCalls: number[][] = [];
+  /** 第 N 次 putBatch（0 起）抛错；-1 表示不失败 */
+  failPutBatchAt: number = -1;
+  private putCallIndex: number = 0;
+
+  async startTransaction(): Promise<void> {
+    this.startCount++;
+    this.staged = new Map();
+    this.stagedDeletes = [];
+    this.putCallIndex = 0;
+  }
+
+  async putBatch(entries: KvBatchEntry[]): Promise<void> {
+    this.putBatchCalls.push(entries.map((e: KvBatchEntry): number => e.key.length));
+    if (this.failPutBatchAt === this.putCallIndex) {
+      this.putCallIndex++;
+      throw new Error('putBatch failed');
+    }
+    this.putCallIndex++;
+    for (const entry of entries) {
+      this.staged.set(entry.key, entry.value);
+    }
+  }
+
+  async deleteBatch(keys: string[]): Promise<void> {
+    this.deleteBatchCalls.push(keys.map((k: string): number => k.length));
+    for (const key of keys) {
+      this.stagedDeletes.push(key);
+    }
+  }
+
+  async commit(): Promise<void> {
+    this.commitCount++;
+    this.staged.forEach((value: string, key: string) => {
+      this.committed.set(key, value);
+    });
+    for (const key of this.stagedDeletes) {
+      this.committed.delete(key);
+    }
+  }
+
+  async rollback(): Promise<void> {
+    this.rollbackCount++;
+    this.staged = new Map();
+    this.stagedDeletes = [];
+  }
+}
+
+/** LegacyTokenKv 内存实现（旧版本令牌迁移用）。 */
+export class MemoryLegacyKv implements LegacyTokenKv {
+  entries: Map<string, string> = new Map();
+
+  getRawEntries(prefix: string): Promise<KvBatchEntry[]> {
+    const out: KvBatchEntry[] = [];
+    this.entries.forEach((value: string, key: string) => {
+      if (key.startsWith(prefix)) {
+        const entry: KvBatchEntry = { key: key, value: value };
+        out.push(entry);
+      }
+    });
+    return Promise.resolve(out);
+  }
+
+  getString(key: string): Promise<string | null> {
+    const value = this.entries.get(key);
+    return Promise.resolve(value !== undefined ? value : null);
+  }
+
+  setString(key: string, value: string): Promise<void> {
+    this.entries.set(key, value);
+    return Promise.resolve();
+  }
+
+  deleteValue(key: string): Promise<void> {
+    this.entries.delete(key);
+    return Promise.resolve();
+  }
+}
+
+/**
+ * 确定性假密码引擎：XOR 流"加密"（可逆），LCG 伪随机；
+ * 记录关键调用供断言。数值正确性不属本层测试目标。
+ */
+export class FakeCryptoEngine implements CryptoEngine {
+  randomSeed: number = 1;
+  failNextCbcDecrypt: boolean = false;
+  failGcmOpen: boolean = false;
+  lastPbkdf2Password: string = '';
+  lastPbkdf2Salt: Uint8Array = new Uint8Array(0);
+  lastPbkdf2Iterations: number = -1;
+  lastPbkdf2KeySize: number = -1;
+  sha256Calls: Uint8Array[] = [];
+  /** 最近一次 aesCbcDecrypt 收到的 iv（供 legacy 固定 IV 断言） */
+  lastCbcDecryptIv: Uint8Array = new Uint8Array(0);
+
+  randomBytes(length: number): Uint8Array {
+    const out = new Uint8Array(length);
+    for (let i = 0; i < length; i++) {
+      this.randomSeed = (this.randomSeed * 48271) % 2147483647;
+      out[i] = this.randomSeed % 256;
+    }
+    return out;
+  }
+
+  utf8Encode(text: string): Uint8Array {
+    const out: number[] = [];
+    for (let i = 0; i < text.length; i++) {
+      let code = text.charCodeAt(i);
+      if (code >= 0xD800 && code <= 0xDBFF && i + 1 < text.length) {
+        const lo = text.charCodeAt(i + 1);
+        if (lo >= 0xDC00 && lo <= 0xDFFF) {
+          code = 0x10000 + ((code - 0xD800) << 10) + (lo - 0xDC00);
+          i++;
+        }
+      }
+      if (code < 0x80) {
+        out.push(code);
+      } else if (code < 0x800) {
+        out.push(0xC0 | (code >> 6), 0x80 | (code & 63));
+      } else if (code < 0x10000) {
+        out.push(0xE0 | (code >> 12), 0x80 | ((code >> 6) & 63), 0x80 | (code & 63));
+      } else {
+        out.push(0xF0 | (code >> 18), 0x80 | ((code >> 12) & 63), 0x80 | ((code >> 6) & 63), 0x80 | (code & 63));
+      }
+    }
+    return new Uint8Array(out);
+  }
+
+  utf8Decode(data: Uint8Array): string {
+    let out = '';
+    let i = 0;
+    while (i < data.length) {
+      let code: number;
+      const b = data[i];
+      if (b < 0x80) {
+        code = b;
+        i += 1;
+      } else if (b < 0xE0) {
+        code = ((b & 0x1F) << 6) | (data[i + 1] & 63);
+        i += 2;
+      } else if (b < 0xF0) {
+        code = ((b & 0x0F) << 12) | ((data[i + 1] & 63) << 6) | (data[i + 2] & 63);
+        i += 3;
+      } else {
+        code = ((b & 0x07) << 18) | ((data[i + 1] & 63) << 12) | ((data[i + 2] & 63) << 6) | (data[i + 3] & 63);
+        i += 4;
+      }
+      if (code >= 0x10000) {
+        code -= 0x10000;
+        out += String.fromCharCode(0xD800 + (code >> 10), 0xDC00 + (code & 1023));
+      } else {
+        out += String.fromCharCode(code);
+      }
+    }
+    return out;
+  }
+
+  async pbkdf2Derive(password: string, salt: Uint8Array, iterations: number, keySize: number): Promise<Uint8Array> {
+    this.lastPbkdf2Password = password;
+    this.lastPbkdf2Salt = salt;
+    this.lastPbkdf2Iterations = iterations;
+    this.lastPbkdf2KeySize = keySize;
+    const out = new Uint8Array(keySize);
+    let acc = 17;
+    for (let i = 0; i < password.length; i++) {
+      acc = (acc * 31 + password.charCodeAt(i)) % 2147483647;
+    }
+    for (let i = 0; i < salt.length; i++) {
+      acc = (acc * 31 + salt[i]) % 2147483647;
+    }
+    acc = (acc + iterations) % 2147483647;
+    for (let i = 0; i < keySize; i++) {
+      acc = (acc * 48271) % 2147483647;
+      out[i] = acc % 256;
+    }
+    return out;
+  }
+
+  async sha256(data: Uint8Array): Promise<Uint8Array> {
+    this.sha256Calls.push(data);
+    const out = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) {
+      let acc = i + 1;
+      for (let j = 0; j < data.length; j++) {
+        acc = ((acc * 31) + data[j] + j) % 65521;
+      }
+      out[i] = acc % 256;
+    }
+    return out;
+  }
+
+  private xorStream(data: Uint8Array, key: Uint8Array, iv: Uint8Array): Uint8Array {
+    const out = new Uint8Array(data.length);
+    for (let i = 0; i < data.length; i++) {
+      out[i] = data[i] ^ key[i % key.length] ^ iv[i % iv.length] ^ (i % 251);
+    }
+    return out;
+  }
+
+  async aesCbcEncrypt(plain: Uint8Array, key: Uint8Array, iv: Uint8Array): Promise<Uint8Array> {
+    return this.xorStream(plain, key, iv);
+  }
+
+  async aesCbcDecrypt(cipher: Uint8Array, key: Uint8Array, iv: Uint8Array): Promise<Uint8Array> {
+    this.lastCbcDecryptIv = iv;
+    if (this.failNextCbcDecrypt) {
+      this.failNextCbcDecrypt = false;
+      throw new Error('fake padding error');
+    }
+    return this.xorStream(cipher, key, iv);
+  }
+
+  async aesGcmSeal(plain: Uint8Array, key: Uint8Array, iv: Uint8Array, _aad: Uint8Array): Promise<CryptoSealedBytes> {
+    const sealed = new CryptoSealedBytes();
+    sealed.ciphertext = this.xorStream(plain, key, iv);
+    const tag = new Uint8Array(16);
+    for (let i = 0; i < 16; i++) {
+      tag[i] = (key[i % key.length] ^ iv[i % iv.length] ^ i) & 0xFF;
+    }
+    sealed.tag = tag;
+    return sealed;
+  }
+
+  async aesGcmOpen(cipher: Uint8Array, key: Uint8Array, iv: Uint8Array, _aad: Uint8Array,
+    tag: Uint8Array): Promise<Uint8Array> {
+    if (this.failGcmOpen) {
+      throw new Error('fake tag mismatch');
+    }
+    for (let i = 0; i < 16; i++) {
+      if (tag[i] !== ((key[i % key.length] ^ iv[i % iv.length] ^ i) & 0xFF)) {
+        throw new Error('fake tag mismatch');
+      }
+    }
+    return this.xorStream(cipher, key, iv);
+  }
+}
+
+/** OathCryptoPort 确定性假实现：两侧计算一致，仅验证协议编排。 */
+export class FakeOathCrypto implements OathCryptoPort {
+  deriveCalls: number = 0;
+  lastDerivePassword: string = '';
+  lastDeriveSalt: Uint8Array = new Uint8Array(0);
+
+  async pbkdf2Sha1Derive(password: string, salt: Uint8Array, _iterations: number, keySize: number):
+    Promise<Uint8Array> {
+    this.deriveCalls++;
+    this.lastDerivePassword = password;
+    this.lastDeriveSalt = salt;
+    const out = new Uint8Array(keySize);
+    for (let i = 0; i < keySize; i++) {
+      out[i] = (password.charCodeAt(i % Math.max(password.length, 1)) + i) & 0xFF;
+    }
+    return out;
+  }
+
+  async hmacSha1(key: Uint8Array, message: Uint8Array): Promise<Uint8Array> {
+    const out = new Uint8Array(20);
+    for (let i = 0; i < 20; i++) {
+      const k = key.length > 0 ? key[i % key.length] : 0;
+      const m = message.length > 0 ? message[i % message.length] : 0;
+      out[i] = (k ^ m ^ (i * 7 + 3)) & 0xFF;
+    }
+    return out;
+  }
+
+  randomBytes(len: number): Uint8Array {
+    const out = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+      out[i] = (i * 11 + 5) & 0xFF;
+    }
+    return out;
+  }
+
+  utf8Decode(data: Uint8Array): string {
+    return this.utf8DecodeImpl(data);
+  }
+
+  private utf8DecodeImpl(data: Uint8Array): string {
+    let out = '';
+    let i = 0;
+    while (i < data.length) {
+      let code: number;
+      const b = data[i];
+      if (b < 0x80) {
+        code = b;
+        i += 1;
+      } else if (b < 0xE0) {
+        code = ((b & 0x1F) << 6) | (data[i + 1] & 63);
+        i += 2;
+      } else if (b < 0xF0) {
+        code = ((b & 0x0F) << 12) | ((data[i + 1] & 63) << 6) | (data[i + 2] & 63);
+        i += 3;
+      } else {
+        code = ((b & 0x07) << 18) | ((data[i + 1] & 63) << 12) | ((data[i + 2] & 63) << 6) | (data[i + 3] & 63);
+        i += 4;
+      }
+      if (code >= 0x10000) {
+        code -= 0x10000;
+        out += String.fromCharCode(0xD800 + (code >> 10), 0xDC00 + (code & 1023));
+      } else {
+        out += String.fromCharCode(code);
+      }
+    }
+    return out;
+  }
+}
+
+/** 脚本化 TagTransport：按队列回放响应，记录 APDU。 */
+export class ScriptedTagTransport implements TagTransport {
+  sentApdus: number[][] = [];
+  private responses: number[][] = [];
+  closed: boolean = false;
+  connected: boolean = false;
+
+  queueResponse(response: number[]): void {
+    this.responses.push(response);
+  }
+
+  connect(): Promise<void> {
+    this.connected = true;
+    return Promise.resolve();
+  }
+
+  transmit(apdu: number[]): Promise<number[]> {
+    this.sentApdus.push(apdu);
+    const resp = this.responses.shift();
+    return Promise.resolve(resp !== undefined ? resp : [0x6F, 0x00]);
+  }
+
+  close(): Promise<void> {
+    this.closed = true;
+    return Promise.resolve();
+  }
+
+  isConnected(): boolean {
+    return this.connected && !this.closed;
+  }
+}

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -39,10 +39,11 @@ const LOGIC_ROOTS = [
 ];
 
 // 真机 only 责任区（docs/TEST_PLAN.md 第 2 节）+ UI 胶水，按文件名剔除。
+// Phase 2 起 SteamSecretStore 已解耦（NamedSecretStore 端口注入），逻辑可测，移出本清单。
 const DEVICE_ONLY_OR_UI = [
   'PermissionManager', 'DlpAntiPeepManager', 'PhotoPickerUtils', 'IconThumbnailTask',
   'RdbManager', 'HuaweiAccountManager', 'BleTokenTransfer', 'WearEngineTransfer',
-  'KvManager', 'AssetSecretStore', 'SteamSecretStore',
+  'KvManager', 'AssetSecretStore',
   'NfcOathReader', 'NfcTagTransport', 'NetworkHttpTransport', 'TokenSwitchPerf',
   'EntryAbility', 'HdsSnackBarUtils',
 ];

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * 逻辑层覆盖率门禁（Phase 1 起，见 docs/TEST_PLAN.md 第 5 节）。
+ *
+ * 用法（LocalUnit 测试跑完后执行）：
+ *   hvigorw test -p module=entry@default --no-daemon
+ *   node scripts/check-coverage.mjs
+ *
+ * 口径（与 TEST_PLAN 三分法一致）：
+ * - 逻辑层 = common 全部 + entry 的 crypto/steam/oath/utils
+ * - 剔除真机 only 责任区（asset/ble/wearEngine/distributedKVStore/NFC/RDB 等
+ *   文件级剔除，归 ohosTest）与 UI 胶水（HdsSnackBarUtils）
+ *
+ * 四道检查：
+ * 1. 行/分支覆盖不得低于 baseline（0.1pp 容差）；
+ * 2. coverageReport.json 不得遗漏口径内文件（分母逃逸：测试导入图树裁掉后
+ *    报告里没有的文件对覆盖率完全不可见）——豁免清单冻结在 baseline 的
+ *    expectedAbsentFromReport，只允许缩小不允许增长；
+ * 3. 磁盘口径内文件数不得少于 baseline.fileCount（防止删文件静默缩分母；
+ *    有意删除/新增文件后请重新生成 baseline 并随代码提交）；
+ * 4. baseline 自身的可诊断性：报告或基线缺失时给出可操作的报错。
+ */
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const path = require('node:path');
+
+const REPORT = path.resolve('entry/.test/default/outputs/test/reports/coverageReport.json');
+const BASELINE = path.resolve('scripts/coverage-baseline.json');
+const PCT_EPSILON = 0.1;
+
+const LOGIC_ROOTS = [
+  'common/src/main/ets',
+  'entry/src/main/ets/crypto',
+  'entry/src/main/ets/steam',
+  'entry/src/main/ets/oath',
+  'entry/src/main/ets/utils',
+];
+
+// 真机 only 责任区（docs/TEST_PLAN.md 第 2 节）+ UI 胶水，按文件名剔除。
+const DEVICE_ONLY_OR_UI = [
+  'PermissionManager', 'DlpAntiPeepManager', 'PhotoPickerUtils', 'IconThumbnailTask',
+  'RdbManager', 'HuaweiAccountManager', 'BleTokenTransfer', 'WearEngineTransfer',
+  'KvManager', 'AssetSecretStore', 'SteamSecretStore',
+  'NfcOathReader', 'NfcTagTransport', 'NetworkHttpTransport', 'TokenSwitchPerf',
+  'EntryAbility', 'HdsSnackBarUtils',
+];
+
+export function isLogicLayerFile(reportPath) {
+  const normalized = reportPath.replace(/\\/g, '/');
+  return LOGIC_ROOTS.some(p => normalized.includes(p))
+    && !DEVICE_ONLY_OR_UI.some(p => normalized.includes(p));
+}
+
+function listLogicFilesOnDisk() {
+  const out = [];
+  for (const root of LOGIC_ROOTS) {
+    walk(path.resolve(root), out);
+  }
+  return out
+    .map(p => p.replace(/\\/g, '/'))
+    .filter(p => !DEVICE_ONLY_OR_UI.some(x => p.includes(x)));
+}
+
+function walk(dir, acc) {
+  if (!existsSync(dir)) {
+    return acc;
+  }
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, acc);
+    } else if (entry.name.endsWith('.ets')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+export function summarize(report, filter = isLogicLayerFile) {
+  const files = report.files.filter(f => filter(f.path));
+  const sum = (kind) => files.reduce((acc, f) => {
+    const s = f.summary[kind] ?? { covered: 0, total: 0 };
+    acc.covered += s.covered;
+    acc.total += s.total;
+    return acc;
+  }, { covered: 0, total: 0 });
+  const pct = (x) => x.total === 0 ? 100 : (100 * x.covered) / x.total;
+  return {
+    fileCount: files.length,
+    lines: sum('lines'),
+    branches: sum('branches'),
+    pctOf: pct,
+    reportedPaths: files.map(f => f.path.replace(/\\/g, '/')),
+    worstFiles: files
+      .map(f => ({ name: path.basename(f.path), ...f.summary.lines }))
+      .sort((a, b) => (a.covered / (a.total || 1)) - (b.covered / (b.total || 1)))
+      .slice(0, 8),
+  };
+}
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+function readJsonOrDie(file, hint) {
+  if (!existsSync(file)) {
+    fail(`${path.relative(process.cwd(), file)} 不存在。${hint}`);
+  }
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch (e) {
+    fail(`${path.relative(process.cwd(), file)} 不是合法 JSON：${e.message}`);
+  }
+}
+
+const report = readJsonOrDie(REPORT, '请先运行 hvigorw test -p module=entry@default --no-daemon 生成覆盖率报告。');
+const baseline = readJsonOrDie(BASELINE, '仓库被损坏或不完整，scripts/coverage-baseline.json 必须随仓库存在。');
+const current = summarize(report);
+const diskLogicFiles = listLogicFilesOnDisk();
+
+console.log(`逻辑层可测基数（${current.fileCount} 个文件在报告中 / ${diskLogicFiles.length} 个在磁盘上，口径冻结于本脚本）:`);
+console.log(`  行覆盖:   ${current.lines.covered}/${current.lines.total} = ${(current.pctOf(current.lines)).toFixed(2)}%（基线 ${baseline.lines.pct}%）`);
+console.log(`  分支覆盖: ${current.branches.covered}/${current.branches.total} = ${(current.pctOf(current.branches)).toFixed(2)}%（基线 ${baseline.branches.pct}%）`);
+console.log('  覆盖最差文件:');
+for (const f of current.worstFiles) {
+  console.log(`    ${f.name.padEnd(32)} ${f.covered}/${f.total}`);
+}
+
+let failed = false;
+const linePct = current.pctOf(current.lines);
+const branchPct = current.pctOf(current.branches);
+if (linePct < baseline.lines.pct - PCT_EPSILON) {
+  fail(`逻辑层行覆盖 ${(linePct).toFixed(2)}% 低于基线 ${baseline.lines.pct}%（容差 ${PCT_EPSILON}pp）。` +
+    '新增/修改的逻辑代码必须带 LocalUnit 用例；有意重排口径需更新 coverage-baseline.json 并说明。');
+  failed = true;
+}
+if (branchPct < baseline.branches.pct - PCT_EPSILON) {
+  fail(`逻辑层分支覆盖 ${(branchPct).toFixed(2)}% 低于基线 ${baseline.branches.pct}%。`);
+  failed = true;
+}
+
+// 检查 2：分母逃逸——报告里必须能找到磁盘上的每个口径内文件（豁免清单除外）。
+const allowlist = baseline.expectedAbsentFromReport ?? [];
+const missing = diskLogicFiles.filter(p => !current.reportedPaths.some(rp => rp.endsWith(p)));
+const unexpectedMissing = missing.filter(p => !allowlist.some(a => p.endsWith(a)));
+if (unexpectedMissing.length > 0) {
+  fail(`以下口径内文件未出现在 coverageReport.json（未被任何测试加载，覆盖率完全不可见）：\n` +
+    unexpectedMissing.map(p => `  - ${path.relative(process.cwd(), p)}`).join('\n') +
+    `\n为新增文件补 LocalUnit 用例（哪怕只是导入触达），或将其移入 DEVICE_ONLY_OR_UI 剔除清单并说明理由。`);
+  failed = true;
+}
+const staleAllowlist = allowlist.filter(a => !missing.some(p => p.endsWith(a)));
+if (staleAllowlist.length > 0) {
+  console.log(`  ℹ 豁免清单中 ${staleAllowlist.length} 个文件已进入报告，请从 coverage-baseline.json 的 expectedAbsentFromReport 移除：`);
+  for (const s of staleAllowlist) {
+    console.log(`    - ${s}`);
+  }
+}
+
+// 检查 3：磁盘口径内文件数不得少于基线（删文件静默缩分母）。
+if (diskLogicFiles.length < baseline.fileCount) {
+  fail(`口径内文件数 ${diskLogicFiles.length} 少于基线 ${baseline.fileCount}。` +
+    '删除逻辑文件会静默缩小覆盖率分母；若属有意重构，请重新生成 scripts/coverage-baseline.json 并随代码提交。');
+  failed = true;
+}
+
+console.log('  ⚠ 未守护目录（三分法有意排除，逻辑写进去不受本门禁约束）: entry 的 pages/dialogs/components/shell/widget、entryability/entryformability 系、uikit/wearable 模块。');
+
+if (!failed) {
+  console.log('✓ 逻辑层覆盖率未回退');
+}

--- a/scripts/coverage-baseline.json
+++ b/scripts/coverage-baseline.json
@@ -1,0 +1,38 @@
+{
+  "date": "2026-09-11",
+  "note": "Phase 1 快速赢面（docs/TEST_PLAN.md 清单 1-10、12）落地后的逻辑层基线。口径冻结于 check-coverage.mjs；全局口径仅作参考防基数漂移。expectedAbsentFromReport = 测试导入图未加载、报告不可见的口径内文件（分母逃逸盲区，只允许缩小；给新文件补导入触达用例后移除对应条目）。",
+  "fileCount": 55,
+  "expectedAbsentFromReport": [
+    "common/src/main/ets/models/AppWindowInfo.ets",
+    "common/src/main/ets/utils/AppFonts.ets",
+    "common/src/main/ets/utils/CloudSyncTask.ets",
+    "common/src/main/ets/utils/CommonConstants.ets",
+    "entry/src/main/ets/oath/NfcSessionTokens.ets",
+    "entry/src/main/ets/oath/OathApplet.ets",
+    "entry/src/main/ets/oath/TagTransport.ets",
+    "entry/src/main/ets/utils/BackupImportOperation.ets",
+    "entry/src/main/ets/utils/TokenBatchOperation.ets"
+  ],
+  "lines": {
+    "covered": 2195,
+    "total": 4311,
+    "pct": 50.92
+  },
+  "branches": {
+    "covered": 396,
+    "total": 913,
+    "pct": 43.37
+  },
+  "globalReference": {
+    "lines": {
+      "covered": 2271,
+      "total": 6561,
+      "pct": 34.61
+    },
+    "branches": {
+      "covered": 422,
+      "total": 1393,
+      "pct": 30.29
+    }
+  }
+}

--- a/scripts/coverage-baseline.json
+++ b/scripts/coverage-baseline.json
@@ -1,38 +1,37 @@
 {
-  "date": "2026-09-11",
-  "note": "Phase 1 快速赢面（docs/TEST_PLAN.md 清单 1-10、12）落地后的逻辑层基线。口径冻结于 check-coverage.mjs；全局口径仅作参考防基数漂移。expectedAbsentFromReport = 测试导入图未加载、报告不可见的口径内文件（分母逃逸盲区，只允许缩小；给新文件补导入触达用例后移除对应条目）。",
-  "fileCount": 55,
+  "date": "2026-09-12",
+  "note": "Phase 2 存储与密钥解耦（docs/TEST_PLAN.md 第 4 节）落地并经红方评审加固后的逻辑层基线。四端口族（KeyValueStore/TokenKvStore、SecretStore/NamedSecretStore、CryptoEngine、FsGateway）入 StoragePorts.ets；TokenStore 迁移三重验证穷举、CryptoUtils 格式层、CloudBackupManager/IconPackCloudBackup 编排、OathApplet 协议层、SteamSecretStore 分片、TokenKvBatch 事务均 LocalUnit 可测。口径冻结于 check-coverage.mjs；SteamSecretStore 移出真机剔除清单。expectedAbsentFromReport = 报告不可见的口径内文件（只允许缩小）。",
+  "fileCount": 58,
   "expectedAbsentFromReport": [
     "common/src/main/ets/models/AppWindowInfo.ets",
     "common/src/main/ets/utils/AppFonts.ets",
     "common/src/main/ets/utils/CloudSyncTask.ets",
     "common/src/main/ets/utils/CommonConstants.ets",
     "entry/src/main/ets/oath/NfcSessionTokens.ets",
-    "entry/src/main/ets/oath/OathApplet.ets",
     "entry/src/main/ets/oath/TagTransport.ets",
     "entry/src/main/ets/utils/BackupImportOperation.ets",
     "entry/src/main/ets/utils/TokenBatchOperation.ets"
   ],
   "lines": {
-    "covered": 2195,
-    "total": 4311,
-    "pct": 50.92
+    "covered": 3545,
+    "total": 4874,
+    "pct": 72.73
   },
   "branches": {
-    "covered": 396,
-    "total": 913,
-    "pct": 43.37
+    "covered": 696,
+    "total": 1045,
+    "pct": 66.6
   },
   "globalReference": {
     "lines": {
-      "covered": 2271,
-      "total": 6561,
-      "pct": 34.61
+      "covered": 3626,
+      "total": 7070,
+      "pct": 51.29
     },
     "branches": {
-      "covered": 422,
-      "total": 1393,
-      "pct": 30.29
+      "covered": 725,
+      "total": 1511,
+      "pct": 47.98
     }
   }
 }

--- a/scripts/coverage-baseline.json
+++ b/scripts/coverage-baseline.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-09-12",
-  "note": "Phase 2 存储与密钥解耦（docs/TEST_PLAN.md 第 4 节）落地并经红方评审加固后的逻辑层基线。四端口族（KeyValueStore/TokenKvStore、SecretStore/NamedSecretStore、CryptoEngine、FsGateway）入 StoragePorts.ets；TokenStore 迁移三重验证穷举、CryptoUtils 格式层、CloudBackupManager/IconPackCloudBackup 编排、OathApplet 协议层、SteamSecretStore 分片、TokenKvBatch 事务均 LocalUnit 可测。口径冻结于 check-coverage.mjs；SteamSecretStore 移出真机剔除清单。expectedAbsentFromReport = 报告不可见的口径内文件（只允许缩小）。",
-  "fileCount": 58,
+  "note": "Phase 3 备份与传输协议（docs/TEST_PLAN.md 第 4 节）落地并经红方评审加固后的逻辑层基线。传输协议纯类 TransferProtocol.ets（分帧构建/头解析/接收状态机/纯 TS UTF-8 含过度编码与代理区校验/UUID 复用决策）入口径，BleTokenTransfer/WearEngineTransfer 生产类改委托后仍留真机剔除清单；IconPackCloudBackup 经 IconPackRegistry 端口补齐恢复成功链路。口径冻结于 check-coverage.mjs。expectedAbsentFromReport = 报告不可见的口径内文件（只允许缩小）。",
+  "fileCount": 59,
   "expectedAbsentFromReport": [
     "common/src/main/ets/models/AppWindowInfo.ets",
     "common/src/main/ets/utils/AppFonts.ets",
@@ -13,25 +13,25 @@
     "entry/src/main/ets/utils/TokenBatchOperation.ets"
   ],
   "lines": {
-    "covered": 3545,
-    "total": 4874,
-    "pct": 72.73
+    "covered": 3800,
+    "total": 5060,
+    "pct": 75.1
   },
   "branches": {
-    "covered": 696,
-    "total": 1045,
-    "pct": 66.6
+    "covered": 771,
+    "total": 1097,
+    "pct": 70.28
   },
   "globalReference": {
     "lines": {
-      "covered": 3626,
-      "total": 7070,
-      "pct": 51.29
+      "covered": 3890,
+      "total": 7185,
+      "pct": 54.14
     },
     "branches": {
-      "covered": 725,
-      "total": 1511,
-      "pct": 47.98
+      "covered": 802,
+      "total": 1551,
+      "pct": 51.71
     }
   }
 }

--- a/scripts/token-batch.test.mjs
+++ b/scripts/token-batch.test.mjs
@@ -26,6 +26,7 @@ const code = [
   'common/src/main/ets/utils/SteamAuth.ets',
   'common/src/main/ets/utils/TokenConfig.ets',
   'common/src/main/ets/utils/TokenBatchProgress.ets',
+  'common/src/main/ets/utils/TokenKvBatch.ets',
   'common/src/main/ets/utils/KvManager.ets',
   'common/src/main/ets/utils/TokenStore.ets',
   'common/src/main/ets/utils/OtpAuthParser.ets'


### PR DESCRIPTION
## 概述

按 docs/TEST_PLAN.md 三阶段推进逻辑层单测与可测性解耦，新增 420 条 LocalUnit 用例全绿，并加入 CI 覆盖率不回退门禁。

| 阶段 | 提交 | 行覆盖 | 分支覆盖 |
|---|---|---|---|
| Phase 1 快速赢面 | e0dce17 | 27% → 50.9% | — |
| Phase 2 存储与密钥解耦 | 6987c67 | 50.9% → 72.7% | 43.4% → 66.6% |
| Phase 3 备份与传输协议 | 4d700ac | 72.7% → 75.1% | 66.6% → 70.3% |

## 主要内容

### Phase 1（e0dce17）
- 新增 11 个测试文件：AppPreference、CloudBackupCrypto、TokenGroupStore、SteamClientExtra、ResponsiveLayoutPolicy 等
- CloudBackupCrypto 注入化改造（BackupCryptoEngine / Base64Codec 端口），避开 LocalUnit 不可用的 util.Base64Helper
- 新增 scripts/check-coverage.mjs + scripts/coverage-baseline.json：解析 test_result.txt 与 coverageReport.json，行/分支低于基线即失败；quality.yml 接入该门禁
- docs/TEST_PLAN.md 落地测试计划

### Phase 2（6987c67）
- 存储与密钥层解耦：新增 StoragePorts.ets 端口层，CryptoUtils、FileUtils、KvManager、CloudBackupManager、IconPackCloudBackup、OathApplet 等改为依赖可注入端口
- 新增 9 个测试文件：CloudBackupManager、CryptoUtils、OathApplet、FileUtils、IconPackCloudBackup、BackupRestoreHelper、SteamSecretStore、StoragePorts 等

### Phase 3（4d700ac）
- 备份/传输协议纯逻辑抽取：新增 TransferProtocol.ets（帧编解码、分片、校验），BleTokenTransfer、WearEngineTransfer 改为薄封装
- 新增 TransferProtocol、CloudBackupManager、IconPackCloudBackup 的 LocalUnit 测试
- 新增 4 条 ohosTest 真机用例：BackupRoundTrip、BleTransferSmoke、DeviceMigration、WearEngineSmoke

## 测试

- `hvigorw test -p module=entry@default`：420 用例全绿（test_result.txt Failure 0 / Error 0）
- `node scripts/check-coverage.mjs` 门禁通过：逻辑层行 75.10% / 分支 70.28%，不低于基线
- ohosTest 16 条用例待真机执行

## 附带改动

- AppScope/app.json5 versionCode 1003000→1003001（出 release 包所需基线+1，独立 commit e69d520，可按需取舍）

## 风险与后续

- TokenGroupStore.getEntries('^') 相关迁移改动需真机回归验证
- 三分法有意排除的 UI 层目录（pages/dialogs/components/shell/widget、entryability 系、uikit/wearable）不受门禁约束，见 check-coverage.mjs 输出说明